### PR TITLE
Change default number of processors

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	DefaultProcessorCount                 = 48
+	DefaultProcessorCount                 = 12
 	DefaultMaxProcessorBatchesInProgress  = 1000
 	DefaultMemtableMaxSizeBytes           = 16 * 1024 * 1024
 	DefaultMemtableMaxReplaceInterval     = 30 * time.Second

--- a/opers/mgr_test.go
+++ b/opers/mgr_test.go
@@ -113,6 +113,7 @@ func testBridgeFromOper(t *testing.T, msgs [][]*kafka.Message, numFailuresToCrea
 	pm := tppm.NewTestProcessorManager()
 	cfg := &conf.Config{}
 	cfg.ApplyDefaults()
+	cfg.ProcessorCount = 48
 
 	fact := msgClientFact{msgs: msgs,
 		numFailuresToCreate: numFailuresToCreate}

--- a/proc/processor_test.go
+++ b/proc/processor_test.go
@@ -109,7 +109,7 @@ func TestForwardBatches(t *testing.T) {
 		Value: []byte("val1"),
 	})
 
-	processorID := 23
+	processorID := 10
 
 	var forwardBatches []*ProcessBatch
 	numParts := 10

--- a/vmgr/vmgr_test.go
+++ b/vmgr/vmgr_test.go
@@ -652,6 +652,7 @@ func TestActivateThenDeactivateWithClusterStateWhileStillActivating(t *testing.T
 func TestFailure(t *testing.T) {
 	cfg := &conf.Config{}
 	cfg.ApplyDefaults()
+	cfg.ProcessorCount = 48
 
 	seqMgr := sequence.NewInMemSequenceManager()
 	vmgr, remotingServer, _, lmgrClient := setupWithSeqMgrWithActivate(t, seqMgr, cfg, true)
@@ -800,6 +801,7 @@ func TestFailureDetectionNotCompletedWithNotAllProcessors(t *testing.T) {
 func TestSecondFailureAtHigherClusterVersion(t *testing.T) {
 	cfg := &conf.Config{}
 	cfg.ApplyDefaults()
+	cfg.ProcessorCount = 48
 
 	seqMgr := sequence.NewInMemSequenceManager()
 	vmgr, remotingServer, _, _ := setupWithSeqMgrWithActivate(t, seqMgr, cfg, true)
@@ -894,6 +896,7 @@ func TestGetLastFailureFlushedVersionWrongClusterVersion(t *testing.T) {
 func TestFailureCompleteWrongClusterVersion(t *testing.T) {
 	cfg := &conf.Config{}
 	cfg.ApplyDefaults()
+	cfg.ProcessorCount = 48
 
 	seqMgr := sequence.NewInMemSequenceManager()
 	vmgr, remotingServer, _, _ := setupWithSeqMgrWithActivate(t, seqMgr, cfg, true)
@@ -950,6 +953,7 @@ func TestFailureCompleteWrongClusterVersion(t *testing.T) {
 func TestIsFailureCompleteWrongClusterVersion(t *testing.T) {
 	cfg := &conf.Config{}
 	cfg.ApplyDefaults()
+	cfg.ProcessorCount = 48
 
 	seqMgr := sequence.NewInMemSequenceManager()
 	vmgr, remotingServer, _, _ := setupWithSeqMgrWithActivate(t, seqMgr, cfg, true)


### PR DESCRIPTION
Previously it was too high (48), this PR changes it to 12, fixes tests that then broke, and fixed a bug in command manager that was revealed by the change.