### PR TITLE
Fixes bug in compaction that was causing non deterministic test failures

### DIFF
--- a/integration/failover_test.go
+++ b/integration/failover_test.go
@@ -238,19 +238,21 @@ func testFailoverReplicationQueuesWithAggregation(t *testing.T, failLevelManager
 	// First we send messages to topic1 - this has one partition, so offsets should come back in contiguous order
 	_, err = sendMessagesForAggregation(numMessages, "sensor_agg", producer)
 	require.NoError(t, err)
-	log.Debug("sent messagaes")
+	log.Info("sent messagaes")
 
 	waitForAggRows(t, "sensor_agg", 20, client)
 
-	log.Debug("**** stopping server")
+	log.Infof("**** stopping server %d", failNode)
 
 	// Now stop one of the nodes - this should cause a failover
 	err = servers[failNode].Stop()
 	require.NoError(t, err)
 
+	log.Info("**** stopped server")
+
 	sleepRandom(2000 * time.Millisecond)
 
-	log.Debug("*** waiting for rows after failover")
+	log.Info("*** waiting for rows after failover")
 
 	waitForAggRows(t, "sensor_agg", 20, client)
 }
@@ -411,7 +413,7 @@ func waitForAggRows(t *testing.T, tableName string, numRows int, client tekclien
 				line := fmt.Sprintf("country:%s avg:%f max:%d min:%d", country, avgTemp, maxTemp, minTemp)
 				exp := expected[i]
 				if exp != line {
-					log.Errorf("%s: expected line: %s got: %s", exp, line, t.Name())
+					log.Errorf("%s: expected line: %s got: %s", t.Name(), exp, line)
 					return false
 				}
 			}

--- a/integration/failover_test.go
+++ b/integration/failover_test.go
@@ -238,21 +238,21 @@ func testFailoverReplicationQueuesWithAggregation(t *testing.T, failLevelManager
 	// First we send messages to topic1 - this has one partition, so offsets should come back in contiguous order
 	_, err = sendMessagesForAggregation(numMessages, "sensor_agg", producer)
 	require.NoError(t, err)
-	log.Info("sent messagaes")
+	log.Debug("sent messagaes")
 
 	waitForAggRows(t, "sensor_agg", 20, client)
 
-	log.Infof("**** stopping server %d", failNode)
+	log.Debugf("**** stopping server %d", failNode)
 
 	// Now stop one of the nodes - this should cause a failover
 	err = servers[failNode].Stop()
 	require.NoError(t, err)
 
-	log.Info("**** stopped server")
+	log.Debug("**** stopped server")
 
 	sleepRandom(2000 * time.Millisecond)
 
-	log.Info("*** waiting for rows after failover")
+	log.Debug("*** waiting for rows after failover")
 
 	waitForAggRows(t, "sensor_agg", 20, client)
 }

--- a/levels/compaction_worker.go
+++ b/levels/compaction_worker.go
@@ -417,8 +417,10 @@ func mergeSSTables(format common.DataFormat, tables [][]tableToMerge, preserveTo
 		k := curr.Key
 		size += 12 + 2*len(k) + len(curr.Value)
 
+		isLast := i == len(mergeResults)-1
+
 		keyNoVersion := k[:len(k)-8]
-		if lastKeyNoVersion != nil && bytes.Equal(lastKeyNoVersion, keyNoVersion) {
+		if lastKeyNoVersion != nil && bytes.Equal(lastKeyNoVersion, keyNoVersion) && !isLast {
 			// If keys only differ by version they must not be split across different sstables
 			continue
 		}
@@ -426,7 +428,7 @@ func mergeSSTables(format common.DataFormat, tables [][]tableToMerge, preserveTo
 
 		// estimate of how much space an entry takes up in the sstable (data and index)
 
-		if size >= maxTableSize || i == len(mergeResults)-1 {
+		if size >= maxTableSize || isLast {
 			iter := newSliceIterator(mergeResults[iLast : i+1])
 			ssTable, smallestKey, largestKey, minVersion, maxVersion, err := sst.BuildSSTable(format, size, i+1-iLast,
 				iter)

--- a/repli/replication.go
+++ b/repli/replication.go
@@ -697,21 +697,6 @@ func (r *replicator) Acquiesce() {
 	}
 }
 
-func (r *replicator) TruncateProcessedBatches(version int) error {
-	seq, err := r.processor.LoadLastProcessedReplBatchSeq(version)
-	log.Debugf("processor %d truncating to sequence %d", r.processor.ID(), seq)
-	if err != nil {
-		return err
-	}
-	if seq != -1 {
-		r.processor.SubmitAction(func() error {
-			r.removeFlushedBatches(int(seq))
-			return nil
-		})
-	}
-	return nil
-}
-
 func (r *replicator) Resume() {
 	r.processor.SubmitAction(func() error {
 		r.acquiescing = false


### PR DESCRIPTION
If we had same key but with multiple versions at the end of the results of merging sstables and the max table size had not been reached then entries were dropped. This resulted in non deterministic test failures in integration failover tests.

This fixes the bug and adds a couple of explicit tests to cover the case.

The PR also removes an unused method.