### PR TITLE
Implement cluster group membership

### DIFF
--- a/cluster/membership.go
+++ b/cluster/membership.go
@@ -1,0 +1,138 @@
+package cluster
+
+import (
+	"github.com/pkg/errors"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/objstore"
+	"sync"
+	"time"
+)
+
+type Membership struct {
+	updateInterval       time.Duration
+	evictionInterval     time.Duration
+	updateTimer          *time.Timer
+	lock                 sync.Mutex
+	started              bool
+	stateMachine         *StateMachine[MembershipState]
+	address              string
+	leader               bool
+	becomeLeaderCallback func()
+}
+
+func NewMembership(bucket string, keyPrefix string, address string, objStoreClient objstore.Client, updateInterval time.Duration,
+	evictionInterval time.Duration, becomeLeaderCallback func()) *Membership {
+	return &Membership{
+		address:              address,
+		stateMachine:         NewStateMachine[MembershipState](bucket, keyPrefix, objStoreClient, StateMachineOpts{}),
+		updateInterval:       updateInterval,
+		evictionInterval:     evictionInterval,
+		becomeLeaderCallback: becomeLeaderCallback,
+	}
+}
+
+func (m *Membership) Start() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.started {
+		return
+	}
+	m.stateMachine.Start()
+	m.scheduleTimer()
+	m.started = true
+}
+
+func (m *Membership) Stop() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if !m.started {
+		return
+	}
+	m.started = false
+	m.updateTimer.Stop()
+	m.stateMachine.Stop()
+}
+
+func (m *Membership) scheduleTimer() {
+	m.updateTimer = time.AfterFunc(m.updateInterval, m.updateOnTimer)
+}
+
+func (m *Membership) updateOnTimer() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if !m.started {
+		return
+	}
+	if err := m.update(); err != nil {
+		log.Errorf("failed to update membership: %v", err)
+	}
+	m.scheduleTimer()
+}
+
+func (m *Membership) update() error {
+	newState, err := m.stateMachine.Update(m.updateState)
+	if err != nil {
+		return err
+	}
+	if newState.Members[0].Address == m.address {
+		if !m.leader {
+			m.becomeLeaderCallback()
+		}
+		m.leader = true
+	}
+	return nil
+}
+
+func (m *Membership) updateState(memberShipState MembershipState) (MembershipState, error) {
+	now := time.Now().UnixMilli()
+	found := false
+	var newMembers []MembershipEntry
+	changed := false
+	for _, member := range memberShipState.Members {
+		if member.Address == m.address {
+			// When we update we preserve position in the slice
+			member.UpdateTime = now
+			found = true
+		} else {
+			if now-member.UpdateTime >= m.evictionInterval.Milliseconds() {
+				// member evicted
+				changed = true
+				continue
+			}
+		}
+		newMembers = append(newMembers, member)
+	}
+	if !found {
+		// Add the new member on the end
+		newMembers = append(newMembers, MembershipEntry{
+			Address:    m.address,
+			UpdateTime: now,
+		})
+		changed = true
+	}
+	memberShipState.Members = newMembers
+	if changed {
+		// NewmMember joined or member(s) where evicted, so we change the epoch
+		memberShipState.Epoch++
+	}
+	return memberShipState, nil
+}
+
+type MembershipState struct {
+	Epoch   int               // Epoch changes every time member joins or leaves the group
+	Members []MembershipEntry // The members of the group, we define the first member to be the leader
+}
+
+type MembershipEntry struct {
+	Address    string // Address of the member
+	UpdateTime int64  // Time the member last updated itself, in Unix millis
+}
+
+func (m *Membership) GetState() (MembershipState, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if !m.started {
+		return MembershipState{}, errors.New("not started")
+	}
+	return m.stateMachine.GetState()
+}

--- a/cluster/membership_test.go
+++ b/cluster/membership_test.go
@@ -1,0 +1,200 @@
+package cluster
+
+import (
+	"fmt"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/objstore/dev"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestJoinSequential(t *testing.T) {
+	t.Parallel()
+	objStore := dev.NewInMemStore(0)
+	var memberships []*Membership
+	defer func() {
+		for _, membership := range memberships {
+			membership.Stop()
+		}
+	}()
+	numMembers := 10
+	var becomeLeaderCalledCount atomic.Int64
+	for i := 0; i < numMembers; i++ {
+		address := fmt.Sprintf("address-%d", i)
+		memberIndex := i
+		membership := NewMembership("bucket1", "prefix1", address, objStore, 100*time.Millisecond, 5*time.Second, func() {
+			if memberIndex != 0 {
+				panic("becomeLeader callback called for wrong member")
+			}
+			becomeLeaderCalledCount.Add(1)
+		})
+		membership.Start()
+		memberships = append(memberships, membership)
+		waitForMembers(t, memberships...)
+		state, err := membership.GetState()
+		require.NoError(t, err)
+		require.Equal(t, i+1, state.Epoch)
+	}
+	require.Equal(t, 1, int(becomeLeaderCalledCount.Load()))
+	for _, membership := range memberships {
+		state, err := membership.GetState()
+		require.NoError(t, err)
+		log.Infof("epoch is %d", state.Epoch)
+		require.Equal(t, numMembers, state.Epoch)
+		require.Equal(t, numMembers, len(state.Members))
+		// should be in order of joining
+		for i, membership2 := range memberships {
+			require.Equal(t, membership2.address, state.Members[i].Address)
+		}
+	}
+}
+
+func TestJoinParallel(t *testing.T) {
+	t.Parallel()
+	objStore := dev.NewInMemStore(0)
+	var memberships []*Membership
+	defer func() {
+		for _, membership := range memberships {
+			membership.Stop()
+		}
+	}()
+	numMembers := 10
+	for i := 0; i < numMembers; i++ {
+		address := fmt.Sprintf("address-%d", i)
+		memberShip := NewMembership("bucket1", "prefix1", address, objStore, 100*time.Millisecond, 5*time.Second, func() {
+		})
+		memberShip.Start()
+		// Randomise join time a little
+		time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+		memberships = append(memberships, memberShip)
+	}
+	// Wait for all members to join
+	waitForMembers(t, memberships...)
+	for _, membership := range memberships {
+		state, err := membership.GetState()
+		require.NoError(t, err)
+		log.Infof("epoch is %d", state.Epoch)
+		require.Equal(t, numMembers, state.Epoch)
+	}
+}
+
+func TestNonLeadersEvicted(t *testing.T) {
+	t.Parallel()
+	objStore := dev.NewInMemStore(0)
+	var memberships []*Membership
+	defer func() {
+		for _, membership := range memberships {
+			membership.Stop()
+		}
+	}()
+	numMembers := 5
+	for i := 0; i < numMembers; i++ {
+		address := fmt.Sprintf("address-%d", i)
+		memberShip := NewMembership("bucket1", "prefix1", address, objStore, 100*time.Millisecond, 1*time.Second, func() {
+		})
+		memberShip.Start()
+		memberships = append(memberships, memberShip)
+	}
+	waitForMembers(t, memberships...)
+	leaderAddress := memberships[0].address
+	for i := 0; i < numMembers-1; i++ {
+		// choose a member at random - but not the leader
+		index := 1 + rand.Intn(len(memberships)-1)
+		// stop it
+		memberships[index].Stop()
+		memberships = append(memberships[:index], memberships[index+1:]...)
+		// wait to be evicted
+		waitForMembers(t, memberships...)
+		for _, membership := range memberships {
+			state, err := membership.GetState()
+			require.NoError(t, err)
+			require.Equal(t, numMembers+i+1, state.Epoch)
+		}
+	}
+	finalState, err := memberships[0].GetState()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(finalState.Members))
+	require.Equal(t, leaderAddress, finalState.Members[0].Address)
+}
+
+func TestLeaderEvicted(t *testing.T) {
+	t.Parallel()
+	objStore := dev.NewInMemStore(0)
+	var memberships []*Membership
+	defer func() {
+		for _, membership := range memberships {
+			membership.Stop()
+		}
+	}()
+	numMembers := 5
+	leaderCallbackCalledCounts := make([]int64, numMembers)
+	for i := 0; i < numMembers; i++ {
+		address := fmt.Sprintf("address-%d", i)
+		memberIndex := i
+		memberShip := NewMembership("bucket1", "prefix1", address, objStore, 100*time.Millisecond, 1*time.Second, func() {
+			newVal := atomic.AddInt64(&leaderCallbackCalledCounts[memberIndex], 1)
+			if newVal != 1 {
+				panic("leader callback called too many times")
+			}
+		})
+		memberShip.Start()
+		memberships = append(memberships, memberShip)
+		waitForMembers(t, memberships...)
+	}
+	waitForMembers(t, memberships...)
+	require.Equal(t, 1, int(atomic.LoadInt64(&leaderCallbackCalledCounts[0])))
+	for i := 1; i < numMembers; i++ {
+		require.Equal(t, 0, int(atomic.LoadInt64(&leaderCallbackCalledCounts[i])))
+	}
+	for i := 0; i < numMembers-1; i++ {
+		expectedNewLeader := memberships[1].address
+		// stop current leader
+		memberships[0].Stop()
+		memberships = memberships[1:]
+		// wait for leader to be evicted
+		waitForMembers(t, memberships...)
+		require.Equal(t, expectedNewLeader, memberships[0].address)
+		for _, membership := range memberships {
+			state, err := membership.GetState()
+			require.NoError(t, err)
+			require.Equal(t, numMembers+i+1, state.Epoch)
+		}
+	}
+	for i := 0; i < numMembers; i++ {
+		require.Equal(t, 1, int(atomic.LoadInt64(&leaderCallbackCalledCounts[i])))
+	}
+}
+
+func waitForMembers(t *testing.T, memberships ...*Membership) {
+	allAddresses := map[string]struct{}{}
+	for _, membership := range memberships {
+		allAddresses[membership.address] = struct{}{}
+	}
+	start := time.Now()
+	for {
+		ok := true
+		for _, membership := range memberships {
+			state, err := membership.GetState()
+			require.NoError(t, err)
+			if len(state.Members) == len(memberships) {
+				for _, member := range state.Members {
+					_, exists := allAddresses[member.Address]
+					require.True(t, exists)
+				}
+			} else {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			break
+		}
+		if time.Now().Sub(start) > 5*time.Second {
+			require.Fail(t, "timed out waiting for memberships")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/kafkaserver/server_test.go
+++ b/kafkaserver/server_test.go
@@ -148,7 +148,9 @@ func createServer(t *testing.T, topic string, serverAddress string, serverAdvert
 
 	gc, err := NewGroupCoordinator(cfg, procProvider, &testStreamMgr{}, meta, &testBatchForwarder{})
 	require.NoError(t, err)
-	server, err := NewServer(cfg, meta, procProvider, gc, &testStreamMgr{}, nil, sequence.NewSequenceManager(dev.NewInMemStore(0), "sequences_obj", lock.NewInMemLockManager(), 1*time.Millisecond))
+	server, err := NewServer(cfg, meta, procProvider, gc, &testStreamMgr{}, nil,
+		sequence.NewSequenceManager(dev.NewInMemStore(0),
+			"sequences_obj", lock.NewInMemLockManager(), 1*time.Millisecond, cfg.BucketName))
 	require.NoError(t, err)
 	err = server.Activate()
 	require.NoError(t, err)


### PR DESCRIPTION
Implements group membership on top of the new distributed state machine. Nodes update their membership periodically by updating an entry for themselves in the shared state along with an updated time. When nodes update they also check the updated time for other nodes, and if the entry is stale the other node's entry is removed. Every time the membership of the group changes, the epoch (an int) is incremented.
This struct is used when all the nodes in a cluster need to agree on which nodes are in the cluster for any particular epoch and which node is the leader.
The PR is based upon the https://github.com/spirit-labs/tektite/pull/241 so you'll see the commit for that one here. I can't set base to be the branch for the other PR or the PR will disappear from this repo, and only appear on my fork. But you can choose to only show changes for this commit when viewing the PR