### PR TITLE
fixes bug in compaction where we could miss an entry

### DIFF
--- a/levels/compaction_worker_test.go
+++ b/levels/compaction_worker_test.go
@@ -902,7 +902,7 @@ func buildAndRegisterTableWithKeyRangeAndVersion(t *testing.T, name string, rang
 		if !tombstones {
 			val = []byte(fmt.Sprintf("val%06d", i))
 		}
-		si.AddKV(encoding.EncodeVersion([]byte(key), uint64(version)), val)
+		si.AddKV(encoding.EncodeVersion(key, uint64(version)), val)
 	}
 	table, smallestKey, largestKey, _, _, err := sst.BuildSSTable(common.DataFormatV1, 0, 0, si)
 	require.NoError(t, err)


### PR DESCRIPTION
This was hard to fix while keeping MaxEntriesIterator, so I've got rid of it and now we gather all results before creating sstables. I think its clearer this way anyway.