### PR TITLE
 Use binary Heap to reduce number of key comparison in merging_iter

### DIFF
--- a/iteration/merging_iter_bench_test.go
+++ b/iteration/merging_iter_bench_test.go
@@ -10,48 +10,52 @@ import (
 
 func BenchmarkMergingIterator(b *testing.B) {
 	numEntries := 1000
-	numIters := 10
-	iters := make([]Iterator, numIters)
-	for i := 0; i < numIters; i++ {
-		iters[i] = &StaticIterator{}
-	}
-	var expectedKeys [][]byte
-	var expectedVals [][]byte
-	for i := 0; i < numEntries; i++ {
-		skey := fmt.Sprintf("someprefix/key-%010d", i)
-		sval := fmt.Sprintf("someprefix/val-%010d", i)
-		expectedKeys = append(expectedKeys, []byte(skey))
-		expectedVals = append(expectedVals, []byte(sval))
-		r := rand.Intn(numIters)
-		sIter := iters[r].(*StaticIterator) //nolint:forcetypeassert
-		sIter.AddKVAsStringWithVersion(skey, sval, 0)
-	}
+	lengths := []int{10, 100, 1000, 10000, 100000}
 
-	for i := 0; i < b.N; i++ {
-
-		for j := 0; j < numIters; j++ {
-			iters[j].(*StaticIterator).pos = 0
+	for _, numIters := range lengths {
+		iters := make([]Iterator, numIters)
+		for i := 0; i < numIters; i++ {
+			iters[i] = &StaticIterator{}
+		}
+		var expectedKeys [][]byte
+		var expectedVals [][]byte
+		for i := 0; i < numEntries; i++ {
+			skey := fmt.Sprintf("someprefix/key-%010d", i)
+			sval := fmt.Sprintf("someprefix/val-%010d", i)
+			expectedKeys = append(expectedKeys, []byte(skey))
+			expectedVals = append(expectedVals, []byte(sval))
+			r := rand.Intn(numIters)
+			sIter := iters[r].(*StaticIterator) //nolint:forcetypeassert
+			sIter.AddKVAsStringWithVersion(skey, sval, 0)
 		}
 
-		mi, err := NewMergingIterator(iters, false, 0)
-		require.NoError(b, err)
+		b.Run(fmt.Sprintf("MerginIterator-%d", numIters), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < numIters; j++ {
+					iters[j].(*StaticIterator).pos = 0
+				}
 
-		for j := 0; j < numEntries; j++ {
-			valid, curr, err := mi.Next()
-			if err != nil {
-				panic(err)
+				mi, err := NewMergingIterator(iters, false, 0)
+				require.NoError(b, err)
+
+				for j := 0; j < numEntries; j++ {
+					valid, curr, err := mi.Next()
+					if err != nil {
+						panic(err)
+					}
+					if !valid {
+						panic("not valid")
+					}
+					expectedKey := expectedKeys[j]
+					expectedVal := expectedVals[j]
+					if !bytes.Equal(expectedKey, curr.Key[:len(curr.Key)-8]) {
+						panic("key not equal")
+					}
+					if !bytes.Equal(expectedVal, curr.Value) {
+						panic("key not equal")
+					}
+				}
 			}
-			if !valid {
-				panic("not valid")
-			}
-			expectedKey := expectedKeys[j]
-			expectedVal := expectedVals[j]
-			if !bytes.Equal(expectedKey, curr.Key[:len(curr.Key)-8]) {
-				panic("key not equal")
-			}
-			if !bytes.Equal(expectedVal, curr.Value) {
-				panic("key not equal")
-			}
-		}
+		})
 	}
 }

--- a/iteration/merging_iter_bench_test.go
+++ b/iteration/merging_iter_bench_test.go
@@ -10,7 +10,7 @@ import (
 
 func BenchmarkMergingIterator(b *testing.B) {
 	numEntries := 1000
-	lengths := []int{10, 100, 1000, 10000, 100000}
+	lengths := []int{2, 3, 4, 5}
 
 	for _, numIters := range lengths {
 		iters := make([]Iterator, numIters)


### PR DESCRIPTION
https://github.com/spirit-labs/tektite/issues/176

This PR changes mergin_iter.go to use a binary min-heap data structure to reduce the number of key comparisons when calculating the next kv between the list of iterators that are merged. Using a Binary Heap should reduce the time to find the next KV compared to the current implementation.

## Heap array
The Heap is maintained with a new array `heap []int` in the struct. The length of this new array is `len(iters) + 1` to store the elements with index-1 based. This is to simplify the calculation of the parent and children of an element in the Heap. The Heap doesn't contain an actual KV but the index of the Iterator from which the KV should be obtained.

## Heap tail 
Iterators can change from an invalid state to a valid state (see [test](https://github.com/watson28/tektite/blob/5970b9f5cf543bf209f1d6b22e843cd72686a7d6/iteration/merging_iter_test.go#L130)). That means that if an iterator returns a value with `valid=false`, we cannot drop it because it could still return valid values in the future. That's why the `heap []int` array is logically split into two regions, active and inactive. Iterators in the range `[1,heapTail]` (both end inclusive) contain the active iterators. Iterators in the range `[heapTail, ...]` are inactive (has returned `valid=false`). It's in the active range `[1, heapTail]` where the actual Heap data structure lives and its property is maintained.

As an example, given the heap with the following iterator indexes:

 _0__1__2__3__4__5__6__7
[-1] [6] [3] [5] [2] [4] [1] [0]
________________^
________________^ heapTail                                 

and `heapTail=5`. The active iterators are: {6, 3, 5, 2, 4}, and the inactive are: {1, 0}. 

## Getting the next value
A heap keeps the minimum value in the pos=1. That means that to get the next KV to return, we do `m.iters[m.heap[1]].Current()`. After the minimum value has been used, it has to be removed from the heap. This is done in the next call of `Next()` by advancing the iterator of the previously returned value: `m.iters[m.heap[1]].Next()`.  If the operation results with valid == true`, the iterator is kept in `pos=1`, and a Heap sift-down operation is executed in the active range of the heap ( to maintain heap property with the new value).

## Iterator changing from valid to invalid
Following the previous section, if the operation results are valid == false, then the iterator is moved to the inactive region. This is done by swapping the element with the last element in the Heap, moving the heapTail to the left, and finally executing a sift-down operation in the new element in `pos=1`.  This is illustrated in the following diagrams:

1 - (swap pos=1 with heapTail)

 _0__1__2__3__4__5__6__7
[-1] [4] [3] [5] [2] [6] [1] [0]
________________^
________________^ heapTail     

2 - (move the heapTail to include the last element in the inactive range)

 _0__1__2__3__4__5__6__7
[-1] [4] [3] [5] [2] [6] [1] [0]
_____________^
_____________^ heapTail     

3 - (do sift-down operation to maintain heap property)

 _0__1__2__3__4__5__6__7
[-1] [3] [5] [2] [4] [6] [1] [0]
_____________^
_____________^ heapTail     

## Iterator changing from invalid to valid
As mentioned before, Iterators can change from an invalid state to a valid state (see [test](https://github.com/watson28/tektite/blob/5970b9f5cf543bf209f1d6b22e843cd72686a7d6/iteration/merging_iter_test.go#L130)). This means that in every call to `Next()` we have to check if the existing invalid iterators have any new valid data and if that's the case then the iterator has to be moved to the valid region of the heap. This is explained in the following three steps:

4 - (assuming iterator 0 has new valid data, we move it to the beginning of the inactive region

 _0__1__2__3__4__5__6__7
[-1] [3] [5] [2] [4] [0] [1] [6]
_____________^
_____________^ heapTail  
 
5 - (move the heapTail to include the first inactive iterator into the active region)

 _0__1__2__3__4__5__6__7
[-1] [3] [5] [2] [4] [0] [1] [6]
________________^
________________^ heapTail  

6 - (perform a sift-up operation to keep heap property. Let's assume the new value of 0 left it in the middle of the heap).

 _0__1__2__3__4__5__6__7
[-1] [3] [5] [0] [4] [2] [1] [6]
________________^
________________^ heapTail  

# performance result

Performance stats were collected by running the command:
```
go test -benchmem -bench ^BenchmarkMergingIterator$ github.com/spirit-labs/tektite/iteration -count=10
```

Additionally, the benchmark test was updated to run with different numbers of iterators: 10, 100, 1000, 10000.

Running `benchstat old.txt new.txt` we got:

```sh
goos: darwin
goarch: arm64
pkg: github.com/spirit-labs/tektite/iteration
                                        │   old.txt    │               new.txt               │
                                        │    sec/op    │   sec/op     vs base                │
MergingIterator/MerginIterator-10-10       178.0µ ± 0%   148.4µ ± 0%  -16.65% (p=0.000 n=10)
MergingIterator/MerginIterator-100-10     1099.7µ ± 0%   310.4µ ± 1%  -71.78% (p=0.000 n=10)
MergingIterator/MerginIterator-1000-10    11.285m ± 0%   3.655m ± 0%  -67.61% (p=0.000 n=10)
MergingIterator/MerginIterator-10000-10    95.90m ± 1%   52.99m ± 0%  -44.74% (p=0.000 n=10)
geomean                                    3.815m        1.728m       -54.70%

                                        │   old.txt    │                new.txt                │
                                        │     B/op     │     B/op      vs base                 │
MergingIterator/MerginIterator-10-10        208.0 ± 0%     240.0 ± 0%   +15.38% (p=0.000 n=10)
MergingIterator/MerginIterator-100-10       304.0 ± 0%    1040.0 ± 0%  +242.11% (p=0.000 n=10)
MergingIterator/MerginIterator-1000-10    1.188Ki ± 0%   8.141Ki ± 0%  +585.53% (p=0.000 n=10)
MergingIterator/MerginIterator-10000-10   10.19Ki ± 0%   80.14Ki ± 0%  +686.66% (p=0.000 n=10)
geomean                                     946.4        3.530Ki       +281.97%

                                        │  old.txt   │               new.txt               │
                                        │ allocs/op  │ allocs/op   vs base                 │
MergingIterator/MerginIterator-10-10      2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
MergingIterator/MerginIterator-100-10     2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
MergingIterator/MerginIterator-1000-10    2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
MergingIterator/MerginIterator-10000-10   2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                   2.000        2.000       +0.00%
¹ all samples are equal
```

We can notice a significant reduction in execution time. Unfortunately, we have seen some increase in the bytes used by the operation. This is mainly because of the new array `heap int[]` of length `len(iters)+1`.  If we think this memory increase is a problem, we can use an array of `heap uint16[]`. This will limit a maximum of 65535 iterators that can be merged (probably a reasonable limit?). Using uint16 we get the following results:

```sh
goos: darwin
goarch: arm64
pkg: github.com/spirit-labs/tektite/iteration
                                        │   old.txt    │           new_uint16.txt            │
                                        │    sec/op    │   sec/op     vs base                │
MergingIterator/MerginIterator-10-10       178.0µ ± 0%   149.6µ ± 0%  -15.95% (p=0.000 n=10)
MergingIterator/MerginIterator-100-10     1099.7µ ± 0%   313.5µ ± 0%  -71.49% (p=0.000 n=10)
MergingIterator/MerginIterator-1000-10    11.285m ± 0%   3.630m ± 0%  -67.83% (p=0.000 n=10)
MergingIterator/MerginIterator-10000-10    95.90m ± 1%   53.39m ± 1%  -44.33% (p=0.000 n=10)
geomean                                    3.815m        1.737m       -54.48%

                                        │   old.txt    │            new_uint16.txt            │
                                        │     B/op     │     B/op      vs base                │
MergingIterator/MerginIterator-10-10        208.0 ± 0%     184.0 ± 0%  -11.54% (p=0.000 n=10)
MergingIterator/MerginIterator-100-10       304.0 ± 0%     368.0 ± 0%  +21.05% (p=0.000 n=10)
MergingIterator/MerginIterator-1000-10    1.188Ki ± 0%   2.156Ki ± 0%  +81.58% (p=0.000 n=10)
MergingIterator/MerginIterator-10000-10   10.19Ki ± 0%   20.16Ki ± 0%  +97.85% (p=0.000 n=10)
geomean                                     946.4        1.294Ki       +40.05%

                                        │  old.txt   │           new_uint16.txt            │
                                        │ allocs/op  │ allocs/op   vs base                 │
MergingIterator/MerginIterator-10-10      2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
MergingIterator/MerginIterator-100-10     2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
MergingIterator/MerginIterator-1000-10    2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
MergingIterator/MerginIterator-10000-10   2.000 ± 0%   2.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                   2.000        2.000       +0.00%
¹ all samples are equal
```