### PR TITLE
Fixes some bugs in iteration

### DIFF
--- a/iteration/chaining_iter.go
+++ b/iteration/chaining_iter.go
@@ -17,11 +17,14 @@ func NewChainingIterator(its []Iterator) *ChainingIterator {
 func (c *ChainingIterator) Next() (bool, common.KV, error) {
 	for ; c.pos < len(c.iterators); c.pos++ {
 		valid, kv, err := c.iterators[c.pos].Next()
-		if err == nil && !valid {
+		if err != nil {
+			return false, common.KV{}, err
+		}
+		if !valid {
 			continue
 		}
 		c.head = kv
-		return valid, kv, err
+		return true, kv, err
 	}
 	c.head = common.KV{}
 	return false, c.head, nil

--- a/levels/iters.go
+++ b/levels/iters.go
@@ -56,6 +56,7 @@ func (r *RemoveExpiredEntriesIterator) Current() common.KV {
 }
 
 func (r *RemoveExpiredEntriesIterator) Close() {
+	r.iter.Close()
 }
 
 func (r *RemoveExpiredEntriesIterator) isExpired(key []byte) (bool, error) {
@@ -88,7 +89,7 @@ func (r *RemoveDeadVersionsIterator) Next() (bool, common.KV, error) {
 	for {
 		valid, curr, err := r.iter.Next()
 		if err != nil || !valid {
-			return valid, curr, err
+			return false, curr, err
 		}
 		dead := r.hasDeadVersion(curr.Key)
 		if !dead {
@@ -106,6 +107,7 @@ func (r *RemoveDeadVersionsIterator) Current() common.KV {
 }
 
 func (r *RemoveDeadVersionsIterator) Close() {
+	r.iter.Close()
 }
 
 func (r *RemoveDeadVersionsIterator) hasDeadVersion(key []byte) bool {

--- a/mem/iter.go
+++ b/mem/iter.go
@@ -38,6 +38,7 @@ func (m *MemtableIterator) Next() (bool, common.KV, error) {
 	}
 
 	if !m.it.Valid() {
+		m.curr = common.KV{}
 		return false, common.KV{}, nil
 	}
 

--- a/sst/iters.go
+++ b/sst/iters.go
@@ -29,6 +29,7 @@ type SSTableIterator struct {
 func (si *SSTableIterator) Next() (bool, common.KV, error) {
 	if si.nextOffset == -1 {
 		si.valid = false
+		si.currkV = common.KV{}
 		return false, common.KV{}, nil
 	}
 	indexOffset := int(si.ss.indexOffset)
@@ -39,6 +40,7 @@ func (si *SSTableIterator) Next() (bool, common.KV, error) {
 		// End of range
 		si.nextOffset = -1
 		si.valid = false
+		si.currkV = common.KV{}
 		return false, common.KV{}, nil
 	} else {
 		si.currkV.Key = k
@@ -139,12 +141,6 @@ func (l *LazySSTableIterator) getIter() (iteration.Iterator, error) {
 		if err != nil {
 			return nil, err
 		}
-		//if log.DebugEnabled {
-		//	DumpLock.Lock()
-		//	defer DumpLock.Unlock()
-		//	dumpSST(l.tableID, ssTable)
-		//}
-
 		iter, err := l.iterFactory(ssTable, l.keyStart, l.keyEnd)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR fixes some bugs introduced after recent major changes to iterators and does some cleanup
* Fixes bug where memtable iterator Current() was returning old entry after Next() had returned valid = false.
* Fixes bug where sstable iterator Current() was returning old entry after Next() had returned valid = false.
* Adds some tests for Current() 
* Merging iterator was removing non compactable entries when key the same
* Make sure iterator.Close() is propagated
* Some cleanup - making return values constants where we know they will be constants, for clarity

@watson28 fyi