### PR TITLE
feat: implement deletion of prepared query

### DIFF
--- a/asl/api/api_test.go
+++ b/asl/api/api_test.go
@@ -7,6 +7,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
 	"github.com/apache/arrow/go/v11/arrow/decimal128"
 	"github.com/spirit-labs/tektite/asl/conf"
 	"github.com/spirit-labs/tektite/asl/encoding"
@@ -22,12 +29,6 @@ import (
 	"github.com/spirit-labs/tektite/wasm"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
-	"io"
-	"net/http"
-	"os"
-	"strings"
-	"sync"
-	"testing"
 )
 
 const (
@@ -883,6 +884,12 @@ func (t *testQueryManager) getPrepareState() *parser.PrepareQueryDesc {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	return t.receiverPrepareQueryDesc
+}
+
+func (t *testQueryManager) DeleteQuery(deleteQuery parser.DeleteQueryDesc) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return nil
 }
 
 func (t *testQueryManager) PrepareQuery(prepareQuery parser.PrepareQueryDesc) error {

--- a/asl/api/server.go
+++ b/asl/api/server.go
@@ -348,8 +348,8 @@ func (s *HTTPAPIServer) handleStatement(writer http.ResponseWriter, request *htt
 		writeInvalidStatementError(err.Error(), writer)
 		return
 	}
-	if tsl.CreateStream == nil && tsl.DeleteStream == nil && tsl.PrepareQuery == nil {
-		writeError("invalid statement. must be create stream / delete stream / prepare query", writer, common.StatementError)
+	if tsl.CreateStream == nil && tsl.DeleteStream == nil && tsl.PrepareQuery == nil && tsl.DeleteQuery == nil {
+		writeError("invalid statement. must be create stream / delete stream / prepare query / delete query", writer, common.StatementError)
 		return
 	}
 	if err := s.commandManager.ExecuteCommand(com); err != nil {

--- a/asl/cli/cli_test.go
+++ b/asl/cli/cli_test.go
@@ -2,6 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
 	"github.com/apache/arrow/go/v11/arrow/decimal128"
 	"github.com/spirit-labs/tektite/asl/api"
 	"github.com/spirit-labs/tektite/asl/conf"
@@ -16,10 +21,6 @@ import (
 	"github.com/spirit-labs/tektite/types"
 	"github.com/spirit-labs/tektite/wasm"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"sync"
-	"sync/atomic"
-	"testing"
 )
 
 const (
@@ -429,6 +430,12 @@ func (t *testQueryManager) getPrepareState() ([]string, []types.ColumnType) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	return t.receivedParamNames, t.receivedParamTypes
+}
+
+func (t *testQueryManager) DeleteQuery(parser.DeleteQueryDesc) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return nil
 }
 
 func (t *testQueryManager) PrepareQuery(parser.PrepareQueryDesc) error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,6 +2,10 @@ package client
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
 	"github.com/apache/arrow/go/v11/arrow/decimal128"
 	"github.com/spirit-labs/tektite/asl/api"
 	"github.com/spirit-labs/tektite/asl/conf"
@@ -15,9 +19,6 @@ import (
 	"github.com/spirit-labs/tektite/types"
 	"github.com/spirit-labs/tektite/wasm"
 	"github.com/stretchr/testify/require"
-	"sync"
-	"sync/atomic"
-	"testing"
 )
 
 const (
@@ -497,6 +498,12 @@ func (t *testQueryManager) getExecState() (string, []any) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	return t.queryName, t.args
+}
+
+func (t *testQueryManager) DeleteQuery(parser.DeleteQueryDesc) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return nil
 }
 
 func (t *testQueryManager) PrepareQuery(parser.PrepareQueryDesc) error {

--- a/cmdmgr/mgr.go
+++ b/cmdmgr/mgr.go
@@ -230,6 +230,8 @@ func (m *manager) processCommands(batch *evbatch.Batch) (int64, error) {
 			}
 		} else if ast.PrepareQuery != nil {
 			err = m.queryManager.PrepareQuery(*ast.PrepareQuery)
+		} else if ast.DeleteQuery != nil {
+			err = m.queryManager.DeleteQuery(*ast.DeleteQuery)
 		} else {
 			panic("invalid command")
 		}

--- a/cmdmgr/mgr.go
+++ b/cmdmgr/mgr.go
@@ -355,6 +355,8 @@ func (m *manager) ExecuteCommand(command string) error {
 		}
 	} else if ast.PrepareQuery != nil {
 		err = m.queryManager.PrepareQuery(*ast.PrepareQuery)
+	} else if ast.DeleteQuery != nil {
+		err = m.queryManager.DeleteQuery(*ast.DeleteQuery)
 	} else {
 		panic("invalid command")
 	}

--- a/integration/command_mgr_test.go
+++ b/integration/command_mgr_test.go
@@ -195,6 +195,47 @@ func TestManagerDeployAndUndeployStreams(t *testing.T) {
 	}
 }
 
+func TestPreparedQueryDeletion(t *testing.T) {
+	fk := &fake.Kafka{}
+	_, err := fk.CreateTopic("test_topic", 16)
+	require.NoError(t, err)
+
+	servers, tearDown := startCluster(t, 3, fk)
+	defer tearDown(t)
+	mgrs := getManagers(servers)
+
+	mgr := mgrs[0]
+
+	command := `test_stream := 
+	(bridge from test_topic	partitions = 16) -> 
+    (project json_int("v0",val) as k0,json_float("v1",val) as k1,json_bool("v2",val) as k2,to_decimal(json_string("v3",val),14,3) as k3,
+			 json_string("v4",val) as k4,to_bytes(json_string("v5",val)) as k5,to_timestamp(json_int("v6",val)) as k6)->
+	(store table by k0,k1,k2,k3,k4,k5,k6)`
+	err = mgr.ExecuteCommand(command)
+	require.NoError(t, err)
+
+	tsl := "prepare test_query1 := (get $p1:int,$p2:float,$p3:bool,$p4:decimal(14,3),$p5:string,$p6:bytes,$p7:timestamp from test_stream)"
+	err = mgr.ExecuteCommand(tsl)
+	require.NoError(t, err)
+
+	tsl2 := "deletequery(test_query1)"
+	err = mgr.ExecuteCommand(tsl2)
+	require.NoError(t, err)
+
+	// Wait until commands are processed on all managers
+	for _, mgr := range mgrs {
+		m := mgr
+		testutils.WaitUntil(t, func() (bool, error) {
+			return m.LastProcessedCommandID() == 2, nil
+		})
+	}
+
+	for _, s := range servers {
+		paramSchema := s.GetQueryManager().GetPreparedQueryParamSchema("test_query1")
+		require.Nil(t, paramSchema)
+	}
+}
+
 func TestManagerPrepareQuery(t *testing.T) {
 	fk := &fake.Kafka{}
 	_, err := fk.CreateTopic("test_topic", 16)

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -2,12 +2,13 @@ package parser
 
 import (
 	"fmt"
-	"github.com/alecthomas/participle/v2/lexer"
-	"github.com/spirit-labs/tektite/common"
-	"github.com/spirit-labs/tektite/types"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/alecthomas/participle/v2/lexer"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/types"
 )
 
 type BaseDesc struct {
@@ -75,6 +76,7 @@ type TSLDesc struct {
 	PrepareQuery *PrepareQueryDesc
 	ListStreams  *ListStreamsDesc
 	ShowStream   *ShowStreamDesc
+	DeleteQuery  *DeleteQueryDesc
 }
 
 func (t *TSLDesc) parse(context *ParseContext) error {
@@ -110,6 +112,12 @@ func (t *TSLDesc) parse(context *ParseContext) error {
 			return err
 		}
 		t.ShowStream = showStream
+	case "deletequery":
+		deleteQuery := NewDeleteQueryDesc()
+		if err := deleteQuery.Parse(context); err != nil {
+			return err
+		}
+		t.DeleteQuery = deleteQuery
 	default:
 		createStreamDesc := NewCreateStreamDesc()
 		if err := createStreamDesc.Parse(context); err != nil {
@@ -391,6 +399,38 @@ func (d *DeleteStreamDesc) parse(context *ParseContext) error {
 		return foundUnexpectedTokenError("identifier", token, context.input)
 	}
 	d.StreamName = token.Value
+	_, err = context.expectToken(")")
+	return err
+}
+
+func NewDeleteQueryDesc() *DeleteQueryDesc {
+	super := &DeleteQueryDesc{}
+	super.BaseDesc.super = super
+	return super
+}
+
+type DeleteQueryDesc struct {
+	BaseDesc
+	QueryName string
+}
+
+func (d *DeleteQueryDesc) parse(context *ParseContext) error {
+	_, err := context.expectToken("deletequery")
+	if err != nil {
+		return err
+	}
+	_, err = context.expectToken("(")
+	if err != nil {
+		return err
+	}
+	token, err := context.expectToken()
+	if err != nil {
+		return err
+	}
+	if token.Type != IdentTokenType {
+		return foundUnexpectedTokenError("identifier", token, context.input)
+	}
+	d.QueryName = token.Value
 	_, err = context.expectToken(")")
 	return err
 }

--- a/parser/ast_test.go
+++ b/parser/ast_test.go
@@ -2861,3 +2861,53 @@ func TestFailedToParseTSL(t *testing.T) {
 	expectedMsg = `reached end of statement`
 	testFailedToParseTSL(t, input, expectedMsg)
 }
+
+func testParseDeleteQuery(t *testing.T, input string, expected DeleteQueryDesc) {
+	cs := NewDeleteQueryDesc()
+	err := NewParser(nil).Parse(input, cs)
+	require.NoError(t, err)
+	cs.clearTokenState()
+	require.Equal(t, &expected, cs)
+}
+
+func testFailedToParseDeleteQuery(t *testing.T, input string, expectedMsg string) {
+	cs := NewDeleteQueryDesc()
+	err := NewParser(nil).Parse(input, cs)
+	require.Error(t, err)
+	require.True(t, common.IsTektiteErrorWithCode(err, common.ParseError))
+	require.Equal(t, expectedMsg, err.Error())
+}
+
+func TestParseDeleteQuery(t *testing.T) {
+	input := "deletequery(my_query)"
+	expected := DeleteQueryDesc{
+		QueryName: "my_query",
+	}
+	testParseDeleteQuery(t, input, expected)
+}
+
+func TestFailedToParseDeleteQuery(t *testing.T) {
+	input := "deletequery"
+	expectedMsg := "reached end of statement"
+	testFailedToParseDeleteQuery(t, input, expectedMsg)
+
+	input = "deletequery("
+	expectedMsg = "reached end of statement"
+	testFailedToParseDeleteQuery(t, input, expectedMsg)
+
+	input = "deletequery()"
+	expectedMsg = `expected identifier but found ')' (line 1 column 13):
+deletequery()
+            ^`
+	testFailedToParseDeleteQuery(t, input, expectedMsg)
+
+	input = "deletequery(my_query"
+	expectedMsg = `reached end of statement`
+	testFailedToParseDeleteQuery(t, input, expectedMsg)
+
+	input = `deletequery("my_query")`
+	expectedMsg = `expected identifier but found '"my_query"' (line 1 column 13):
+deletequery("my_query")
+            ^`
+	   testFailedToParseDeleteQuery(t, input, expectedMsg)
+}

--- a/query/mgr.go
+++ b/query/mgr.go
@@ -39,6 +39,7 @@ type Manager interface {
 	Activate()
 	Start() error
 	Stop() error
+	DeleteQuery(deleteQuery parser.DeleteQueryDesc) error
 }
 
 type iteratorProvider interface {
@@ -205,6 +206,17 @@ func (m *manager) GetPreparedQueryParamSchema(preparedQueryName string) *evbatch
 		return nil
 	}
 	return pqi.ParamSchema
+}
+
+func (m *manager) DeleteQuery(deleteQuery parser.DeleteQueryDesc) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	_, exists := m.preparedQueries[deleteQuery.QueryName]
+	if !exists {
+		return common.NewQueryErrorf("query with name '%s' can't be deleted as it doesn't exist", deleteQuery.QueryName)
+	}
+	delete(m.preparedQueries, deleteQuery.QueryName)
+	return nil
 }
 
 func (m *manager) PrepareQuery(prepareQuery parser.PrepareQueryDesc) error {

--- a/query/mgr_test.go
+++ b/query/mgr_test.go
@@ -1151,6 +1151,8 @@ func deleteQuery(t *testing.T, query string, ctx *mgrCtx) {
 	for _, pair := range ctx.qms {
 		err = pair.qm.DeleteQuery(*ast.DeleteQuery)
 		require.NoError(t, err)
+		paramSchema := pair.qm.GetPreparedQueryParamSchema(ast.DeleteQuery.QueryName)
+		require.Nil(t, paramSchema)
 	}
 }
 

--- a/query/mgr_test.go
+++ b/query/mgr_test.go
@@ -36,6 +36,20 @@ const (
 	defaultSlabID        = 10
 )
 
+func TestGetPreparedQueryDeletion(t *testing.T) {
+	keyCols := []int{0, 1, 2}
+	columnNames := []string{"offset", "f1", "f2"}
+	columnTypes := []types.ColumnType{types.ColumnTypeInt, types.ColumnTypeString, types.ColumnTypeFloat}
+	schema := evbatch.NewEventSchema(columnNames, columnTypes)
+	slInfoProvider, _ := createStreamInfoProvider("test_slab1", defaultSlabID, schema, defaultNumPartitions, keyCols)
+	ctx := setupQueryManagers(1, defaultNumPartitions, defaultMaxBatchRows, slInfoProvider)
+	defer ctx.tearDown(t)
+	tsl := `prepare test_query1 := (scan $p1:int,$p2:string,$p3:float to end from test_slab1)`
+	prepareQuery(t, tsl, ctx)
+	tsl2 := `deletequery(test_query1)`
+	deleteQuery(t, tsl2, ctx)
+}
+
 func TestGetPreparedQueryParamMeta(t *testing.T) {
 	keyCols := []int{0, 1, 2}
 	columnNames := []string{"offset", "f1", "f2"}
@@ -1128,6 +1142,15 @@ func setupQueryManagersWithClusterVersionProvider(numMgrs int, numPartitions int
 		qms:  pairs,
 		st:   procMgr.GetStore(),
 		tnpp: npp,
+	}
+}
+
+func deleteQuery(t *testing.T, query string, ctx *mgrCtx) {
+	ast, err := parser.NewParser(nil).ParseTSL(query)
+	require.NoError(t, err)
+	for _, pair := range ctx.qms {
+		err = pair.qm.DeleteQuery(*ast.DeleteQuery)
+		require.NoError(t, err)
 	}
 }
 


### PR DESCRIPTION
- fixes #4 
- Discussion thread: https://github.com/spirit-labs/tektite/discussions/226

- Local testing
  - Created a prepared query `my_query`
![image](https://github.com/user-attachments/assets/4e6565a5-b9ba-4957-a648-2e9bed265aeb)
  - Tried deleting prepared query `my-query` (hypen instead of underscore). As expected this threw an error.
  - However, prepared query `my_query` was successfully deleted. 
![image](https://github.com/user-attachments/assets/7c2c268b-34e4-4e87-9347-c81e9f7f27c0)

  
- Screenshots of all 3 terminals used for local testing:
  - terminal-1
![image](https://github.com/user-attachments/assets/8e202e96-f91d-47fd-81f7-1771c54b946a)
 
  - terminal-2
![image](https://github.com/user-attachments/assets/8fb5c3af-f63b-4381-babd-c445f01f081e)

  - terminal-3    
![image](https://github.com/user-attachments/assets/a1361916-58d7-4f82-a66f-5ff3b4ae8210)
