### PR TITLE
fixed a few bugs that were causing failover tests to fail

### DIFF
--- a/debug/debug_on.go
+++ b/debug/debug_on.go
@@ -8,3 +8,5 @@ package debug
 //goland:noinspection GoUnusedGlobalVariable
 var Debug = true
 var SanityChecks = true
+
+var AggregateChecks = false

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -20,6 +20,7 @@ const (
 	LevelManagerNotLeaderNode
 	VersionManagerShutdown
 	FailureCancelled
+	RegisterDeadVersionWrongClusterVersion
 	InvalidConfiguration ErrorCode = iota + 3000
 	InternalError        ErrorCode = iota + 5000
 )

--- a/integration/failover_test.go
+++ b/integration/failover_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spirit-labs/tektite/kafka"
 	"github.com/spirit-labs/tektite/kafka/fake"
 	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/sanity"
 	"github.com/spirit-labs/tektite/server"
 	"github.com/spirit-labs/tektite/tekclient"
 	"github.com/spirit-labs/tektite/testutils"
@@ -197,6 +198,8 @@ func testFailoverReplicationQueuesWithAggregation(t *testing.T, failLevelManager
 	failNode, clientNode := getFailAndClientNodes(failLevelManager, servers)
 	client := createClient(t, clientNode, servers)
 	defer client.Close()
+
+	sanity.ClearStores()
 
 	defer func() {
 		r := recover()

--- a/iteration/merging_iter.go
+++ b/iteration/merging_iter.go
@@ -87,6 +87,9 @@ func (m *MergingIterator) Next() (bool, common.KV, error) {
 					// in same iterator we can have multiple versions of the same key
 					keyNoVersion = c.Key[:len(c.Key)-8]
 					if !m.firstSameKeyNonCompactable && bytes.Equal(lastKeyNoVersion, keyNoVersion) {
+						if version >= m.minNonCompactableVersion {
+							panic("compacting non compactable version") //sanity check
+						}
 						if log.DebugEnabled {
 							lastVersion := encoding.DecodeKeyVersion(m.current.Key)
 							log.Debugf("%p mi: dropping key in next as same key: key %v (%s) value %v (%s) version:%d last key: %v (%s) last value %v (%s) last version %d minnoncompactableversion:%d",

--- a/levels/compaction.go
+++ b/levels/compaction.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/debug"
 	"github.com/spirit-labs/tektite/encoding"
 	"github.com/spirit-labs/tektite/errors"
 	log "github.com/spirit-labs/tektite/logger"
@@ -53,26 +54,12 @@ func (lm *LevelManager) maybeScheduleCompaction() error {
 	return err
 }
 
-func (lm *LevelManager) chooseL0TablesToCompact() ([][]*TableEntry, bool) {
-	if lm.compactingStartupL0Group {
-		// If we're already compacting startup L0 group (processor id = -1) then we cannot compact any more L0 tables
-		// until that is complete. That's because the startup L0 group can have key overlap with other groups so
-		// if we processed a compaction for a non startup L0 group before the startup compaction completed it could result
-		// in moves to L1 with overlapping keys.
-		return nil, false
-	}
-	// If we have table entries for processor -1, these are ones added on startup where we do not know the processor id.
-	// So we must compact this in a single job, before compact any others.
-	startupEntries, ok := lm.level0Groups[-1]
-	if ok {
-		return [][]*TableEntry{startupEntries}, true
-	}
-	// We currently compact the whole level - a job for each group
+func (lm *LevelManager) getAllL0Tables() [][]*TableEntry {
 	var tableSlices [][]*TableEntry
 	for _, g := range lm.level0Groups {
 		tableSlices = append(tableSlices, g)
 	}
-	return tableSlices, true
+	return tableSlices
 }
 
 func (lm *LevelManager) scheduleCompaction(level int, tableSlices [][]*TableEntry, deadVersionRanges []VersionRange,
@@ -200,7 +187,7 @@ outer:
 			preserveTombstones: preserveTombstones,
 			scheduleTime:       common.NanoTime(),
 			serverTime:         uint64(time.Now().UTC().UnixMilli()),
-			lastFlushedVersion: lm.masterRecord.lastFlushedVersion,
+			lastFlushedVersion: lm.minNonCompactableVersion(),
 		}
 
 		log.Debugf("created compaction job %s from level %d last level is %d, preserve tombstones is %t",
@@ -229,6 +216,21 @@ outer:
 
 	// return number of jobs, whether any tables were locked
 	return len(jobs), hasLocked, nil
+}
+
+func (lm *LevelManager) minNonCompactableVersion() int64 {
+	var minRange int64 = math.MaxInt64
+	for _, rng := range lm.masterRecord.deadVersionRanges {
+		if int64(rng.VersionStart) < minRange {
+			minRange = int64(rng.VersionStart)
+		}
+	}
+	lfv := lm.masterRecord.lastFlushedVersion
+	if lfv < minRange {
+		// FIXME - is this ever true?
+		return lfv
+	}
+	return minRange
 }
 
 func (lm *LevelManager) hasPotentialExpiredEntries(te *TableEntry, now uint64) bool {
@@ -353,12 +355,16 @@ func (lm *LevelManager) tableCount(level int) int {
 
 func (lm *LevelManager) chooseTablesToCompact(level int, maxTables int) ([][]*TableEntry, error) {
 	if level == 0 {
-		tables, ok := lm.chooseL0TablesToCompact()
-		if !ok {
+		if lm.compactingStartupL0Group {
 			// L0 startup group compaction in progress
 			return nil, nil
 		}
-		return tables, nil
+		startupEntries, ok := lm.level0Groups[-1]
+		if ok {
+			// There are startup entries - they must be compacted first
+			return [][]*TableEntry{startupEntries}, nil
+		}
+		return lm.getAllL0Tables(), nil
 	}
 	iter, err := lm.levelIterator(level)
 	if err != nil {
@@ -599,6 +605,30 @@ func (lm *LevelManager) connectionClosed(connectionID int) {
 	}
 }
 
+func (lm *LevelManager) checkForDeadEntries(rng VersionRange) bool {
+	for level, _ := range lm.masterRecord.levelSegmentEntries {
+		iter, err := lm.levelIterator(level)
+		if err != nil {
+			panic(err)
+		}
+		for {
+			te, err := iter.Next()
+			if err != nil {
+				panic(err)
+			}
+			if te == nil {
+				break
+			}
+			// Only add the tables that match
+			if te.MaxVersion >= rng.VersionStart && te.MinVersion <= rng.VersionEnd {
+				log.Errorf("entry with dead version in sstable %s level %d", string(te.SSTableID), level)
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (lm *LevelManager) maybeScheduleRemoveDeadVersionEntries() error {
 	log.Debugf("levelmanager.maybeScheduleRemoveDeadVersionEntries")
 	if lm.removeDeadVersionsInProgress {
@@ -630,7 +660,6 @@ func (lm *LevelManager) maybeScheduleRemoveDeadVersionEntries() error {
 			if level == 0 {
 				// We compact the entire level, if at least one table matches dead version
 				hasMatch := false
-				entries := lm.getLevelSegmentEntries(0)
 				if len(entries.segmentEntries) > 0 {
 					l0SegmentEntry := entries.segmentEntries[0]
 					l0Seg, err := lm.getSegment(l0SegmentEntry.segmentID)
@@ -646,12 +675,17 @@ func (lm *LevelManager) maybeScheduleRemoveDeadVersionEntries() error {
 					}
 				}
 				if hasMatch {
-					var ok bool
-					tableEntries, ok = lm.chooseL0TablesToCompact()
-					if !ok {
-						// We can't choose any L0 tables as there is a startup L0 compaction in progress, this doesn't
-						// mean there are no dead version entries, so we won't remove the entry on completion
+					if lm.compactingStartupL0Group {
 						scheduledAll = false
+					} else {
+						startupEntries, ok := lm.level0Groups[-1]
+						if ok {
+							// If there are any startup entries they should be scheduled first
+							tableEntries = [][]*TableEntry{startupEntries}
+							scheduledAll = false // There could be other L0 entries too, with dead versions in them
+						} else {
+							tableEntries = lm.getAllL0Tables()
+						}
 					}
 				}
 			} else {
@@ -678,10 +712,13 @@ func (lm *LevelManager) maybeScheduleRemoveDeadVersionEntries() error {
 			}
 		}
 
-		if len(infos) == 0 {
+		if scheduledAll && len(infos) == 0 {
 			log.Debugf("removal of dead version range: %v - no data to remove so doing nothing", versionRange)
 			// Nothing to do, we can remove the dead version now
 			lm.masterRecord.deadVersionRanges = lm.masterRecord.deadVersionRanges[1:]
+			if debug.SanityChecks && lm.checkForDeadEntries(versionRange) {
+				panic(fmt.Sprintf("dead entries for range %v still exist after removal", versionRange))
+			}
 			if len(lm.masterRecord.deadVersionRanges) > 0 {
 				// Try with the next version range
 				continue
@@ -705,6 +742,9 @@ func (lm *LevelManager) maybeScheduleRemoveDeadVersionEntries() error {
 				// range can remain - we remove the dead version
 				log.Debugf("dead version range %v removed on level manager", lm.masterRecord.deadVersionRanges[0])
 				lm.masterRecord.deadVersionRanges = lm.masterRecord.deadVersionRanges[1:]
+				if debug.SanityChecks && lm.checkForDeadEntries(versionRange) {
+					panic(fmt.Sprintf("dead entries for range %v still exist after removal", versionRange))
+				}
 			}
 			lm.removeDeadVersionsInProgress = false
 		})

--- a/levels/level_manager.go
+++ b/levels/level_manager.go
@@ -627,8 +627,10 @@ func (lm *LevelManager) RegisterDeadVersionRange(versionRange VersionRange, clus
 	defer lm.updateReplSeq(replSeq)
 	lowestVersion := lm.clusterVersions[clusterName]
 	if clusterVersion < lowestVersion {
-		return errors.NewTektiteErrorf(errors.Unavailable,
-			"RegisterDeadVersionRange - registration batch version is too low %d expected %d", clusterVersion, lowestVersion)
+		// Note we send back RegisterDeadVersionWrongClusterVersion as we do not want the sender to retry - failure
+		// should be cancelled
+		return errors.NewTektiteErrorf(errors.RegisterDeadVersionWrongClusterVersion,
+			"RegisterDeadVersionRange - cluster version is too low %d expected %d", clusterVersion, lowestVersion)
 	}
 	// We update the cluster version - this prevents L0 tables with a dead version range being pushed after this has been
 	// called - as we clear the local store when we get the new cluster version in proc mgr.

--- a/opers/aggregate_test.go
+++ b/opers/aggregate_test.go
@@ -1168,7 +1168,7 @@ func testAggregateWithStoredData(t *testing.T, inColumnNames []string, inColumnT
 
 	agg, err := NewAggregateOperator(&OperatorSchema{EventSchema: inSchema, PartitionScheme: PartitionScheme{MappingID: "mapping", Partitions: 200}}, aggDesc, tableID,
 		-1, -1, -1, 0, 0, 0, false, false,
-		&expr.ExpressionFactory{})
+		&expr.ExpressionFactory{}, 0)
 	require.NoError(t, err)
 
 	require.Equal(t, outColumnNames, agg.aggStateSchema.ColumnNames())

--- a/opers/mgr.go
+++ b/opers/mgr.go
@@ -932,7 +932,7 @@ func (sm *streamManager) deployAggregateOperator(streamName string, op *parser.A
 		}
 	}
 	aggOper, err := NewAggregateOperator(prevOperator.OutSchema(), op, aggStateSlabID, openWindowsSlabID, resultsSlabID,
-		closedWindowReceiverID, size, hop, lateness, storeResults, includeWindowCols, sm.expressionFactory)
+		closedWindowReceiverID, size, hop, lateness, storeResults, includeWindowCols, sm.expressionFactory, sm.cfg.NodeID)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/opers/window_test.go
+++ b/opers/window_test.go
@@ -38,7 +38,7 @@ func TestAugmentWithWindows(t *testing.T) {
 		PartitionScheme: NewPartitionScheme("foo", 10, false, 48)},
 		aggDesc, 0,
 		-1, -1, -1, time.Duration(size)*time.Millisecond,
-		time.Duration(hop)*time.Millisecond, 0, false, false, &expr.ExpressionFactory{})
+		time.Duration(hop)*time.Millisecond, 0, false, false, &expr.ExpressionFactory{}, 0)
 	require.NoError(t, err)
 
 	eventTimes := []int{100, 101, 105, 107, 109}

--- a/opers/windowed_agg_test.go
+++ b/opers/windowed_agg_test.go
@@ -356,7 +356,7 @@ func setupAgg(t *testing.T, latenessMs int, tableID int, offset bool) *Aggregate
 	agg, err := NewAggregateOperator(operSchema, aggDesc, tableID,
 		1002, 1003, 1004, time.Duration(100)*time.Millisecond,
 		time.Duration(10)*time.Millisecond, time.Duration(latenessMs)*time.Millisecond, false, true,
-		&expr.ExpressionFactory{})
+		&expr.ExpressionFactory{}, 0)
 	require.NoError(t, err)
 	require.Equal(t, outColumnNames, agg.aggStateSchema.ColumnNames())
 	require.Equal(t, outColumnTypes, agg.aggStateSchema.ColumnTypes())

--- a/proc/failure.go
+++ b/proc/failure.go
@@ -197,7 +197,7 @@ func (f *failureHandler) getLastFailureFlushedVersion() error {
 		return err
 	}
 	// -2 return represents still waiting for versions to complete for required cluster version
-	if lastFlushedVersion == -2 || err != nil {
+	if lastFlushedVersion == -2 {
 		log.Debugf("node: %d calling GetLastFailureFlushedVersion for clusterVersion %d returned last flushed %d err %v",
 			f.procMgr.cfg.NodeID, f.failingClusterVersion, lastFlushedVersion, err)
 		// not all processors have called in to version manager or version manager is unavailable - we will retry
@@ -329,6 +329,7 @@ func (f *failureHandler) maybeRunFailure(cs *clustmgr.ClusterState) error {
 	}
 	nodeFailures := f.hasNodeFailure(cs)
 	if nodeFailures || f.failingClusterVersion != -1 || reflect.DeepEqual(f.lastFailedClusterState, cs) {
+		log.Debugf("node %d failure detected at cluster version %d", f.procMgr.cfg.NodeID, cs.Version)
 		// If any node failures, or we're already failing, or this cluster state is same as last cluster state failure
 		// was attempted with then we start failure.
 		// The same cluster state, with a different version can arrive, and we must make sure we reprocess failure with

--- a/sanity/sanity_store.go
+++ b/sanity/sanity_store.go
@@ -1,0 +1,147 @@
+package sanity
+
+import (
+	"fmt"
+	"github.com/spirit-labs/tektite/encoding"
+	"github.com/spirit-labs/tektite/levels"
+	log "github.com/spirit-labs/tektite/logger"
+	"sync"
+)
+
+func NewSanityStore() *SanityStore {
+	return &SanityStore{data: map[string][]valueHolder{}}
+}
+
+type SanityStore struct {
+	lock         sync.Mutex
+	data         map[string][]valueHolder
+	deadVersions []levels.VersionRange
+}
+
+type valueHolder struct {
+	version uint64
+	value   []byte
+}
+
+var procStores = make(map[int]*SanityStore)
+var mapLock sync.Mutex
+
+func GetSanityStore(processorID int) *SanityStore {
+	mapLock.Lock()
+	defer mapLock.Unlock()
+	ss, ok := procStores[processorID]
+	if !ok {
+		ss = NewSanityStore()
+		procStores[processorID] = ss
+	}
+	return ss
+}
+
+func ClearStores() {
+	mapLock.Lock()
+	defer mapLock.Unlock()
+	for _, ss := range procStores {
+		ss.Clear()
+	}
+}
+
+func RegisterDeadVersionRange(versionRange levels.VersionRange) {
+	mapLock.Lock()
+	defer mapLock.Unlock()
+	for _, ss := range procStores {
+		ss.RegisterDeadVersionRange(versionRange)
+	}
+}
+
+func (s *SanityStore) Put(key []byte, value []byte) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	version := encoding.DecodeKeyVersion(key)
+	keyNoVersion := key[:len(key)-8]
+	sKey := string(keyNoVersion)
+	values, ok := s.data[sKey]
+	//log.Infof("sanitystore putting key %v value %v", key, value)
+	if !ok {
+		s.data[sKey] = []valueHolder{{value: value, version: version}}
+	} else {
+		// check version is higher
+		prevHolder := values[len(values)-1]
+		if version < prevHolder.version {
+			panic(fmt.Sprintf("version for key %v (%d) is lower than previous version (%d)", key, version, prevHolder.version))
+		}
+		s.data[sKey] = append(values, valueHolder{value: value, version: version})
+	}
+}
+
+func (s *SanityStore) LogValuesForKey(keyNoVersion []byte) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	values, ok := s.data[string(keyNoVersion)]
+	if !ok {
+		log.Infof("sanity store has no values for key %v", keyNoVersion)
+	} else {
+		log.Infof("sanity store has %d values for key %v:\n", len(values), keyNoVersion)
+		for _, value := range values {
+			log.Infof("%v\n", value)
+		}
+	}
+}
+
+func (s *SanityStore) Get(keyNoVersion []byte, maxVersion uint64) []byte {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	values, ok := s.data[string(keyNoVersion)]
+	if !ok {
+		return nil
+	}
+	for i := len(values) - 1; i >= 0; i-- {
+		holder := values[i]
+		if holder.version > maxVersion {
+			continue
+		}
+		if s.isDead(holder.version) {
+			continue
+		}
+		if len(holder.value) == 0 {
+			// tombstone
+			return nil
+		}
+		return holder.value
+	}
+	return nil
+}
+
+func (s *SanityStore) Clear() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.data = map[string][]valueHolder{}
+	s.deadVersions = nil
+}
+
+func (s *SanityStore) RegisterDeadVersionRange(versionRange levels.VersionRange) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	log.Infof("registering dead version range %v", versionRange)
+	s.deadVersions = append(s.deadVersions, versionRange)
+}
+
+func (s *SanityStore) UnregisterDeadVersionRange(versionRange levels.VersionRange) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	var newVersions []levels.VersionRange
+	for _, rng := range s.deadVersions {
+		if rng.VersionStart != versionRange.VersionStart || rng.VersionEnd != versionRange.VersionEnd {
+			newVersions = append(newVersions, rng)
+		}
+	}
+	s.deadVersions = newVersions
+}
+
+func (s *SanityStore) isDead(version uint64) bool {
+	for _, versionRange := range s.deadVersions {
+		if version >= versionRange.VersionStart && version <= versionRange.VersionEnd {
+			return true
+		}
+	}
+	return false
+}

--- a/vmgr/failure.go
+++ b/vmgr/failure.go
@@ -2,9 +2,11 @@ package vmgr
 
 import (
 	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/debug"
 	"github.com/spirit-labs/tektite/errors"
 	"github.com/spirit-labs/tektite/levels"
 	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/sanity"
 	"sync/atomic"
 	"time"
 )
@@ -139,6 +141,9 @@ func (v *VersionManager) failureVersionsCompleted(deadVersionRange levels.Versio
 	for {
 		err := v.levelMgrClient.RegisterDeadVersionRange(deadVersionRange, v.cfg.ClusterName, failureClusterVersion)
 		if err == nil {
+			if debug.AggregateChecks {
+				sanity.RegisterDeadVersionRange(deadVersionRange)
+			}
 			break
 		}
 		if v.isStopped() {


### PR DESCRIPTION
This PR fixes a few bugs that were causing intermittent failures in FailoverTests.
* Bug in removing dead version entries which meant the dead version range was removed from the master record while there were still dead entries in the database
* Infinite retry loop for RegisterDeadVersionRange. If this returned wrong cluster version it would end up in an infinite retry loop
* Bug in clearing processor store during failover - wasn't cleared properly resulting in dead versions being visible in queries.
* I have also added a struct called SanityStore - this a device that is useful in detecting whether the store is behaving correctly for puts/gets. After a get in an aggregation we validate it against a get in the SanityStore and make sure the same entry is returned. Bugs with duplicate or missing entries are notoriously hard to track down, and this makes it much easier. It is left disabled in the code and can be enabled for debugging if other bugs like this are spotted in the future.