### PR TITLE
Move some user data that was being stored in sys tables to user tables

### DIFF
--- a/command/mgr.go
+++ b/command/mgr.go
@@ -455,20 +455,20 @@ func calcSequencesCountForStream(cp *parser.CreateStreamDesc) (receiverCount int
 		switch desc.(type) {
 		case *parser.BridgeFromDesc:
 			receiverCount++
-			slabCount++ // dedup slab
+			slabCount++
 		case *parser.BridgeToDesc:
 			receiverCount++
-			slabCount += 2
+			slabCount += 3
 		case *parser.KafkaInDesc:
 			receiverCount++
-			slabCount++ // offsets slab
+			slabCount++
 		case *parser.KafkaOutDesc:
 			slabCount += 2
 		case *parser.PartitionDesc:
 			receiverCount++
-			slabCount++ // dedup slab
 		case *parser.BackfillDesc:
 			receiverCount++
+			slabCount++
 		case *parser.AggregateDesc:
 			slabCount += 3
 			receiverCount++

--- a/common/sys_table.go
+++ b/common/sys_table.go
@@ -2,13 +2,11 @@ package common
 
 // Reserved SlabIDs
 const (
-	StreamOffsetSequenceSlabID = 1
-	BackfillOffsetSlabID       = 2
-	CommandsSlabID             = 3
-	KafkaOffsetsSlabID         = 5
-	ReplSeqSlabID              = 6
-	StreamMetaSlabID           = 7
-	UserSlabIDBase             = 1000
+	CommandsSlabID     = 1
+	KafkaOffsetsSlabID = 2
+	ReplSeqSlabID      = 3
+	StreamMetaSlabID   = 4
+	UserSlabIDBase     = 1000
 )
 
 // Reserved ReceiverIDs

--- a/opers/bridge_to.go
+++ b/opers/bridge_to.go
@@ -207,7 +207,7 @@ func (b *BridgeToOperator) flushLastCommitted(execCtx StreamExecContext) {
 	for _, partitionID := range partitionIDs {
 		offsetToCommit := b.offsetsToCommit[partitionID]
 		if offsetToCommit != -1 {
-			b.backFillOperator.storeCommittedOffSetForPartition(partitionID, offsetToCommit, execCtx)
+			b.backFillOperator.storeCommittedOffSetForPartition(offsetToCommit, execCtx)
 			b.offsetsToCommit[partitionID] = -1
 		}
 	}

--- a/opers/offsets.go
+++ b/opers/offsets.go
@@ -4,14 +4,10 @@ import (
 	"encoding/binary"
 	"github.com/spirit-labs/tektite/common"
 	"github.com/spirit-labs/tektite/encoding"
-	"github.com/spirit-labs/tektite/proc"
 )
 
-func loadOffset(slabID int, partitionID int, mappingID string, store store) (int64, error) {
-	partitionHash := proc.CalcPartitionHash(mappingID, uint64(partitionID))
-	key := encoding.EncodeEntryPrefix(partitionHash, common.StreamOffsetSequenceSlabID, 40)
-	key = encoding.AppendUint64ToBufferBE(key, uint64(slabID))
-	key = encoding.AppendUint64ToBufferBE(key, uint64(partitionID))
+func loadOffset(partitionHash []byte, slabID int, store store) (int64, error) {
+	key := encoding.EncodeEntryPrefix(partitionHash, uint64(slabID), 24)
 	value, err := store.Get(key)
 	if err != nil {
 		return 0, err
@@ -23,13 +19,8 @@ func loadOffset(slabID int, partitionID int, mappingID string, store store) (int
 	return int64(seq), nil
 }
 
-func storeOffset(execCtx StreamExecContext, offset int64, slabID int, version int, mappingID string) {
-	// Note the offset is always stored locally to the actual partition it refers to. The zero partition here isn't
-	// used, it's just required by the key format.
-	partitionHash := proc.CalcPartitionHash(mappingID, uint64(execCtx.PartitionID()))
-	key := encoding.EncodeEntryPrefix(partitionHash, common.StreamOffsetSequenceSlabID, 48)
-	key = encoding.AppendUint64ToBufferBE(key, uint64(slabID))
-	key = encoding.AppendUint64ToBufferBE(key, uint64(execCtx.PartitionID()))
+func storeOffset(execCtx StreamExecContext, offset int64, partitionHash []byte, slabID int, version int) {
+	key := encoding.EncodeEntryPrefix(partitionHash, uint64(slabID), 32)
 	key = encoding.EncodeVersion(key, uint64(version))
 	value := make([]byte, 8)
 	binary.LittleEndian.PutUint64(value, uint64(offset))

--- a/opers/store_stream_test.go
+++ b/opers/store_stream_test.go
@@ -101,7 +101,7 @@ func testStoreOperator(t *testing.T, to *StoreStreamOperator, columnNamesIn []st
 			expectedPartitionHash := proc.CalcPartitionHash(to.OutSchema().MappingID, uint64(partID))
 			require.Equal(t, expectedPartitionHash, partitionHash)
 			slabID, _ := encoding.ReadUint64FromBufferBE(kv.Key, 16)
-			if !foundOffsetEntry && slabID == common.StreamOffsetSequenceSlabID {
+			if !foundOffsetEntry && slabID == uint64(to.offsetsSlabID) {
 				foundOffsetEntry = true
 				continue
 			}

--- a/scripttest/script_test_runner.go
+++ b/scripttest/script_test_runner.go
@@ -565,7 +565,7 @@ func (st *scriptTest) verifyRemainingData(require *require.Assertions) {
 						return false, err
 					}
 					if valid {
-						log.Infof("found data for prefix %v on node %d", prefix, processorNode)
+						log.Infof("found data for prefix %v slabID %d on node %d", prefix, slabID, processorNode)
 					}
 					// We don't want to see any data
 					return !valid, nil


### PR DESCRIPTION
Previously, we were storing some user related data (offsets for streams, table and backfill operators) under sys tables.

All user data, should be stored under user tables, so they've been moved there, and made sure they're properly deleted on undeploy of streams