### PR TITLE
Force remove tmp files when running tests

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rm testutils/*.txt; rm testutils/*.lock
+rm -f testutils/*.txt; rm -f testutils/*.lock
 pkill etcd
 date > test-results.log
 time go test ./... -count=1 -race -failfast -timeout 10m 2>&1 | tee -a test-results.log


### PR DESCRIPTION
Without `-f` on Linux (running Fedora),  run_tests.sh throws an error that the files don't exist.

![2024-05-29_15-29](https://github.com/spirit-labs/tektite/assets/1930204/8f650fa9-fd11-46f2-b2b1-471a341841a1)
