### PR TITLE
update merging iterator benchmark with realistic number of iterators

### DIFF
--- a/iteration/merging_iter_bench_test.go
+++ b/iteration/merging_iter_bench_test.go
@@ -10,48 +10,52 @@ import (
 
 func BenchmarkMergingIterator(b *testing.B) {
 	numEntries := 1000
-	numIters := 10
-	iters := make([]Iterator, numIters)
-	for i := 0; i < numIters; i++ {
-		iters[i] = &StaticIterator{}
-	}
-	var expectedKeys [][]byte
-	var expectedVals [][]byte
-	for i := 0; i < numEntries; i++ {
-		skey := fmt.Sprintf("someprefix/key-%010d", i)
-		sval := fmt.Sprintf("someprefix/val-%010d", i)
-		expectedKeys = append(expectedKeys, []byte(skey))
-		expectedVals = append(expectedVals, []byte(sval))
-		r := rand.Intn(numIters)
-		sIter := iters[r].(*StaticIterator) //nolint:forcetypeassert
-		sIter.AddKVAsStringWithVersion(skey, sval, 0)
-	}
+	lengths := []int{2, 3, 4, 5}
 
-	for i := 0; i < b.N; i++ {
-
-		for j := 0; j < numIters; j++ {
-			iters[j].(*StaticIterator).pos = 0
+	for _, numIters := range lengths {
+		iters := make([]Iterator, numIters)
+		for i := 0; i < numIters; i++ {
+			iters[i] = &StaticIterator{}
+		}
+		var expectedKeys [][]byte
+		var expectedVals [][]byte
+		for i := 0; i < numEntries; i++ {
+			skey := fmt.Sprintf("someprefix/key-%010d", i)
+			sval := fmt.Sprintf("someprefix/val-%010d", i)
+			expectedKeys = append(expectedKeys, []byte(skey))
+			expectedVals = append(expectedVals, []byte(sval))
+			r := rand.Intn(numIters)
+			sIter := iters[r].(*StaticIterator) //nolint:forcetypeassert
+			sIter.AddKVAsStringWithVersion(skey, sval, 0)
 		}
 
-		mi, err := NewMergingIterator(iters, false, 0)
-		require.NoError(b, err)
+		b.Run(fmt.Sprintf("MerginIterator-%d", numIters), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < numIters; j++ {
+					iters[j].(*StaticIterator).pos = 0
+				}
 
-		for j := 0; j < numEntries; j++ {
-			valid, curr, err := mi.Next()
-			if err != nil {
-				panic(err)
+				mi, err := NewMergingIterator(iters, false, 0)
+				require.NoError(b, err)
+
+				for j := 0; j < numEntries; j++ {
+					valid, curr, err := mi.Next()
+					if err != nil {
+						panic(err)
+					}
+					if !valid {
+						panic("not valid")
+					}
+					expectedKey := expectedKeys[j]
+					expectedVal := expectedVals[j]
+					if !bytes.Equal(expectedKey, curr.Key[:len(curr.Key)-8]) {
+						panic("key not equal")
+					}
+					if !bytes.Equal(expectedVal, curr.Value) {
+						panic("key not equal")
+					}
+				}
 			}
-			if !valid {
-				panic("not valid")
-			}
-			expectedKey := expectedKeys[j]
-			expectedVal := expectedVals[j]
-			if !bytes.Equal(expectedKey, curr.Key[:len(curr.Key)-8]) {
-				panic("key not equal")
-			}
-			if !bytes.Equal(expectedVal, curr.Value) {
-				panic("key not equal")
-			}
-		}
+		})
 	}
 }


### PR DESCRIPTION
When creating queries or doing compaction, which uses merging iterators, we would have one iterator per level in the LSM. We'd have 1, 2, 3, 4 or maybe 5 iterators for a very large database.
reference: https://github.com/spirit-labs/tektite/pull/205#issuecomment-2282858969