### PR TITLE
No need for atomics to ensure memtable is not full

### DIFF
--- a/iteration/merging_iter.go
+++ b/iteration/merging_iter.go
@@ -40,15 +40,6 @@ func NewCompactionMergingIterator(iters []Iterator, preserveTombstones bool, min
 	return mi, nil
 }
 
-func (m *MergingIterator) PrependIterator(iter Iterator) error {
-	iters := make([]Iterator, 0, len(m.iters)+1)
-	iters = append(iters, iter)
-	iters = append(iters, m.iters...)
-	m.iters = iters
-	_, err := m.IsValid()
-	return err
-}
-
 func (m *MergingIterator) IsValid() (bool, error) {
 	repeat := true
 	for repeat {


### PR DESCRIPTION
Now that memtable.Write() is always called from processor loop, we can simplify the calculation of whether a write can be accommodated by the memtable by not using atomics.

Also, removes an unused method