### PR TITLE
Now the processor write cache is write-through, this is important as …

### DIFF
--- a/opers/bridge_to.go
+++ b/opers/bridge_to.go
@@ -194,10 +194,6 @@ func (b *BridgeToOperator) exitPausedMode(processor proc.Processor, partIDs []in
 		b.timers.Delete(procID)
 		b.pausedMode[procID] = false
 		b.lastRetryDuration[procID] = 0 // reset retry delay
-		// We must flush write cache before loading as version might not have completed and data could still be in cache
-		if err := processor.WriteCache().MaybeWriteToStore(); err != nil {
-			return err
-		}
 		for _, partID := range partIDs {
 			// Tell the backfill operator to start back-filling from last committed offset.
 			if err := b.backFillOperator.restartBackfill(partID, processor); err != nil {

--- a/opers/mgr.go
+++ b/opers/mgr.go
@@ -1996,12 +1996,12 @@ func (e *execContext) StoreEntry(kv common.KV, noCache bool) {
 			tp.ValidateKeyRange(kv.Key)
 		}
 	}
-	if noCache {
-		if e.entries == nil {
-			e.entries = mem.NewBatch()
-		}
-		e.entries.AddEntry(kv)
-	} else {
+	if e.entries == nil {
+		e.entries = mem.NewBatch()
+	}
+	// We always write through - this is essential to ensure repl seq is written in the same memtable
+	e.entries.AddEntry(kv)
+	if !noCache {
 		e.processor.WriteCache().Put(kv)
 	}
 }

--- a/proc/processor.go
+++ b/proc/processor.go
@@ -565,12 +565,6 @@ func (p *processor) processBarrier(barrier *ProcessBatch) error {
 	if err != nil {
 		return err
 	}
-	// We write the cache on every barrier. However, instead of writing cache on every barrier it would be better to
-	// write it when we know there will be no more barriers on a processor for a version. This is not as simple as
-	// writing it on VersionComplete as VersionComplete is only called on terminal processors
-	if err := p.WriteCache().MaybeWriteToStore(); err != nil {
-		return err
-	}
 	if len(remoteBatches) > 0 {
 		p.enqueueForwardBatches(remoteBatches)
 	} else {

--- a/tppm/proc_mgr.go
+++ b/tppm/proc_mgr.go
@@ -377,9 +377,6 @@ func (t *TestProcessor) handleBatchHolder(holder ingestBatchHolder) {
 		}
 	}
 	holder.cf(nil)
-	if err := t.WriteCache().MaybeWriteToStore(); err != nil {
-		log.Errorf("failed to write to store %v", err)
-	}
 }
 
 func (t *TestProcessor) close() {


### PR DESCRIPTION
…we need to make sure that replseq is always written in the same memtable, otherwise we lose correctness on failover