### PR TITLE
improve initial buffer sizes for encoding key prefixes

### DIFF
--- a/opers/aggregate.go
+++ b/opers/aggregate.go
@@ -555,7 +555,7 @@ func (a *AggregateOperator) closeWindow(entry windowEntry, partitionID int, exec
 	// Note that `ws` must be the first column for us to be able to load the window efficiently
 
 	partitionHash := a.hashCache.getHash(partitionID)
-	keyStart := encoding.EncodeEntryPrefix(partitionHash, a.aggStateSlabID, 25)
+	keyStart := encoding.EncodeEntryPrefix(partitionHash, a.aggStateSlabID, 33)
 	keyStart = append(keyStart, 1) // not null
 	keyStart = encoding.KeyEncodeTimestamp(keyStart, types.NewTimestamp(entry.ws))
 	keyEnd := common.IncrementBytesBigEndian(keyStart)

--- a/opers/backfill.go
+++ b/opers/backfill.go
@@ -345,7 +345,7 @@ func (b *BackfillOperator) initialiseIteratorAtOffset(partID int, offset int64, 
 	keyStart := encoding.EncodeEntryPrefix(partitionHash, uint64(b.fromSlabID), 33)
 	keyStart = append(keyStart, 1) // not null
 	keyStart = encoding.KeyEncodeInt(keyStart, offset)
-	keyEnd := encoding.EncodeEntryPrefix(partitionHash, uint64(b.fromSlabID)+1, 32)
+	keyEnd := encoding.EncodeEntryPrefix(partitionHash, uint64(b.fromSlabID)+1, 24)
 	iter, err := b.store.NewIterator(keyStart, keyEnd, math.MaxInt64, false)
 	if err != nil {
 		return err
@@ -359,7 +359,7 @@ func (b *BackfillOperator) initialiseIteratorAtOffset(partID int, offset int64, 
 
 func (b *BackfillOperator) loadCommittedOffsetForPartition(execCtx StreamExecContext) (int64, bool, error) {
 	partitionHash := b.hashCache.getHash(execCtx.PartitionID())
-	key := encoding.EncodeEntryPrefix(partitionHash, common.BackfillOffsetSlabID, 40)
+	key := encoding.EncodeEntryPrefix(partitionHash, common.BackfillOffsetSlabID, 48)
 	key = encoding.AppendUint64ToBufferBE(key, uint64(b.fromSlabID))
 	key = encoding.AppendUint64ToBufferBE(key, uint64(b.receiverID))
 	key = encoding.AppendUint64ToBufferBE(key, uint64(execCtx.PartitionID()))

--- a/opers/backfill_test.go
+++ b/opers/backfill_test.go
@@ -344,7 +344,7 @@ func writeRowsToPartition(t *testing.T, partID int, numRows int, tableID int, st
 	mb := mem.NewBatch()
 	for j := 0; j < numRows; j++ {
 		partitionHash := proc.CalcPartitionHash("bar", uint64(partID))
-		keyPrefix := encoding.EncodeEntryPrefix(partitionHash, uint64(tableID), 25)
+		keyPrefix := encoding.EncodeEntryPrefix(partitionHash, uint64(tableID), 41)
 		key := append(keyPrefix, 1) // not null byte
 		key = encoding.KeyEncodeInt(key, int64(j))
 		key = encoding.EncodeVersion(key, uint64(version))

--- a/opers/bridge_from.go
+++ b/opers/bridge_from.go
@@ -432,7 +432,7 @@ func (c *consumerHolder) pause() {
 
 func (bf *BridgeFromOperator) loadLastOffset(partitionID int, maxVersion uint64) (int64, error) {
 	partitionHash := bf.hashCache.getHash(partitionID)
-	key := encoding.EncodeEntryPrefix(partitionHash, bf.offsetsSlabID, 32)
+	key := encoding.EncodeEntryPrefix(partitionHash, bf.offsetsSlabID, 24)
 	v, err := bf.store.GetWithMaxVersion(key, maxVersion)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Just a simple PR to improve some initial buffer sizes when encoding prefixes.