### PR TITLE
Add remaining data check

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -956,6 +956,10 @@ func (t *testCommandManager) Start() error {
 	return nil
 }
 
+func (t *testCommandManager) Activate() error {
+	return nil
+}
+
 func (t *testCommandManager) Stop() error {
 	return nil
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -591,6 +591,10 @@ func (t *testCommandManager) Start() error {
 	return nil
 }
 
+func (t *testCommandManager) Activate() error {
+	return nil
+}
+
 func (t *testCommandManager) Stop() error {
 	return nil
 }

--- a/command/mgr_test.go
+++ b/command/mgr_test.go
@@ -432,6 +432,8 @@ func setupManagers(t *testing.T, st *store2.Store) ([]*manager, []opers.StreamMa
 	for _, mgr := range mgrs {
 		err := mgr.Start()
 		require.NoError(t, err)
+		err = mgr.Activate()
+		require.NoError(t, err)
 	}
 	return mgrs, pMgrs, qMgrs, rem
 }

--- a/opers/mgr.go
+++ b/opers/mgr.go
@@ -1336,7 +1336,6 @@ func (sm *streamManager) deleteSlab(slabInfo *SlabInfo) {
 
 		sm.processorManager.ForwardBatch(batch, false, func(err error) {
 			if err != nil {
-				// This can fail when undeploy is executed again when nodes restart and replay old commands
 				log.Warnf("%s: failed to write tombstones for deleting slab %d %v", sm.cfg.LogScope, slabInfo.SlabID, err)
 			}
 		})

--- a/tekclient/client_test.go
+++ b/tekclient/client_test.go
@@ -590,6 +590,10 @@ func (t *testCommandManager) Start() error {
 	return nil
 }
 
+func (t *testCommandManager) Activate() error {
+	return nil
+}
+
 func (t *testCommandManager) Stop() error {
 	return nil
 }


### PR DESCRIPTION
This PR:
* Puts back and improved version of the remaining data check at the end of script test, that was removed in an earlier PR.
* Activates command manager after replicators are ready. This ensures we don't fail to process batches at startup, e.g. for saving compacted log state or deleting slabs.