### PR TITLE
Preserve tombstones if any non compactable entries in job

### DIFF
--- a/sst/sstable.go
+++ b/sst/sstable.go
@@ -114,7 +114,10 @@ func BuildSSTable(format common.DataFormat, buffSizeEstimate int, entriesEstimat
 		}
 		largestKey = kv.Key
 		version := math.MaxUint64 - binary.BigEndian.Uint64(kv.Key[len(kv.Key)-8:]) // last 8 bytes is version
-		if version > maxVersion {
+
+		if version != math.MaxUint64 && version > maxVersion {
+			// prefix delete tombstones have a special version = math.MaxUint64 which identifies them in merging_iterator
+			// we don't consider this a real version and don't take it into account here
 			maxVersion = version
 		}
 		if version < minVersion {


### PR DESCRIPTION
Now we do not remove tombstones if there are any entries in any tables of the compaction which have a version > last flushed version. This prevents a situation where entries with a tombstone can remain and tombstone can be removed if entry version > last flushed version so not compacted, but tombstone is still removed as last level, resulting in data not being deleted.