### PR TITLE
Run GitHub action on GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ on:
 jobs:
 
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_API_VERSION: 1.43
     steps:
       - uses: actions/checkout@v4
 
@@ -20,9 +22,14 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-
+      - name : Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y etcd-server default-jre
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Build
         run: go build -v ./...
-
-      - name: Test
-        run: go test -v -race -count=1 -timeout 10m -failfast ./...
+      - name: Run Unit Tests
+        run: gotestsum -f github-actions -- -race -count=1 -timeout 10m -failfast ./...
+      - name: Run Integration Tests
+        if: always()
+        run: gotestsum -f github-actions -- -race -count=1 -timeout 10m -failfast -tags=integration ./integration/...

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/compaction_test.go
+++ b/integration/compaction_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/consumer_endpoint_test.go
+++ b/integration/consumer_endpoint_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/failover_test.go
+++ b/integration/failover_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/levelmanager_test.go
+++ b/integration/levelmanager_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/producer_endpoint_test.go
+++ b/integration/producer_endpoint_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/versions_test.go
+++ b/integration/versions_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/integration/watermark_test.go
+++ b/integration/watermark_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration
 
 import (

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 date > test-results.log
-time go test ./... -count=1 -race -failfast -timeout 10m 2>&1 | tee -a test-results.log
+time gotestsum -f testname -- -count=1 -race -failfast -timeout 10m ./... 2>&1 | tee -a test-results.log
+time gotestsum -f testname -- -count=1 -race -failfast -timeout 10m -tags=integration ./integration/... 2>&1 | tee -a test-results.log


### PR DESCRIPTION
This PR is for running the GitHub action on GitHub runner.

Changes:
- Set an `integration` build flag for integration tests.
- Change the GitHub Action workflow to run unit tests followed by integration tests.


Stacked on #93 & #94