### PR TITLE
fix: cancel previous github action if new commits are pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "main"]
   pull_request:
     branches: [ "main" ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It isn't uncommon for Pull Request to be updated before CI/CD is finished for the previous version. So, we can cancel all old GitHub Actions runs that are stale after a new version of the Pull Request was uploaded.

Reference: https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions