### PR TITLE
Add listener config for kafka server listener

### DIFF
--- a/cfg/cluster-minio.conf
+++ b/cfg/cluster-minio.conf
@@ -6,43 +6,61 @@ processor-count = 48
 min-replicas = 2
 max-replicas = 3
 
-// This must have a unique name for your cluster
-cluster-name = "test_cluster"
-
 processing-enabled = true
 level-manager-enabled = true
 compaction-workers-enabled = true
 
-// These are the addresses for intra-cluster traffic. They can be local to your network. One entry for each node.
-cluster-addresses = ["127.0.0.1:44400", "127.0.0.1:44401", "127.0.0.1:44402"]
-
-http-api-enabled = true
-// The addresses the api server listens at - must be accessible from any tektite clients. One entry for each node.
-http-api-addresses = ["127.0.0.1:7770", "127.0.0.1:7771", "127.0.0.1:7772" ]
-http-api-tls-key-path = "cfg/certs/server.key"
-http-api-tls-cert-path = "cfg/certs/server.crt"
-
-kafka-server-enabled = true
-// The addresses the kafka server listens at - must be accessible from any Kafka clients. One entry for each node.
-kafka-server-addresses = ["127.0.0.1:8880", "127.0.0.1:8881", "127.0.0.1:8882"]
-
-admin-console-enabled = true
-admin-console-addresses = ["127.0.0.1:9990", "127.0.0.1:9991", "127.0.0.1:9992"]
-
 // Minio config
 object-store-type = "minio"
-minio-endpoint = "127.0.0.1:9000"
-minio-access-key = "Oq1CGzCuLqbnLAgMzGxW"
-minio-secret-key = "klxPlFJQkYKaCllTGvwmL1QuH8ddHPK433tuP3zw"
-minio-bucket-name = "tektite-dev"
+minio {
+    endpoint = "127.0.0.1:9000"
+    access-key = "Oq1CGzCuLqbnLAgMzGxW"
+    secret-key = "klxPlFJQkYKaCllTGvwmL1QuH8ddHPK433tuP3zw"
+    bucket-name = "tektite-dev"
+}
+
+cluster {
+    // This must have a unique name for your cluster
+    name = "test_cluster"
+    // These are the addresses for intra-cluster traffic. They can be local to your network. One entry for each node.
+    addresses = ["127.0.0.1:44400", "127.0.0.1:44401", "127.0.0.1:44402"]
+}
+
+
+http-api {
+    enabled = true
+    // The addresses the api server listens at - must be accessible from any tektite clients. One entry for each node.
+    addresses = ["127.0.0.1:7770", "127.0.0.1:7771", "127.0.0.1:7772" ]
+    tls-key-path = "cfg/certs/server.key"
+    tls-cert-path = "cfg/certs/server.crt"
+}
+
+kafka-server {
+    listener {
+        // The addresses the kafka server listens at - must be accessible from any Kafka clients. One entry for each node.
+        addresses = ["127.0.0.1:8880", "127.0.0.1:8881", "127.0.0.1:8882"]
+    }
+    enabled = true
+}
+
+admin-console {
+    enabled = true
+    addresses = ["127.0.0.1:9990", "127.0.0.1:9991", "127.0.0.1:9992"]
+}
+
+
 
 // Addresses of etcd
 cluster-manager-addresses = ["127.0.0.1:2379"]
 
 // Logging config
-log-level = "info"
-log-format = "console"
+log {
+    level = "info"
+    format = "console"
+}
 
 // Debug
-debug-server-enabled = false
-debug-server-addresses = ["127.0.0.1:2220", "127.0.0.1:2221", "127.0.0.1:2222"]
+debug-server {
+    enabled = false
+    addresses = ["127.0.0.1:2220", "127.0.0.1:2221", "127.0.0.1:2222"]
+}

--- a/cfg/standalone-minio.conf
+++ b/cfg/standalone-minio.conf
@@ -1,7 +1,6 @@
 // Config for a standalone one node Tektite server that uses minio for object storage- useful for development purposes
 
 processor-count = 16
-
 processing-enabled = true
 level-manager-enabled = true
 compaction-workers-enabled = true
@@ -9,25 +8,42 @@ compaction-workers-enabled = true
 l0-compaction-trigger = 4
 l0-max-tables-before-blocking = 10
 
-cluster-addresses = ["127.0.0.1:44400"]
-
-http-api-enabled = true
-http-api-addresses  = ["127.0.0.1:7770"]
-http-api-tls-key-path = "cfg/certs/server.key"
-http-api-tls-cert-path = "cfg/certs/server.crt"
-
-kafka-server-enabled = true
-kafka-server-addresses  = ["127.0.0.1:8880"]
-
-admin-console-enabled = true
-admin-console-addresses =  ["127.0.0.1:9990"]
-
 object-store-type = "minio"
-minio-endpoint = "127.0.0.1:9000"
-minio-access-key = "Oq1CGzCuLqbnLAgMzGxW"
-minio-secret-key = "klxPlFJQkYKaCllTGvwmL1QuH8ddHPK433tuP3zw"
-minio-bucket-name = "tektite-dev"
+minio {
+    endpoint = "127.0.0.1:9000"
+    access-key = "Oq1CGzCuLqbnLAgMzGxW"
+    secret-key = "klxPlFJQkYKaCllTGvwmL1QuH8ddHPK433tuP3zw"
+    bucket-name = "tektite-dev"
+}
+
+cluster {
+    addresses = ["127.0.0.1:44400"]
+}
+
+http-api {
+    enabled = true
+    addresses  = ["127.0.0.1:7770"]
+    tls {
+        key-path = "cfg/certs/server.key"
+        cert-path = "cfg/certs/server.crt"
+    }
+}
+
+kafka-server {
+    listener {
+        addresses  = ["127.0.0.1:8880"]
+    }
+    enabled = true
+}
+
+admin-console {
+    enabled = true
+    addresses =  ["127.0.0.1:9990"]
+}
 
 // Logging config
-log-level = "info"
-log-format = "console"
+log {
+    level = "info"
+    format = "console"
+}
+

--- a/cfg/standalone.conf
+++ b/cfg/standalone.conf
@@ -1,26 +1,38 @@
 // Config for a standalone one node Tektite server with embedded object storage - useful for development purposes
 
 processor-count = 16
-
 processing-enabled = true
 level-manager-enabled = true
 compaction-workers-enabled = true
-
-cluster-addresses = ["127.0.0.1:44400"]
-
-http-api-enabled = true
-http-api-addresses  = ["127.0.0.1:7770"]
-http-api-tls-key-path = "cfg/certs/server.key"
-http-api-tls-cert-path = "cfg/certs/server.crt"
-
-kafka-server-enabled = true
-kafka-server-addresses  = ["127.0.0.1:8880"]
-
-admin-console-enabled = true
-admin-console-addresses =  ["127.0.0.1:9990"]
-
 object-store-type = "embedded"
 
+cluster {
+    addresses = ["127.0.0.1:44400"]
+}
+
+http-api {
+    enabled = true
+    addresses  = ["127.0.0.1:7770"]
+    tls {
+        key-path = "cfg/certs/server.key"
+        cert-path = "cfg/certs/server.crt"
+    }
+}
+
+kafka-server {
+    listener {
+        addresses  = ["127.0.0.1:8880"]
+    }
+    enabled = true
+}
+
+admin-console {
+    enabled = true
+    addresses =  ["127.0.0.1:9990"]
+}
+
 // Logging config
-log-level = "info"
-log-format = "console"
+log {
+    level = "info"
+    format = "console"
+}

--- a/cmd/tektited/main.go
+++ b/cmd/tektited/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 type arguments struct {
-	Config        kong.ConfigFlag `help:"Path to config file" type:"existingfile" required:""`
+	Config        kong.ConfigFlag `help:"Path to config file" placeholder:"CONFIG_FILE" type:"existingfile" required:""`
 	Server        conf.Config     `help:"Server configuration" embed:"" prefix:""`
 	Log           log.Config      `help:"Configuration for the logger" embed:"" prefix:"log-"`
 	Shutdown      bool            `help:"Shut down the cluster"`

--- a/cmd/tektited/runner_test.go
+++ b/cmd/tektited/runner_test.go
@@ -106,16 +106,18 @@ func createConfigWithAllFields() conf.Config {
 		MetricsBind:    "localhost:9102",
 		MetricsEnabled: false,
 
-		KafkaServerEnabled:      true,
-		KafkaServerAddresses:    []string{"kafka1:9301", "kafka2:9301", "kafka3:9301", "kafka4:9301", "kafka5:9301"},
-		KafkaUseServerTimestamp: true,
-		KafkaServerTLSConfig: conf.TLSConfig{
-			Enabled:         true,
-			KeyPath:         "kafka-key-path",
-			CertPath:        "kafka-cert-path",
-			ClientCertsPath: "kafka-client-certs-path",
-			ClientAuth:      "require-and-verify-client-cert",
+		KafkaServerEnabled: true,
+		KafkaServerListenerConfig: conf.ListenerConfig{
+			Addresses: []string{"kafka1:9301", "kafka2:9301", "kafka3:9301", "kafka4:9301", "kafka5:9301"},
+			TLSConfig: conf.TLSConfig{
+				Enabled:         true,
+				KeyPath:         "kafka-key-path",
+				CertPath:        "kafka-cert-path",
+				ClientCertsPath: "kafka-client-certs-path",
+				ClientAuth:      "require-and-verify-client-cert",
+			},
 		},
+		KafkaUseServerTimestamp:     true,
 		KafkaInitialJoinDelay:       2 * time.Second,
 		KafkaMinSessionTimeout:      7 * time.Second,
 		KafkaMaxSessionTimeout:      25 * time.Second,

--- a/cmd/tektited/testdata/config.hcl
+++ b/cmd/tektited/testdata/config.hcl
@@ -96,7 +96,7 @@ http-api-tls-client-certs-path = "http-client-certs-path"
 http-api-tls-client-auth = "require-and-verify-client-cert"
 
 kafka-server-enabled              = true
-kafka-server-addresses  = [
+kafka-server-listener-addresses  = [
   "kafka1:9301",
   "kafka2:9301",
   "kafka3:9301",
@@ -104,11 +104,11 @@ kafka-server-addresses  = [
   "kafka5:9301"
 ]
 kafka-use-server-timestamp        = true
-kafka-server-tls-enabled       = true
-kafka-server-tls-key-path      = "kafka-key-path"
-kafka-server-tls-cert-path     = "kafka-cert-path"
-kafka-server-tls-client-certs-path = "kafka-client-certs-path"
-kafka-server-tls-client-auth = "require-and-verify-client-cert"
+kafka-server-listener-tls-enabled       = true
+kafka-server-listener-tls-key-path      = "kafka-key-path"
+kafka-server-listener-tls-cert-path     = "kafka-cert-path"
+kafka-server-listener-tls-client-certs-path = "kafka-client-certs-path"
+kafka-server-listener-tls-client-auth = "require-and-verify-client-cert"
 kafka-initial-join-delay = "2s"
 kafka-min-session-timeout = "7s"
 kafka-max-session-timeout = "25s"

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -7,11 +7,6 @@ import (
 	"time"
 )
 
-type configPair struct {
-	errMsg string
-	conf   Config
-}
-
 func invalidNodeIDConf() Config {
 	cnf := validConf()
 	cnf.NodeID = -1
@@ -284,66 +279,313 @@ func kafkaMaxSessionTimeoutLowerThanMinSessionTimeout() Config {
 	return cnf
 }
 
-var invalidConfigs = []configPair{
-	{"invalid configuration: node-id must be >= 0", invalidNodeIDConf()},
-	{"invalid configuration: node-id must be >= 0 and < length cluster-addresses", nodeIDOutOfRangeConf()},
+func invalidKafkaServerListenerZerosAddress() Config {
+	cnf := validConf()
+	cnf.KafkaServerListenerConfig.Addresses = []string{"0.0.0.0:8880"}
+	return cnf
+}
 
-	{"invalid configuration: cluster-name must be specified", invalidClusterNameConf()},
-	{"invalid configuration: processor-count must be > 0", invalidProcessorCountNoLevelManagerConf()},
-	{"invalid configuration: processor-count must be >= 0", invalidProcessorCountLevelManagerConf()},
-	{"invalid configuration: max-backfill-batch-size must be > 0", invalidMaxBackfillBatchSize()},
-	{"invalid configuration: max-processor-batches-in-progress must be > 0", invalidMaxProcessorQueueSizeConf()},
-	{"invalid configuration: min-snapshot-interval must be >= 1 millisecond", invalidMinSnapshotInterval()},
-	{"invalid configuration: idle-processor-check-interval must be >= 1 millisecond", invalidIdleProcessorCheckInterval()},
-	{"invalid configuration: memtable-flush-queue-max-size must be > 0", invalidMemtableFlushQueueMaxSizeConf()},
-	{"invalid configuration: memtable-max-replace-time must be >= 1 ms", invalidMemtableMaxReplaceTimeConf()},
-	{"invalid configuration: memtable-max-size-bytes must be > 0", invalidMemtableMaxSizeBytesConf()},
-	{"invalid configuration: min-replicas must be > 0", invalidMinReplicasConf()},
-	{"invalid configuration: max-replicas must be > 0", invalidMaxReplicasConf()},
-	{"invalid configuration: min-replicas must be <= max-replicas", invalidMaxLessThanMinReplicasConf()},
-	{"invalid configuration: table-format must be specified", invalidTableFormatConf()},
+func invalidKafkaServerListenerAddressPortOnly() Config {
+	cnf := validConf()
+	cnf.KafkaServerListenerConfig.Addresses = []string{"192.168.9.1:8880", ":8880"}
+	return cnf
+}
 
-	{"invalid configuration: http-api-addresses must be specified", invalidHTTPAPIServerListenAddress()},
-	{"invalid configuration: life-cycle-address must be specified", invalidLifecycleListenAddress()},
-	{"invalid configuration: startup-endpoint-path must be specified", invalidStartupEndpointPath()},
-	{"invalid configuration: live-endpoint-path must be specified", invalidLiveEndpointPath()},
-	{"invalid configuration: ready-endpoint-path must be specified", invalidReadyEndpointPath()},
+func invalidKafkaServerListenerAddressPort() Config {
+	cnf := validConf()
+	cnf.KafkaServerListenerConfig.Addresses = []string{"192.168.9.1:8xbc"}
+	return cnf
+}
 
-	{"invalid configuration: http-api-tls-key-path must be specified for HTTP API server", httpAPIServerTLSKeyPathNotSpecifiedConfig()},
-	{"invalid configuration: http-api-tls-cert-path must be specified for HTTP API server", httpAPIServerTLSCertPathNotSpecifiedConfig()},
-	{"invalid configuration: http-api-tls-enabled must be true if http-api-enabled is true", httpAPIServerTLSNotEnabled()},
-	{"invalid configuration: http-api-tls-client-certs-path must be provided if client auth is enabled", httpAPIServerNoClientCerts()},
+func invalidKafkaServerListenerZerosAdvertisedAddress() Config {
+	cnf := validConf()
+	cnf.KafkaServerListenerConfig.Addresses = []string{"192.168.0.1:8880"}
+	cnf.KafkaServerListenerConfig.AdvertisedAddresses = []string{"0.0.0.0:8880"}
+	return cnf
+}
 
-	{"invalid configuration: admin-console-addresses must be specified", adminConsoleNoAddresses()},
+func invalidKafkaServerListenerAdvertisedAddressPortOnly() Config {
+	cnf := validConf()
+	cnf.KafkaServerListenerConfig.Addresses = []string{"192.168.0.1:8880", "192.168.1.1:8880"}
+	cnf.KafkaServerListenerConfig.AdvertisedAddresses = []string{"192.168.9.1:8880", ":8880"}
+	return cnf
+}
 
-	{"invalid configuration: cluster-tls-key-path must be specified if cluster-tls-enabled is true", intraClusterTLSKeyPathNotSpecifiedConfig()},
-	{"invalid configuration: cluster-tls-cert-path must be specified if cluster-tls-enabled is true", intraClusterTLSCertPathNotSpecifiedConfig()},
-	{"invalid configuration: cluster-tls-client-certs-path must be specified if cluster-tls-enabled is true", intraClusterTLSCAPathNotSpecifiedConfig()},
+func invalidKafkaServerListenerAdvertisedAddressPort() Config {
+	cnf := validConf()
+	cnf.KafkaServerListenerConfig.Addresses = []string{"192.168.9.1:8880"}
+	cnf.KafkaServerListenerConfig.AdvertisedAddresses = []string{"192.168.9.1:8xbc"}
+	return cnf
+}
 
-	{"invalid configuration: level-manager-flush-interval must be >= 1ms", invalidLevelManagerFlushInterval()},
-	{"invalid configuration: segment-cache-max-size must be >= 0", invalidSegmentCacheMaxSize()},
-
-	{"invalid configuration: cluster-manager-lock-timeout must be >= 1ms", invalidLockTimeoutConf()},
-	{"invalid configuration: cluster-manager-key-prefix must be specified", invalidClusterManagerKeyPrefix()},
-	{"invalid configuration: cluster-manager-addresses must be specified", invalidClusterAddresses()},
-	{"invalid configuration: cluster-eviction-timeout must be >= 1s", invalidClusterEvictionTimeout()},
-	{"invalid configuration: cluster-state-update-interval must be >= 1ms", invalidClusterStateUpdateInterval()},
-
-	{"invalid configuration: kafka-initial-join-delay must be >= 0", invalidKafkaInitialJoinDelay()},
-	{"invalid configuration: kafka-min-session-timeout must be >= 0", invalidKafkaMinSessionTimeout()},
-	{"invalid configuration: kafka-max-session-timeout must be >= 0", invalidKafkaMaxSessionTimeout()},
-	{"invalid configuration: kafka-max-session-timeout must be > kafka-min-session-timeout", kafkaMaxSessionTimeoutLowerThanMinSessionTimeout()},
+func invalidKafkaServerListenerAdvertisedAddressLength() Config {
+	cnf := validConf()
+	cnf.KafkaServerListenerConfig.Addresses = []string{"192.168.0.1:8880", "192.168.1.1:8880"}
+	cnf.KafkaServerListenerConfig.AdvertisedAddresses = []string{"192.168.0.1:8880"}
+	return cnf
 }
 
 func TestValidate(t *testing.T) {
-	for _, cp := range invalidConfigs {
-		err := cp.conf.Validate()
-		require.Error(t, err, "Didn't get error, expected: %s", cp.errMsg)
-		//goland:noinspection GoTypeAssertionOnErrors
-		pe, ok := errors.Cause(err).(errors.TektiteError)
-		require.True(t, ok)
-		require.Equal(t, errors.InvalidConfiguration, int(pe.Code))
-		require.Equal(t, cp.errMsg, pe.Msg)
+	tcs := []struct {
+		name string
+		conf Config
+		err  string
+	}{
+		{
+			"Negative node-id",
+			invalidNodeIDConf(),
+			"invalid configuration: node-id must be >= 0",
+		},
+		{
+			"node-id > length of cluster-addresses",
+			nodeIDOutOfRangeConf(),
+			"invalid configuration: node-id must be >= 0 and < length cluster-addresses",
+		},
+
+		{
+			"No cluster-name",
+			invalidClusterNameConf(),
+			"invalid configuration: cluster-name must be specified",
+		},
+		{
+			"Zero processor-count",
+			invalidProcessorCountNoLevelManagerConf(),
+			"invalid configuration: processor-count must be > 0",
+		},
+		{
+			"Negative processor-count",
+			invalidProcessorCountLevelManagerConf(),
+			"invalid configuration: processor-count must be >= 0",
+		},
+		{
+			"Zero mak-backfill-size", invalidMaxBackfillBatchSize(),
+			"invalid configuration: max-backfill-batch-size must be > 0",
+		},
+		{
+			"Zero max-processor-batches-in-progress",
+			invalidMaxProcessorQueueSizeConf(),
+			"invalid configuration: max-processor-batches-in-progress must be > 0",
+		},
+		{
+			"Zero min-snapshot-interval",
+			invalidMinSnapshotInterval(),
+			"invalid configuration: min-snapshot-interval must be >= 1 millisecond",
+		},
+		{
+			"Zero idle-processor-check-interval",
+			invalidIdleProcessorCheckInterval(),
+			"invalid configuration: idle-processor-check-interval must be >= 1 millisecond",
+		},
+		{
+			"Zero memtable-flush-queue-max-size",
+			invalidMemtableFlushQueueMaxSizeConf(),
+			"invalid configuration: memtable-flush-queue-max-size must be > 0",
+		},
+		{
+			"Zero memtable-max-replace-time",
+			invalidMemtableMaxReplaceTimeConf(),
+			"invalid configuration: memtable-max-replace-time must be >= 1 ms",
+		},
+		{
+			"Zero memtable-max-size-bytes",
+			invalidMemtableMaxSizeBytesConf(),
+			"invalid configuration: memtable-max-size-bytes must be > 0",
+		},
+		{
+			"Zero min-replicas",
+			invalidMinReplicasConf(),
+			"invalid configuration: min-replicas must be > 0",
+		},
+		{
+			"Zero max-replicas",
+			invalidMaxReplicasConf(),
+			"invalid configuration: max-replicas must be > 0",
+		},
+		{
+			"min-replicas > max-replicas",
+			invalidMaxLessThanMinReplicasConf(),
+			"invalid configuration: min-replicas must be <= max-replicas",
+		},
+		{
+			"No table-format",
+			invalidTableFormatConf(),
+			"invalid configuration: table-format must be specified",
+		},
+
+		{
+			"No http-api-addresses",
+			invalidHTTPAPIServerListenAddress(),
+			"invalid configuration: http-api-addresses must be specified",
+		},
+		{
+			"No life-cycle-address",
+			invalidLifecycleListenAddress(),
+			"invalid configuration: life-cycle-address must be specified",
+		},
+		{
+			"No startup-endpoint-path",
+			invalidStartupEndpointPath(),
+			"invalid configuration: startup-endpoint-path must be specified",
+		},
+		{
+			"No live-endpoint-path",
+			invalidLiveEndpointPath(),
+			"invalid configuration: live-endpoint-path must be specified",
+		},
+		{
+			"No ready-endpoint-path",
+			invalidReadyEndpointPath(),
+			"invalid configuration: ready-endpoint-path must be specified",
+		},
+
+		{
+			"No http-api-tls-key-path",
+			httpAPIServerTLSKeyPathNotSpecifiedConfig(),
+			"invalid configuration: http-api-tls-key-path must be specified for HTTP API server",
+		},
+		{
+			"No http-api-tls-cert-path",
+			httpAPIServerTLSCertPathNotSpecifiedConfig(),
+			"invalid configuration: http-api-tls-cert-path must be specified for HTTP API server",
+		},
+		{
+			"http-api-tls-enabled is false and http-api-enabled is true",
+			httpAPIServerTLSNotEnabled(),
+			"invalid configuration: http-api-tls-enabled must be true if http-api-enabled is true",
+		},
+		{
+			"No http-api-tls-client-certs-path and client auth is enabled",
+			httpAPIServerNoClientCerts(),
+			"invalid configuration: http-api-tls-client-certs-path must be provided if client auth is enabled",
+		},
+
+		{
+			"No admin-console-addresses",
+			adminConsoleNoAddresses(),
+			"invalid configuration: admin-console-addresses must be specified",
+		},
+
+		{
+			"No cluster-tls-key-path and cluster-tls-enabled is true",
+			intraClusterTLSKeyPathNotSpecifiedConfig(),
+			"invalid configuration: cluster-tls-key-path must be specified if cluster-tls-enabled is true",
+		},
+		{
+			"No cluster-tls-cert-path and cluster-tls-enabled is true",
+			intraClusterTLSCertPathNotSpecifiedConfig(),
+			"invalid configuration: cluster-tls-cert-path must be specified if cluster-tls-enabled is true",
+		},
+		{
+			"No cluster-tls-client-certs-path and cluster-tls-enabled is true",
+			intraClusterTLSCAPathNotSpecifiedConfig(),
+			"invalid configuration: cluster-tls-client-certs-path must be specified if cluster-tls-enabled is true",
+		},
+
+		{
+			"Zero level-manager-flush-interval",
+			invalidLevelManagerFlushInterval(),
+			"invalid configuration: level-manager-flush-interval must be >= 1ms",
+		},
+		{
+			"Negative segment-cache-max-size",
+			invalidSegmentCacheMaxSize(),
+			"invalid configuration: segment-cache-max-size must be >= 0",
+		},
+
+		{
+			"Zero cluster-manager-lock-timeout",
+			invalidLockTimeoutConf(),
+			"invalid configuration: cluster-manager-lock-timeout must be >= 1ms",
+		},
+		{
+			"No cluster-manager-key-prefix",
+			invalidClusterManagerKeyPrefix(),
+			"invalid configuration: cluster-manager-key-prefix must be specified",
+		},
+		{
+			"No cluster-manager-addresses",
+			invalidClusterAddresses(),
+			"invalid configuration: cluster-manager-addresses must be specified",
+		},
+		{
+			"cluster-eviction-timeout less than 1s",
+			invalidClusterEvictionTimeout(),
+			"invalid configuration: cluster-eviction-timeout must be >= 1s",
+		},
+		{
+			"cluster-state-update-interval less than 1ms",
+			invalidClusterStateUpdateInterval(),
+			"invalid configuration: cluster-state-update-interval must be >= 1ms",
+		},
+
+		{
+			"Negative kafka-initial-join-delay", invalidKafkaInitialJoinDelay(),
+			"invalid configuration: kafka-initial-join-delay must be >= 0",
+		},
+		{
+			"Negative kafka-min-session-timeout",
+			invalidKafkaMinSessionTimeout(),
+			"invalid configuration: kafka-min-session-timeout must be >= 0",
+		},
+		{
+			"Negative kafka-max-session-timeout",
+			invalidKafkaMaxSessionTimeout(),
+			"invalid configuration: kafka-max-session-timeout must be >= 0",
+		},
+		{
+			"kafka-max-session-timeout < kafka-min-session-timeout",
+			kafkaMaxSessionTimeoutLowerThanMinSessionTimeout(),
+			"invalid configuration: kafka-max-session-timeout must be > kafka-min-session-timeout",
+		},
+		{
+			"0.0.0.0 kafka-server-listener-addresses",
+			invalidKafkaServerListenerZerosAddress(),
+			"invalid configuration: 0.0.0.0 is not a valid address for kafka-server-listener-addresses",
+		},
+		{
+			":8880 kafka-server-listener-addresses",
+			invalidKafkaServerListenerAddressPortOnly(),
+			"invalid configuration: invalid address :8880 for kafka-server-listener-addresses. IP address is required",
+		},
+		{
+			":8xbc kafka-server-listener-addresses",
+			invalidKafkaServerListenerAddressPort(),
+			"invalid configuration: invalid port 8xbc for kafka-server-listener-addresses. Port must be a number",
+		},
+		{
+			"0.0.0.0 kafka-server-listener-advertised-addresses",
+			invalidKafkaServerListenerZerosAdvertisedAddress(),
+			"invalid configuration: 0.0.0.0 is not a valid address for kafka-server-listener-advertised-addresses",
+		},
+		{
+			":8880 kafka-server-listener-advertised-addresses",
+			invalidKafkaServerListenerAdvertisedAddressPortOnly(),
+			"invalid configuration: invalid address :8880 for kafka-server-listener-advertised-addresses. IP address is required",
+		},
+		{
+			":8xbc kafka-server-listener-advertised-addresses",
+			invalidKafkaServerListenerAdvertisedAddressPort(),
+			"invalid configuration: invalid port 8xbc for kafka-server-listener-advertised-addresses. Port must be a number",
+		},
+		{
+
+			"kafka-server-listener-advertised-addresses different length than kafka-server-listener-addresses",
+			invalidKafkaServerListenerAdvertisedAddressLength(),
+			"invalid configuration: kafka-server-listener-advertised-addresses must be the same length as kafka-server-listener-addresses",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.conf.Validate()
+			require.Error(t, err)
+			require.Equal(t, tc.err, err.Error())
+			require.Error(t, err, "Didn't get error, expected: %s", tc.err)
+			//goland:noinspection GoTypeAssertionOnErrors
+			pe, ok := errors.Cause(err).(errors.TektiteError)
+			require.True(t, ok)
+			require.Equal(t, errors.InvalidConfiguration, pe.Code)
+			require.Equal(t, tc.err, pe.Msg)
+		})
 	}
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -7,12 +7,12 @@ import (
 type ErrorCode int
 
 const (
-	ParseError = iota + 1000
+	ParseError ErrorCode = iota + 1000
 	StatementError
 	PrepareQueryError
 	ExecuteQueryError
 	WasmError
-	Unavailable = iota + 2000
+	Unavailable ErrorCode = iota + 2000
 	ConnectionError
 	ShutdownError
 	CompactionPollTimeout
@@ -20,8 +20,8 @@ const (
 	LevelManagerNotLeaderNode
 	VersionManagerShutdown
 	FailureCancelled
-	InvalidConfiguration = iota + 3000
-	InternalError        = iota + 5000
+	InvalidConfiguration ErrorCode = iota + 3000
+	InternalError        ErrorCode = iota + 5000
 )
 
 func NewInternalError(errReference string) TektiteError {

--- a/integration/bridge_test.go
+++ b/integration/bridge_test.go
@@ -66,7 +66,7 @@ egest_stream := local_topic -> (bridge to remote_topic props = ("bootstrap.serve
 	ingest_stream := (bridge from remote_topic partitions = 10 props = ("bootstrap.servers" = "%s" "auto.offset.reset" = "earliest")) -> (store stream)`, kHolder.address))
 	require.NoError(t, err)
 
-	tektiteKafkaAddress := s.GetConfig().KafkaServerAddresses[0]
+	tektiteKafkaAddress := s.GetConfig().KafkaServerListenerConfig.Addresses[0]
 
 	producer, err := kafkago.NewProducer(&kafkago.ConfigMap{
 		"partitioner":       "murmur2_random", // This matches the default hash algorithm we use, and same as Java client
@@ -133,7 +133,7 @@ egest_stream := local_topic -> (bridge to remote_topic props = ("bootstrap.serve
 	ingest_stream := (bridge from remote_topic partitions = 10 props = ("bootstrap.servers" = "%s" "auto.offset.reset" = "earliest")) -> (store stream)`, kHolder.address))
 	require.NoError(t, err)
 
-	tektiteKafkaAddress := s.GetConfig().KafkaServerAddresses[0]
+	tektiteKafkaAddress := s.GetConfig().KafkaServerListenerConfig.Addresses[0]
 
 	producer, err := kafkago.NewProducer(&kafkago.ConfigMap{
 		"partitioner":       "murmur2_random", // This matches the default hash algorithm we use, and same as Java client
@@ -222,7 +222,7 @@ egest_stream := local_topic -> (bridge to remote_topic props = ("bootstrap.serve
 	ingest_stream := (bridge from remote_topic partitions = 10 props = ("bootstrap.servers" = "%s" "auto.offset.reset" = "earliest")) -> (store stream)`, kHolder.address))
 	require.NoError(t, err)
 
-	tektiteKafkaAddress := s.GetConfig().KafkaServerAddresses[0]
+	tektiteKafkaAddress := s.GetConfig().KafkaServerListenerConfig.Addresses[0]
 
 	producer, err := kafkago.NewProducer(&kafkago.ConfigMap{
 		"partitioner":       "murmur2_random", // This matches the default hash algorithm we use, and same as Java client
@@ -335,7 +335,7 @@ func startStandaloneServer(t *testing.T, objStoreAddress string, clusterName str
 	cfg.KafkaServerEnabled = true
 	kafkaAddress, err := common.AddressWithPort("localhost")
 	require.NoError(t, err)
-	cfg.KafkaServerAddresses = []string{kafkaAddress}
+	cfg.KafkaServerListenerConfig.Addresses = []string{kafkaAddress}
 	cfg.ClientType = conf.KafkaClientTypeConfluent
 	cfg.ObjectStoreType = conf.DevObjectStoreType
 	cfg.DevObjectStoreAddresses = []string{objStoreAddress}

--- a/integration/compaction_test.go
+++ b/integration/compaction_test.go
@@ -34,7 +34,7 @@ func TestCompaction(t *testing.T) {
 			require.NoError(t, err)
 			kafkaListenAddresses = append(kafkaListenAddresses, address)
 		}
-		cfg.KafkaServerAddresses = kafkaListenAddresses
+		cfg.KafkaServerListenerConfig.Addresses = kafkaListenAddresses
 		cfg.MemtableMaxSizeBytes = 100 * 1024
 		cfg.MemtableMaxReplaceInterval = 5 * time.Second
 		cfg.CompactionWorkersEnabled = true
@@ -53,7 +53,7 @@ func TestCompaction(t *testing.T) {
 	err = client.ExecuteStatement(`table1 := (kafka in partitions=32) -> (store table by key)`)
 	require.NoError(t, err)
 
-	serverAddress := servers[0].GetConfig().KafkaServerAddresses[0]
+	serverAddress := servers[0].GetConfig().KafkaServerListenerConfig.Addresses[0]
 
 	producer, err := kafkago.NewProducer(&kafkago.ConfigMap{
 		"partitioner":       "murmur2_random", // This matches the default hash algorithm we use, and same as Java client

--- a/integration/consumer_endpoint_test.go
+++ b/integration/consumer_endpoint_test.go
@@ -38,7 +38,7 @@ func testConsumerEndpoint(t *testing.T, ct clientType) {
 			require.NoError(t, err)
 			kafkaListenAddresses = append(kafkaListenAddresses, address)
 		}
-		cfg.KafkaServerAddresses = kafkaListenAddresses
+		cfg.KafkaServerListenerConfig.Addresses = kafkaListenAddresses
 	})
 	defer tearDown(t)
 	client, err := tekclient.NewClient(servers[0].GetConfig().HttpApiAddresses[0], clientTLSConfig)
@@ -53,7 +53,7 @@ func testConsumerEndpoint(t *testing.T, ct clientType) {
 
 	startTime := time.Now().UTC()
 
-	serverAddress := servers[0].GetConfig().KafkaServerAddresses[0]
+	serverAddress := servers[0].GetConfig().KafkaServerListenerConfig.Addresses[0]
 
 	switch ct {
 	case clientTypeGo:

--- a/integration/failover_test.go
+++ b/integration/failover_test.go
@@ -52,7 +52,7 @@ func testFailoverReplicationQueues(t *testing.T, failLevelManager bool) {
 
 	producer, err := kafkago.NewProducer(&kafkago.ConfigMap{
 		"partitioner":       "murmur2_random", // This matches the default hash algorithm we use, and same as Java client
-		"bootstrap.servers": servers[0].GetConfig().KafkaServerAddresses[0],
+		"bootstrap.servers": servers[0].GetConfig().KafkaServerListenerConfig.Addresses[0],
 		"acks":              "all"})
 	require.NoError(t, err)
 	defer producer.Close()
@@ -230,7 +230,7 @@ func testFailoverReplicationQueuesWithAggregation(t *testing.T, failLevelManager
 
 	producer, err := kafkago.NewProducer(&kafkago.ConfigMap{
 		"partitioner":       "murmur2_random", // This matches the default hash algorithm we use, and same as Java client
-		"bootstrap.servers": servers[0].GetConfig().KafkaServerAddresses[0],
+		"bootstrap.servers": servers[0].GetConfig().KafkaServerListenerConfig.Addresses[0],
 		"acks":              "all"})
 	require.NoError(t, err)
 	defer producer.Close()
@@ -448,7 +448,7 @@ func setupServers(t *testing.T, fk *fake.Kafka) ([]*server.Server, func(t *testi
 			require.NoError(t, err)
 			kafkaListenAddresses = append(kafkaListenAddresses, address)
 		}
-		cfg.KafkaServerAddresses = kafkaListenAddresses
+		cfg.KafkaServerListenerConfig.Addresses = kafkaListenAddresses
 		cfg.MinSnapshotInterval = 1 * time.Second
 		// Make sure we push frequently to exercise logic on level manager with dead versions
 		cfg.MemtableMaxReplaceInterval = 1 * time.Second

--- a/integration/kafka_listener_advertised_address_test.go
+++ b/integration/kafka_listener_advertised_address_test.go
@@ -1,0 +1,299 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/conf"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/tekclient"
+	"github.com/stretchr/testify/require"
+	"net"
+	"testing"
+	"time"
+)
+
+// MetadataRequest represents a Kafka Metadata request
+type MetadataRequest struct {
+	Topics []MetadataRequestTopic
+}
+
+// MetadataRequestTopic represents a topic in the Metadata request
+type MetadataRequestTopic struct {
+	Name *string
+}
+
+// MetadataResponse represents a Kafka Metadata response
+type MetadataResponse struct {
+	ThrottleTimeMs int32
+	Brokers        []Broker
+	ClusterID      *string
+	ControllerID   int32
+	Topics         []TopicMetadata
+}
+
+// Broker represents a broker in the Metadata response
+type Broker struct {
+	NodeID int32
+	Host   string
+	Port   int32
+	Rack   *string
+}
+
+// TopicMetadata represents topic metadata in the Metadata response
+type TopicMetadata struct {
+	ErrorCode  int16
+	Name       string
+	IsInternal bool
+	Partitions []PartitionMetadata
+}
+
+// PartitionMetadata represents partition metadata in the Metadata response
+type PartitionMetadata struct {
+	ErrorCode      int16
+	PartitionIndex int32
+	LeaderID       int32
+	LeaderEpoch    int32
+	ReplicaNodes   []int32
+	IsrNodes       []int32
+}
+
+func TestBrokerSendsAdvertisedAddress(t *testing.T) {
+
+	tcs := []struct {
+		name                string
+		advertisedAddresses []string
+	}{
+		{
+			name:                "Addresses are set and AdvertisedAddresses are not set",
+			advertisedAddresses: nil,
+		},
+		{
+			name:                "Addresses are set and AdvertisedAddresses are set",
+			advertisedAddresses: []string{"advertisedAddress1:8080", "advertisedAddress2:8080", "advertisedAddress3:8080"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			clientTLSConfig := tekclient.TLSConfig{
+				TrustedCertsPath: serverCertPath,
+			}
+			servers, tearDown := startClusterWithConfigSetter(t, 3, nil, func(cfg *conf.Config) {
+				cfg.KafkaServerEnabled = true
+				var kafkaListenAddresses []string
+				for i := 0; i < 3; i++ {
+					address, err := common.AddressWithPort("localhost")
+					require.NoError(t, err)
+					kafkaListenAddresses = append(kafkaListenAddresses, address)
+
+				}
+				cfg.KafkaServerListenerConfig.Addresses = kafkaListenAddresses
+				if tc.advertisedAddresses != nil {
+					cfg.KafkaServerListenerConfig.AdvertisedAddresses = tc.advertisedAddresses
+				}
+			})
+			defer tearDown(t)
+			client, err := tekclient.NewClient(servers[0].GetConfig().HttpApiAddresses[0], clientTLSConfig)
+			require.NoError(t, err)
+			defer client.Close()
+
+			err = client.ExecuteStatement(`topic1 :=  (kafka in partitions=1) -> (store stream)`)
+			require.NoError(t, err)
+
+			serverAddress := servers[0].GetConfig().KafkaServerListenerConfig.Addresses[0]
+			wantAddresses := servers[0].GetConfig().KafkaServerListenerConfig.Addresses
+			if tc.advertisedAddresses != nil {
+				wantAddresses = tc.advertisedAddresses
+			}
+
+			err = executeMetadataRequest(t, serverAddress, wantAddresses)
+			if err != nil {
+				log.Errorf("failed to execute client actions %v", err)
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func executeMetadataRequest(t *testing.T, serverAddress string, desiredAddresses []string) error {
+	conn, err := net.DialTimeout("tcp", serverAddress, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer conn.Close()
+
+	// Create a Metadata request
+	request := MetadataRequest{
+		Topics: []MetadataRequestTopic{},
+	}
+
+	// Serialize the request
+	requestData := serializeMetadataRequest(request)
+
+	// Send the request
+	buf := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf, uint32(len(requestData)))
+	_, err = conn.Write(buf)
+	_, err = conn.Write(requestData)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+
+	// Read the response size (first 4 bytes)
+	var size int32
+	err = binary.Read(conn, binary.BigEndian, &size)
+	if err != nil {
+		return fmt.Errorf("failed to read response size: %w", err)
+	}
+
+	// Read the response data
+	responseData := make([]byte, size)
+	_, err = conn.Read(responseData)
+	if err != nil {
+		return fmt.Errorf("failed to read response data: %w", err)
+	}
+	var correlationId = int32(binary.BigEndian.Uint32(responseData[0:4]))
+	t.Logf("correlationId: %d\n", correlationId)
+	// Deserialize the response
+	response := deserializeMetadataResponse(responseData[4:])
+	for _, broker := range response.Brokers {
+		require.Contains(t, desiredAddresses, fmt.Sprintf("%s:%d", broker.Host, broker.Port))
+	}
+	t.Logf("Metadata Response: %+v\n", response)
+	return nil
+}
+
+func serializeMetadataRequest(req MetadataRequest) []byte {
+	buf := new(bytes.Buffer)
+
+	// API Key for Metadata request
+	binary.Write(buf, binary.BigEndian, int16(3))
+	// API Version
+	binary.Write(buf, binary.BigEndian, int16(3))
+	// Correlation ID
+	binary.Write(buf, binary.BigEndian, int32(1))
+	// Client ID (Nullable String)
+	writeNullableString(buf, "go-client")
+
+	// Number of topics
+	writeCompactArrayLength(buf, len(req.Topics))
+	for _, topic := range req.Topics {
+		// Topic name (String)
+		writeString(buf, topic.Name)
+	}
+
+	return buf.Bytes()
+}
+
+func deserializeMetadataResponse(data []byte) MetadataResponse {
+	buf := bytes.NewReader(data)
+	var resp MetadataResponse
+
+	// ThrottleTimeMs
+	binary.Read(buf, binary.BigEndian, &resp.ThrottleTimeMs)
+
+	// Brokers
+	brokerCount := readArrayLength(buf)
+	resp.Brokers = make([]Broker, brokerCount)
+	for i := range resp.Brokers {
+		var broker Broker
+		binary.Read(buf, binary.BigEndian, &broker.NodeID)
+		broker.Host = readString(buf)
+		binary.Read(buf, binary.BigEndian, &broker.Port)
+		broker.Rack = readNullableString(buf)
+		resp.Brokers[i] = broker
+	}
+
+	// ClusterID
+	resp.ClusterID = readNullableString(buf)
+	// ControllerID
+	binary.Read(buf, binary.BigEndian, &resp.ControllerID)
+
+	// Topics
+	topicCount := readArrayLength(buf)
+	resp.Topics = make([]TopicMetadata, topicCount)
+	for i := range resp.Topics {
+		var topic TopicMetadata
+		binary.Read(buf, binary.BigEndian, &topic.ErrorCode)
+		topic.Name = readString(buf)
+		binary.Read(buf, binary.BigEndian, &topic.IsInternal)
+
+		// Partitions
+		partitionCount := readArrayLength(buf)
+		topic.Partitions = make([]PartitionMetadata, partitionCount)
+		for j := range topic.Partitions {
+			var partition PartitionMetadata
+			binary.Read(buf, binary.BigEndian, &partition.ErrorCode)
+			binary.Read(buf, binary.BigEndian, &partition.PartitionIndex)
+			binary.Read(buf, binary.BigEndian, &partition.LeaderID)
+			partition.ReplicaNodes = readInt32Array(buf)
+			partition.IsrNodes = readInt32Array(buf)
+			topic.Partitions[j] = partition
+		}
+
+		resp.Topics[i] = topic
+	}
+
+	return resp
+}
+
+func writeNullableString(buf *bytes.Buffer, str string) {
+	length := len(str)
+	binary.Write(buf, binary.BigEndian, uint16(length))
+	buf.WriteString(str)
+}
+
+func writeString(buf *bytes.Buffer, str *string) {
+	if str == nil {
+		binary.Write(buf, binary.BigEndian, uint16(0))
+	} else {
+		length := len(*str)
+		binary.Write(buf, binary.BigEndian, uint16(length))
+		buf.WriteString(*str)
+	}
+}
+
+func writeCompactArrayLength(buf *bytes.Buffer, length int) {
+	binary.Write(buf, binary.BigEndian, uint32(length))
+}
+
+func readString(buf *bytes.Reader) string {
+	var length uint16
+	binary.Read(buf, binary.BigEndian, &length)
+	strBytes := make([]byte, length)
+	buf.Read(strBytes)
+	return string(strBytes)
+}
+
+func readNullableString(buf *bytes.Reader) *string {
+	var length uint16
+	binary.Read(buf, binary.BigEndian, &length)
+	if int16(length) == -1 {
+		return nil
+	}
+	strBytes := make([]byte, length)
+	buf.Read(strBytes)
+	str := string(strBytes)
+	return &str
+}
+
+func readArrayLength(buf *bytes.Reader) int32 {
+	var length uint32
+	binary.Read(buf, binary.BigEndian, &length)
+	return int32(length)
+}
+
+func readInt32Array(buf *bytes.Reader) []int32 {
+	length := readArrayLength(buf)
+	array := make([]int32, length)
+	for i := range array {
+		var n uint32
+		binary.Read(buf, binary.BigEndian, &n)
+		array[i] = int32(n)
+	}
+	return array
+}

--- a/integration/producer_endpoint_test.go
+++ b/integration/producer_endpoint_test.go
@@ -48,7 +48,7 @@ func testProducerEndpoint(t *testing.T, ct clientType) {
 			require.NoError(t, err)
 			kafkaListenAddresses = append(kafkaListenAddresses, address)
 		}
-		cfg.KafkaServerAddresses = kafkaListenAddresses
+		cfg.KafkaServerListenerConfig.Addresses = kafkaListenAddresses
 	})
 	defer tearDown(t)
 	client, err := tekclient.NewClient(servers[0].GetConfig().HttpApiAddresses[0], clientTLSConfig)
@@ -80,7 +80,7 @@ func testProducerEndpoint(t *testing.T, ct clientType) {
 
 	startTime := time.Now().UTC()
 
-	serverAddress := servers[0].GetConfig().KafkaServerAddresses[0]
+	serverAddress := servers[0].GetConfig().KafkaServerListenerConfig.Addresses[0]
 
 	switch ct {
 	case clientTypeGo:

--- a/kafkaserver/api_handler.go
+++ b/kafkaserver/api_handler.go
@@ -527,7 +527,10 @@ func (c *connection) handleFindCoordinator(apiVersion int16, reqBuff []byte, res
 
 	key, _ := ReadStringFromBytes(reqBuff)
 	nodeID := c.s.groupCoordinator.FindCoordinator(key)
-	address := c.s.cfg.KafkaServerAddresses[nodeID]
+	address := c.s.cfg.KafkaServerListenerConfig.Addresses[nodeID]
+	if len(c.s.cfg.KafkaServerListenerConfig.AdvertisedAddresses) > 0 {
+		address = c.s.cfg.KafkaServerListenerConfig.AdvertisedAddresses[nodeID]
+	}
 	host, sPort, err := net.SplitHostPort(address)
 	var port int
 	if err == nil {

--- a/kafkaserver/meta.go
+++ b/kafkaserver/meta.go
@@ -22,8 +22,12 @@ type metaDataProvider struct {
 }
 
 func NewMetaDataProvider(cfg *conf.Config, procMgr proc.Manager, streamMgr opers.StreamManager) (MetadataProvider, error) {
-	brokerInfos := make([]BrokerInfo, len(cfg.KafkaServerAddresses))
-	for nodeID, address := range cfg.KafkaServerAddresses {
+	advertisedAddresses := cfg.KafkaServerListenerConfig.Addresses
+	if len(cfg.KafkaServerListenerConfig.AdvertisedAddresses) > 0 {
+		advertisedAddresses = cfg.KafkaServerListenerConfig.AdvertisedAddresses
+	}
+	brokerInfos := make([]BrokerInfo, len(advertisedAddresses))
+	for nodeID, address := range advertisedAddresses {
 		host, sPort, err := net.SplitHostPort(address)
 		var port int
 		if err == nil {

--- a/kafkaserver/server.go
+++ b/kafkaserver/server.go
@@ -78,7 +78,7 @@ func (s *Server) Activate() error {
 	s.fetcher.start()
 	s.acceptLoopExitGroup.Add(1)
 	common.Go(s.acceptLoop)
-	log.Debugf("started kafka Server on %s", s.cfg.KafkaServerAddresses[s.cfg.NodeID])
+	log.Debugf("started kafka Server on %s", s.cfg.KafkaServerListenerConfig.Addresses[s.cfg.NodeID])
 	return nil
 }
 
@@ -86,9 +86,9 @@ func (s *Server) createNetworkListener() (net.Listener, error) {
 	var list net.Listener
 	var err error
 	var tlsConfig *tls.Config
-	listenAddress := s.cfg.KafkaServerAddresses[s.cfg.NodeID]
-	if s.cfg.KafkaServerTLSConfig.Enabled {
-		tlsConfig, err = conf.CreateServerTLSConfig(s.cfg.KafkaServerTLSConfig)
+	listenAddress := s.cfg.KafkaServerListenerConfig.Addresses[s.cfg.NodeID]
+	if s.cfg.KafkaServerListenerConfig.TLSConfig.Enabled {
+		tlsConfig, err = conf.CreateServerTLSConfig(s.cfg.KafkaServerListenerConfig.TLSConfig)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -144,7 +144,7 @@ func (s *Server) Stop() error {
 }
 
 func (s *Server) ListenAddress() string {
-	return s.cfg.KafkaServerAddresses[s.cfg.NodeID]
+	return s.cfg.KafkaServerListenerConfig.Addresses[s.cfg.NodeID]
 }
 
 func (s *Server) removeConnection(conn *connection) {

--- a/levels/compaction_test.go
+++ b/levels/compaction_test.go
@@ -45,7 +45,7 @@ func TestPollerTimeout(t *testing.T) {
 		var perr errors.TektiteError
 		isTektiteError := errors.As(err, &perr)
 		require.True(t, isTektiteError)
-		require.Equal(t, errors.CompactionPollTimeout, int(perr.Code))
+		require.Equal(t, errors.CompactionPollTimeout, perr.Code)
 	}
 }
 

--- a/objstore/dev/dev_store_test.go
+++ b/objstore/dev/dev_store_test.go
@@ -87,7 +87,7 @@ func TestDevStoreUnavailable(t *testing.T) {
 	require.Error(t, err)
 	var perr errors.TektiteError
 	if errors.As(err, &perr) {
-		require.Equal(t, errors.Unavailable, int(perr.Code))
+		require.Equal(t, errors.Unavailable, perr.Code)
 	} else {
 		require.Fail(t, "not a TektiteError")
 	}
@@ -96,7 +96,7 @@ func TestDevStoreUnavailable(t *testing.T) {
 	require.Error(t, err)
 	perr = errors.TektiteError{}
 	if errors.As(err, &perr) {
-		require.Equal(t, errors.Unavailable, int(perr.Code))
+		require.Equal(t, errors.Unavailable, perr.Code)
 	} else {
 		require.Fail(t, "not a TektiteError")
 	}
@@ -105,7 +105,7 @@ func TestDevStoreUnavailable(t *testing.T) {
 	require.Error(t, err)
 	perr = errors.TektiteError{}
 	if errors.As(err, &perr) {
-		require.Equal(t, errors.Unavailable, int(perr.Code))
+		require.Equal(t, errors.Unavailable, perr.Code)
 	} else {
 		require.Fail(t, "not a TektiteError")
 	}

--- a/remoting/client_test.go
+++ b/remoting/client_test.go
@@ -30,7 +30,7 @@ func TestRPCInternalError(t *testing.T) {
 	err := errors.New("spiders")
 	testRPCError(t, err, func(t *testing.T, tektiteError errors.TektiteError) {
 		t.Helper()
-		require.Equal(t, errors.InternalError, int(tektiteError.Code))
+		require.Equal(t, errors.InternalError, tektiteError.Code)
 	})
 }
 
@@ -168,7 +168,7 @@ func TestBroadcastErrorAllServers(t *testing.T) {
 	//goland:noinspection GoTypeAssertionOnErrors
 	perr, ok := err.(errors.TektiteError)
 	require.True(t, ok)
-	require.Equal(t, errors.InternalError, int(perr.Code))
+	require.Equal(t, errors.InternalError, perr.Code)
 
 	client.Stop()
 }
@@ -177,7 +177,7 @@ func TestBroadcastErrorOneServerInternalErrorNoDelays(t *testing.T) {
 	err := errors.New("spiders")
 	testBroadcastErrorOneServer(t, err, 0, 0, func(t *testing.T, tektiteError errors.TektiteError) {
 		t.Helper()
-		require.Equal(t, errors.InternalError, int(tektiteError.Code))
+		require.Equal(t, errors.InternalError, tektiteError.Code)
 	})
 }
 

--- a/remoting/connection_test.go
+++ b/remoting/connection_test.go
@@ -128,7 +128,7 @@ func TestResponseInternalError(t *testing.T) {
 
 	testResponseError(t, err, func(t *testing.T, perr errors.TektiteError) {
 		t.Helper()
-		require.Equal(t, errors.InternalError, int(perr.Code))
+		require.Equal(t, errors.InternalError, perr.Code)
 	})
 
 }
@@ -140,7 +140,7 @@ func TestResponseTektiteError(t *testing.T) {
 
 	testResponseError(t, err, func(t *testing.T, terr errors.TektiteError) {
 		t.Helper()
-		require.Equal(t, errors.ExecuteQueryError, int(terr.Code))
+		require.Equal(t, errors.ExecuteQueryError, terr.Code)
 		require.Equal(t, err.Msg, terr.Msg)
 	})
 }

--- a/scripttest/script_test_runner.go
+++ b/scripttest/script_test_runner.go
@@ -157,7 +157,7 @@ func (w *scriptTestSuite) createServerConfs() []conf.Config {
 	cfg.HttpApiEnabled = true
 	cfg.HttpApiAddresses = httpServerListenAddresses
 	cfg.HttpApiTlsConfig = serverTLSConfig
-	cfg.KafkaServerAddresses = kafkaListenAddresses
+	cfg.KafkaServerListenerConfig.Addresses = kafkaListenAddresses
 	cfg.KafkaServerEnabled = true
 	cfg.ProcessingEnabled = true
 	cfg.LevelManagerEnabled = true
@@ -753,7 +753,7 @@ func (st *scriptTest) produceMessages(require *require.Assertions, msgs []*kafka
 	s := st.chooseServer()
 	producer, err := kafkago.NewProducer(&kafkago.ConfigMap{
 		"partitioner":       "murmur2_random", // This matches the default hash algorithm we use, and same as Java client
-		"bootstrap.servers": s.GetConfig().KafkaServerAddresses[s.GetConfig().NodeID],
+		"bootstrap.servers": s.GetConfig().KafkaServerListenerConfig.Addresses[s.GetConfig().NodeID],
 		"acks":              "all"})
 	require.NoError(err)
 	defer producer.Close()
@@ -801,7 +801,7 @@ func (st *scriptTest) executeConsumeData(require *require.Assertions, command st
 
 	s := st.chooseServer()
 	cm := &kafkago.ConfigMap{
-		"bootstrap.servers":  s.GetConfig().KafkaServerAddresses[s.GetConfig().NodeID],
+		"bootstrap.servers":  s.GetConfig().KafkaServerListenerConfig.Addresses[s.GetConfig().NodeID],
 		"group.id":           groupID,
 		"auto.offset.reset":  earliestOrLatest,
 		"enable.auto.commit": false,


### PR DESCRIPTION
This PR introduces a listener config to the Kafka Server configuration which introduces a new `AdvertisedAddresses` config.

>[!Note]
> This is the first of multiple PRs that will introduce the same concept to the HTTP API, web console, and intra cluster.

### Changes
- Add ListenerConfig abstraction to KafkaServer config.
- Add `AdvertisedAddresses` 
- Add proper validation for `Addresses` and `AdvertisedAddresses` with proper unit tests.
- Refactors the Conf unit tests to use table tests.
- Adds an integration test that validates the broker sending the correct metadata response with broker info when setting `AdvertisedAddresses`

Related to: #81 