### PR TITLE
Implement SASL SCRAM authentication for the Kafka API

### DIFF
--- a/auth/sasl.go
+++ b/auth/sasl.go
@@ -1,0 +1,30 @@
+package auth
+
+type SaslAuthManager struct {
+}
+
+const (
+	SASL_SCRAM = "SASL_SCRAM"
+)
+
+func (s *SaslAuthManager) CreateConversation(mechanism string) (SaslConversation, bool) {
+	switch mechanism {
+	case SASL_SCRAM:
+		return &saslScramConversion{}, true
+	default:
+		return nil, false
+	}
+}
+
+type SaslConversation interface {
+	Process(request []byte) (response []byte, complete bool)
+	Principal() string
+}
+
+type saslScramConversion struct {
+}
+
+func (s *saslScramConversion) Process(request []byte) ([]byte, bool) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/kafkaserver/server.go
+++ b/kafkaserver/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	groupCoordinator    *GroupCoordinator
 	fetcher             *fetcher
 	listenCancel        context.CancelFunc
+	saslAuthManager     *auth.SaslAuthManager
 }
 
 type processorProvider interface {
@@ -165,12 +166,13 @@ func (s *Server) newConnection(conn net.Conn) *connection {
 }
 
 type connection struct {
-	s           *Server
-	conn        net.Conn
-	closeGroup  sync.WaitGroup
-	lock        sync.Mutex
-	closed      bool
-	authContext auth.Context
+	s                *Server
+	conn             net.Conn
+	closeGroup       sync.WaitGroup
+	lock             sync.Mutex
+	closed           bool
+	authContext      auth.Context
+	saslConversation auth.SaslConversation
 }
 
 func (c *connection) start() {


### PR DESCRIPTION
This PR implements SCRAM (256 and 512) authentication support for the Tektite Kafka API.

Please note that
* There is no way to add/update users yet (this will be on the HTTP API)
* The HTTP API is not secured yet

The above will follow in subsequent PRs.