### PR TITLE
Split ci workflow into separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,56 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
-name: Go
-
+name: Change Validation
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
 jobs:
-
   build:
     runs-on: ubuntu-latest
     env:
       DOCKER_API_VERSION: 1.43
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-      - name : Install dependencies
+      - name: Build
+        run: go build -v ./...
+  run-unit-tests:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_API_VERSION: 1.43
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y etcd-server default-jre
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
-      - name: Build
-        run: go build -v ./...
       - name: Run Unit Tests
         run: gotestsum -f github-actions -- -race -count=1 -timeout 10m -failfast ./...
+  run-integration-tests:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_API_VERSION: 1.43
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y etcd-server default-jre
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: Run Integration Tests
-        if: always()
         run: gotestsum -f github-actions -- -race -count=1 -timeout 10m -failfast -tags=integration ./integration/...


### PR DESCRIPTION
Currently the CI workflow consists of a single job that's called "build" that does three different kind of validation: build, unit-tests and integration tests. This change will split that into three separate jobs:

- build: it very quickly builds the project without installing any dependency. This is gonna be a fail fast step.
- run-unit-tests: will only run if `build` succeeds
- run-integration-tests: will only run if `build` succeeds and in parallel to run-unit-tests

### Changes

- Rename the workflow to "Change Validation"
- Split the workflow into three jobs


This way instead of the single "build" item 

![2024-06-05_11-39_1](https://github.com/spirit-labs/tektite/assets/1930204/2e4c708f-a62b-4bae-a33b-73cafc579902)

we'll have

```mermaid
flowchart LR
    A[bulid] --> B(run-unit-tests)
    A --> C(run-integration-tests)
```