### PR TITLE
Now we lock source and dest ranges in levels when we compact, this is…

### DIFF
--- a/levels/level_manager_test.go
+++ b/levels/level_manager_test.go
@@ -1476,10 +1476,16 @@ func TestDeadVersionsRemovedOnStartup(t *testing.T) {
 		VersionEnd:   33,
 	}
 	// Apply a lock to prevent compaction happening straight away
-	lm.lockTable("sst1")
+	lr := lockedRange{
+		level: 1,
+		start: regEntry.KeyStart,
+		end:   regEntry.KeyEnd,
+	}
+	lm.LockRange(lr)
+
 	err = lm.RegisterDeadVersionRange(rng, "test_cluster", 123, false, 0)
 	require.NoError(t, err)
-	lm.unlockTable("sst1")
+	lm.UnlockRange(lr)
 
 	stats := lm.GetCompactionStats()
 	require.Equal(t, 0, stats.QueuedJobs)


### PR DESCRIPTION
… an improvement over previous behaviour where we locked tables, but this ended up not locking anything where nothing overlapping in the destination so could allow multiple concurrent compactions into same range to occur