### PR TITLE
Now we use testcontainers for starting etcd

### DIFF
--- a/clustmgr/clitest/mgr_test.go
+++ b/clustmgr/clitest/mgr_test.go
@@ -386,7 +386,7 @@ func startManagers(t *testing.T, prefix string, numNodes int, numGroups int, max
 
 func startManager(t *testing.T, prefix string, nodeID int, numGroups int, maxReplicas int) (*clustmgr.ClusteredStateManager, chan clustmgr.ClusterState) {
 	mgr := clustmgr.NewClusteredStateManager(prefix, "test_cluster", nodeID,
-		[]string{"localhost:2379", "localhost:22379", "localhost:32379"}, 1*time.Second, 1*time.Second, 5*time.Second,
+		[]string{etcdAddress}, 1*time.Second, 1*time.Second, 5*time.Second,
 		numGroups, maxReplicas)
 	ch := make(chan clustmgr.ClusterState, 100)
 	mgr.SetClusterStateHandler(func(state clustmgr.ClusterState) error {

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -22,9 +22,15 @@ const (
 	serverCertPath = "testdata/servercert.pem"
 )
 
+var etcdAddress string
+
 func TestMain(m *testing.M) {
-	testutils.RequireEtcd()
-	defer testutils.ReleaseEtcd()
+	etcd, err := testutils.CreateEtcdContainer()
+	if err != nil {
+		panic(err)
+	}
+	etcdAddress = etcd.Address()
+	defer etcd.Stop()
 	m.Run()
 }
 
@@ -68,6 +74,7 @@ func startClusterWithConfigSetter(t *testing.T, numServers int, fk *fake.Kafka, 
 	cfg.LevelManagerEnabled = true
 	cfg.MinSnapshotInterval = 100 * time.Millisecond
 	cfg.CompactionWorkersEnabled = true
+	cfg.ClusterManagerAddresses = []string{etcdAddress}
 
 	// In real life don't want to set this so low otherwise cluster state will be calculated when just one node
 	// is started with all leaders

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,3 @@
 #!/bin/bash
-
-rm -f testutils/*.txt; rm -f testutils/*.lock
-pkill etcd
 date > test-results.log
 time go test ./... -count=1 -race -failfast -timeout 10m 2>&1 | tee -a test-results.log

--- a/run_tests_in_loop.sh
+++ b/run_tests_in_loop.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-rm testutils/*.txt; rm testutils/*.lock
-pkill etcd
-
 iteration=0
 
 date > test-results.log

--- a/scripttest/dummy_test.go
+++ b/scripttest/dummy_test.go
@@ -10,8 +10,14 @@ import (
 // are controlled by build flags
 var tlsKeysInfo *TLSKeysInfo
 
+var etcdAddress string
+
 func TestMain(m *testing.M) {
-	testutils.RequireEtcd()
-	defer testutils.ReleaseEtcd()
+	etcd, err := testutils.CreateEtcdContainer()
+	if err != nil {
+		panic(err)
+	}
+	etcdAddress = etcd.Address()
+	defer etcd.Stop()
 	m.Run()
 }

--- a/scripttest/script_test.go
+++ b/scripttest/script_test.go
@@ -11,7 +11,7 @@ func TestScriptStandalone(t *testing.T) {
 	if testing.Short() {
 		t.Skip("-short: skipped")
 	}
-	testScript(t, 1, 1, false, tlsKeysInfo)
+	testScript(t, 1, 1, false, tlsKeysInfo, etcdAddress)
 }
 
 func TestScriptThreeNodes(t *testing.T) {
@@ -19,7 +19,7 @@ func TestScriptThreeNodes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("-short: skipped")
 	}
-	testScript(t, 3, 3, false, tlsKeysInfo)
+	testScript(t, 3, 3, false, tlsKeysInfo, etcdAddress)
 }
 
 //	func TestScriptFiveNodes(t *testing.T) {

--- a/shutdown/shutdown_test.go
+++ b/shutdown/shutdown_test.go
@@ -21,10 +21,16 @@ const (
 	serverCertPath = "testdata/servercert.pem"
 )
 
+var etcdAddress string
+
 func TestMain(m *testing.M) {
 	common.EnableTestPorts()
-	testutils.RequireEtcd()
-	defer testutils.ReleaseEtcd()
+	etcd, err := testutils.CreateEtcdContainer()
+	if err != nil {
+		panic(err)
+	}
+	etcdAddress = etcd.Address()
+	defer etcd.Stop()
 	m.Run()
 }
 
@@ -70,6 +76,7 @@ func createConfig(t *testing.T, objStoreAddress string) conf.Config {
 	cfg := conf.Config{}
 	cfg.ApplyDefaults()
 	cfg.ClusterManagerKeyPrefix = t.Name()
+	cfg.ClusterManagerAddresses = []string{etcdAddress}
 	cfg.ClusterAddresses = clusterAddresses
 	cfg.HttpApiEnabled = true
 	cfg.HttpApiAddresses = apiAddresses

--- a/testutils/etcd.go
+++ b/testutils/etcd.go
@@ -1,278 +1,70 @@
-//go:build !main
-
 package testutils
 
 import (
 	"context"
 	"fmt"
-	"github.com/alexflint/go-filemutex"
-	log "github.com/spirit-labs/tektite/logger"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
+	"github.com/docker/go-connections/nat"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 	"sync"
-	"syscall"
-	"time"
 )
 
-var (
-	_, b, _, _           = runtime.Caller(0)
-	thisDir              = filepath.Dir(b)
-	etcdLockPath         = filepath.Join(thisDir, "tektite_etcd_service.lock")
-	etcdRefCountFilePath = filepath.Join(thisDir, "tektite_etcd_refcount.txt")
-	etcdPidFilePath      = filepath.Join(thisDir, "tektite_etcd_pid.txt")
-)
-
-const etcdCommand = "etcd"
-
-var etcd etcdInfo
-
-type etcdInfo struct {
-	lock sync.Mutex
-	pid  int
+type EtcdHolder struct {
+	lock      sync.Mutex
+	started   bool
+	container testcontainers.Container
+	address   string
 }
 
-func newFlock(fileName string) *flock {
-	fm, err := filemutex.New(fileName)
-	if err != nil {
-		panic(fmt.Sprintf("failed to create filelock: %v", err))
-	}
-	return &flock{fm: fm}
-}
-
-type flock struct {
-	fm *filemutex.FileMutex
-}
-
-func (f *flock) lock() {
-	if err := f.fm.Lock(); err != nil {
-		panic(fmt.Sprintf("failed to lock filelock: %v", err))
-	}
-}
-
-func (f *flock) unlock() {
-	if err := f.fm.Unlock(); err != nil {
-		panic(fmt.Sprintf("failed to unlock filelock: %v", err))
-	}
-}
-
-func (e *etcdInfo) require() error {
+func (e *EtcdHolder) Stop() {
 	e.lock.Lock()
 	defer e.lock.Unlock()
-
-	fl := newFlock(etcdLockPath)
-	fl.lock()
-	defer fl.unlock()
-
-	count, err := e.readRefCount()
-	if err != nil {
-		cleanupAndExit()
+	if !e.started {
+		return
 	}
-
-	pid := -1
-	content, err := os.ReadFile(etcdPidFilePath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-	} else {
-		pid, err = strconv.Atoi(string(content))
-		if err != nil {
-			return err
-		}
-		if !isProcessRunning(pid) {
-			cleanupAndExit()
-		}
+	if err := e.container.Stop(context.Background(), nil); err != nil {
+		panic(err)
 	}
-	if count == 0 {
-		// check if etcd already running
-		cmd := exec.Command("ps", "aux")
-		output, err := cmd.Output()
-		if err != nil {
-			return err
-		}
-		if strings.Contains(string(output), "etcd") {
-			panic("etcd process already running. please kill it and re-run tests")
-		}
-
-		pid = startEtcd()
-		spid := strconv.Itoa(pid)
-		if err := os.WriteFile(etcdPidFilePath, []byte(spid), 0644); err != nil {
-			return err
-		}
-	} else {
-		if pid == -1 {
-			cleanupAndExit()
-		}
-	}
-	e.pid = pid
-	count++
-	if err := e.writeRefCount(count); err != nil {
-		return err
-	}
-	return nil
+	e.started = false
 }
 
-func cleanupAndExit() {
-	if err := os.Remove(etcdPidFilePath); err != nil {
-		// Ignore
-	}
-	if err := os.Remove(etcdRefCountFilePath); err != nil {
-		// Ignore
-	}
-	panic("previous test run left state in directory. please re-run tests")
+func (e *EtcdHolder) Address() string {
+	return e.address
 }
 
-func isProcessRunning(pid int) bool {
-	if _, err := syscall.Getpgid(pid); err != nil {
-		return false
+func CreateEtcdContainer() (*EtcdHolder, error) {
+	ctx := context.Background()
+	req := testcontainers.ContainerRequest{
+		Image:        "gcr.io/etcd-development/etcd:v3.5.10",
+		WaitingFor:   wait.ForListeningPort("2379"),
+		ExposedPorts: []string{"2379/tcp"},
+		Env: map[string]string{
+			"ETCD_LOG_LEVEL": "debug",
+		},
+		Cmd: []string{"etcd", "--advertise-client-urls", "http://0.0.0.0:2379", "--listen-client-urls", "http://0.0.0.0:2379",
+			"--data-dir", "/tmp/tektite-test-etcd-data"},
 	}
-	return true
-}
-
-func (e *etcdInfo) release() error {
-	e.lock.Lock()
-	defer e.lock.Unlock()
-
-	fl := newFlock(etcdLockPath)
-	fl.lock()
-	defer fl.unlock()
-
-	count, err := e.readRefCount()
-	if err != nil {
-		return err
-	}
-
-	count--
-	if count < 0 {
-		panic("etcd refCount < 0")
-	}
-
-	if count == 0 {
-		stopEtcd(e.pid)
-		if err := os.Remove(etcdPidFilePath); err != nil {
-			return err
-		}
-	}
-	if err := e.writeRefCount(count); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (e *etcdInfo) readRefCount() (int, error) {
-	content, err := os.ReadFile(etcdRefCountFilePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, nil
-		}
-		return 0, err
-	}
-	count, err := strconv.Atoi(string(content))
-	if err != nil {
-		return 0, err
-	}
-	return count, nil
-}
-
-func (e *etcdInfo) writeRefCount(count int) error {
-	sCount := strconv.Itoa(count)
-	return os.WriteFile(etcdRefCountFilePath, []byte(sCount), 0644)
-}
-
-func startEtcd() int {
-	deleteEtcDir()
-	start := time.Now()
-	cmd := exec.Command(etcdCommand)
-	err := cmd.Start()
-	if err != nil {
-		panic(fmt.Sprintf("etcdx:failed to start etcd %v", err))
-	}
-	for !tryExecuteOp() {
-		// Wait for it to startup and be operational
-		time.Sleep(10 * time.Millisecond)
-	}
-	log.Debugf("etcdx: etcd started in %d ms", time.Since(start).Milliseconds())
-	return cmd.Process.Pid
-}
-
-func stopEtcd(pid int) {
-	cmd := exec.Command("kill", "-TERM", strconv.Itoa(pid))
-
-	// Set the process group ID to ensure that all child processes are also terminated
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Run()
-	if err != nil {
-		panic(fmt.Sprintf("failed to kill etcd process: %v", err))
-	}
-	deleteEtcDir()
-	log.Debug("etcd stopped")
-}
-
-func RequireEtcd() {
-	if err := etcd.require(); err != nil {
-		panic(fmt.Sprintf("failed to require etcd: %v", err))
-	}
-}
-
-func ReleaseEtcd() {
-	if err := etcd.release(); err != nil {
-		panic(fmt.Sprintf("failed to release etcd: %v", err))
-	}
-}
-
-func tryExecuteOp() bool {
-	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   []string{"localhost:2379"},
-		DialTimeout: 100 * time.Millisecond,
+	etcdContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
 	})
-	//goland:noinspection GoUnhandledErrorResult
-	defer cli.Close()
-	if err != nil && checkUnavailableError(err) {
-		return false
+	if err != nil {
+		return nil, err
 	}
-
-	resp, err := cli.Get(context.Background(), "__tektitetest_ready_key")
-	if err != nil && checkUnavailableError(err) {
-		return false
+	if err := etcdContainer.Start(ctx); err != nil {
+		return nil, err
 	}
-
-	if len(resp.Kvs) > 0 {
-		log.Errorf("etcdx: __tektitetest_ready_key key already exists:%d - NOTE go test must be run with -p 1")
-		panic("etcdx: __tektitetest_ready_key key already exists")
-		return true
+	host, err := etcdContainer.Host(ctx)
+	if err != nil {
+		return nil, err
 	}
-
-	_, err = cli.Put(context.Background(), "__tektitetest_ready_key", "")
-	if err != nil && checkUnavailableError(err) {
-		return false
+	np := nat.Port("2379/tcp")
+	port, err := etcdContainer.MappedPort(ctx, np)
+	if err != nil {
+		return nil, err
 	}
-	log.Debugf("etcdx: successfully put __tektitetest_ready_key key")
-	return true
-}
-
-func checkUnavailableError(err error) bool {
-	if e, ok := status.FromError(err); ok {
-		if e.Code() == codes.Unavailable || e.Code() == codes.Canceled || e.Code() == codes.DeadlineExceeded {
-			return true
-		}
-	}
-	panic(err)
-}
-
-func deleteEtcDir() {
-	if err := os.RemoveAll("default.etcd"); err != nil {
-		log.Debug("etcdx:failed to delete etcd dir")
-	} else {
-		log.Debug("etcdx:successfully deleted etcd dir")
-	}
+	return &EtcdHolder{
+		started:   true,
+		container: etcdContainer,
+		address:   fmt.Sprintf("%s:%d", host, port.Int()),
+	}, nil
 }


### PR DESCRIPTION
This PR removes the code we used to manage a singleton etcd when running tests, and didn't work well.

Now, each test that requires etcd, starts an instance using testcontainers.