### PR TITLE
Set loopback ip address in standalone config

### DIFF
--- a/cfg/cluster-minio.conf
+++ b/cfg/cluster-minio.conf
@@ -14,20 +14,20 @@ level-manager-enabled = true
 compaction-workers-enabled = true
 
 // These are the addresses for intra-cluster traffic. They can be local to your network. One entry for each node.
-cluster-addresses = [":44400", ":44401", ":44402"]
+cluster-addresses = ["127.0.0.1:44400", "127.0.0.1:44401", "127.0.0.1:44402"]
 
 http-api-enabled = true
 // The addresses the api server listens at - must be accessible from any tektite clients. One entry for each node.
-http-api-addresses = [":7770", ":7771", ":7772" ]
+http-api-addresses = ["127.0.0.1:7770", "127.0.0.1:7771", "127.0.0.1:7772" ]
 http-api-tls-key-path = "cfg/certs/server.key"
 http-api-tls-cert-path = "cfg/certs/server.crt"
 
 kafka-server-enabled = true
 // The addresses the kafka server listens at - must be accessible from any Kafka clients. One entry for each node.
-kafka-server-addresses = [":8880", ":8881", ":8882"]
+kafka-server-addresses = ["127.0.0.1:8880", "127.0.0.1:8881", "127.0.0.1:8882"]
 
 admin-console-enabled = true
-admin-console-addresses = [":9990", ":9991", ":9992"]
+admin-console-addresses = ["127.0.0.1:9990", "127.0.0.1:9991", "127.0.0.1:9992"]
 
 // Minio config
 object-store-type = "minio"
@@ -45,4 +45,4 @@ log-format = "console"
 
 // Debug
 debug-server-enabled = false
-debug-server-addresses = [":2220", ":2221", ":2222"]
+debug-server-addresses = ["127.0.0.1:2220", "127.0.0.1:2221", "127.0.0.1:2222"]

--- a/cfg/standalone-minio.conf
+++ b/cfg/standalone-minio.conf
@@ -9,18 +9,18 @@ compaction-workers-enabled = true
 l0-compaction-trigger = 4
 l0-max-tables-before-blocking = 10
 
-cluster-addresses = [":44400"]
+cluster-addresses = ["127.0.0.1:44400"]
 
 http-api-enabled = true
-http-api-addresses  = [":7770"]
+http-api-addresses  = ["127.0.0.1:7770"]
 http-api-tls-key-path = "cfg/certs/server.key"
 http-api-tls-cert-path = "cfg/certs/server.crt"
 
 kafka-server-enabled = true
-kafka-server-addresses  = [":8880"]
+kafka-server-addresses  = ["127.0.0.1:8880"]
 
 admin-console-enabled = true
-admin-console-addresses =  [":9990"]
+admin-console-addresses =  ["127.0.0.1:9990"]
 
 object-store-type = "minio"
 minio-endpoint = "127.0.0.1:9000"

--- a/cfg/standalone.conf
+++ b/cfg/standalone.conf
@@ -6,18 +6,18 @@ processing-enabled = true
 level-manager-enabled = true
 compaction-workers-enabled = true
 
-cluster-addresses = [":44400"]
+cluster-addresses = ["127.0.0.1:44400"]
 
 http-api-enabled = true
-http-api-addresses  = [":7770"]
+http-api-addresses  = ["127.0.0.1:7770"]
 http-api-tls-key-path = "cfg/certs/server.key"
 http-api-tls-cert-path = "cfg/certs/server.crt"
 
 kafka-server-enabled = true
-kafka-server-addresses  = [":8880"]
+kafka-server-addresses  = ["127.0.0.1:8880"]
 
 admin-console-enabled = true
-admin-console-addresses =  [":9990"]
+admin-console-addresses =  ["127.0.0.1:9990"]
 
 object-store-type = "embedded"
 


### PR DESCRIPTION
When following the [Getting started](https://tektitedb.com/getting_started/), my local kcat couldn't produce messages and librdkafka spit the error

```shell
bash -c 'while read -r line; do echo "$line" | kcat -b 127.0.0.1:8880 -t my-topic -P -K: ; done'

hello
%3|1717062818.724|FAIL|rdkafka#producer-1| [thrd::8880/0]: :8880/0: Failed to resolve ':8880': Name or service not known (after 1ms in state CONNECT)
% ERROR: Local: Host resolution failure: :8880/0: Failed to resolve ':8880': Name or service not known (after 1ms in state CONNECT)
from%3|1717062819.725|FAIL|rdkafka#producer-1| [thrd::8880/0]: :8880/0: Failed to resolve ':8880': Name or service not known (after 0ms in state CONNECT, 1 identical error(s) suppressed)
% ERROR: Local: Host resolution failure: :8880/0: Failed to resolve ':8880': Name or service not known (after 0ms in state CONNECT, 1 identical error(s) suppressed)
^C%4|1717062826.288|TERMINATE|rdkafka#producer-1| [thrd:app]: Producer terminating with 1 message (5 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```

I believe tektite advertises ":8880" as the address and my librdkafka version complains about that.

When explicitly setting "127.0.0.1" in the addresses, things work flawlessly.

I'll create a followup issue to fix this behavior anyway. But at least for now, this should be good enough for people who are trying out the Getting Started. 