### PR TITLE
Extract and simplify level manager into LSM manager

### DIFF
--- a/lsm/client.go
+++ b/lsm/client.go
@@ -1,0 +1,37 @@
+package lsm
+
+import (
+	"time"
+)
+
+type Client interface {
+	QueryTablesInRange(keyStart []byte, keyEnd []byte) (OverlappingTables, error)
+
+	RegisterL0Tables(registrationBatch RegistrationBatch) error
+
+	ApplyChanges(registrationBatch RegistrationBatch) error
+
+	PollForJob() (*CompactionJob, error)
+
+	RegisterDeadVersionRange(versionRange VersionRange, clusterName string, clusterVersion int) error
+
+	StoreLastFlushedVersion(version int64) error
+
+	LoadLastFlushedVersion() (int64, error)
+
+	GetStats() (Stats, error)
+
+	RegisterSlabRetention(slabID int, retention time.Duration) error
+
+	UnregisterSlabRetention(slabID int) error
+
+	GetSlabRetention(slabID int) (time.Duration, error)
+
+	Start() error
+
+	Stop() error
+}
+
+type ClientFactory interface {
+	CreateLevelManagerClient() Client
+}

--- a/lsm/compaction.go
+++ b/lsm/compaction.go
@@ -1,0 +1,852 @@
+package lsm
+
+import (
+	"bytes"
+	"container/heap"
+	"encoding/binary"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/asl/arista"
+	"github.com/spirit-labs/tektite/asl/encoding"
+	"github.com/spirit-labs/tektite/common"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/sst"
+	"math"
+	"strings"
+	"time"
+)
+
+type compactionState struct {
+	tableDeleteTimer   *time.Timer
+	tablesToDelete     []deleteTableEntry
+	jobQueue           []jobHolder
+	inProgress         map[string]inProgressCompaction
+	pendingCompactions map[int]int
+	lockedRanges       map[int][]lockedRange
+	pollers            *pollerQueue
+	stats              CompactionStats
+}
+
+func newCompactionState() compactionState {
+	return compactionState{
+		inProgress:         make(map[string]inProgressCompaction),
+		pendingCompactions: map[int]int{},
+		lockedRanges:       map[int][]lockedRange{},
+		pollers:            &pollerQueue{},
+	}
+}
+
+type jobHolder struct {
+	job            CompactionJob
+	completionFunc func(error)
+}
+
+type lockedRange struct {
+	level int
+	start []byte
+	end   []byte
+}
+
+func (lr *lockedRange) overlaps(rng *lockedRange) bool {
+	dontOverlapRight := bytes.Compare(rng.start, lr.end) > 0
+	dontOverlapLeft := bytes.Compare(rng.end, lr.start) < 0
+	dontOverlap := dontOverlapLeft || dontOverlapRight
+	return !dontOverlap
+}
+
+func (lm *Manager) maybeScheduleCompaction() error {
+	// Get a level to compact (if any)
+	level, numTables := lm.chooseLevelToCompact()
+	if level == -1 {
+		if log.DebugEnabled {
+			lm.dumpLevelInfo()
+		}
+		// nothing to do
+		return nil
+	}
+	tables, err := lm.chooseTablesToCompact(level, numTables)
+	if err != nil {
+		return err
+	}
+	log.Debugf("in maybeScheduleCompaction - chose level %d num tables to compact: %d", level, len(tables))
+	if len(tables) == 0 {
+		return nil
+	}
+	_, _, err = lm.scheduleCompaction(level, tables, nil)
+	return err
+}
+
+func (lm *Manager) getAllL0Tables() ([][]*TableEntry, error) {
+	entry := lm.getLevelEntry(0)
+	tableEntries := make([]*TableEntry, len(entry.tableEntries))
+	for i, lte := range entry.tableEntries {
+		tableEntries[i] = lte.Get(entry)
+	}
+	return [][]*TableEntry{tableEntries}, nil
+}
+
+func (lm *Manager) scheduleCompaction(level int, tableSlices [][]*TableEntry, completionFunc func(error)) (int, bool, error) {
+	// If we are compacting into the last level, then we delete tombstones
+	var jobs []CompactionJob
+	destLevelEntries := lm.getLevelEntry(level + 1)
+	destLevelExists := len(destLevelEntries.tableEntries) > 0
+	hasLocked := false
+	now := uint64(time.Now().UTC().UnixMilli())
+	lfv := lm.masterRecord.lastFlushedVersion
+outer:
+	for _, tables := range tableSlices {
+		// We compact each inner slice in its own job
+		var tablesToCompact [][]tableToCompact
+		// Calculate overall range of source tables
+		sourceRangeStart, sourceRangeEnd := lm.calculateOverallRange(tables)
+		sourceRange := lockedRange{
+			level: level,
+			start: sourceRangeStart,
+			end:   sourceRangeEnd,
+		}
+		// First check if this range is already locked
+		if lm.isRangeLocked(sourceRange) {
+			// there's already a job that includes this range - we can't compact this slice
+			hasLocked = true
+			continue outer
+		}
+		// find overlap with tables in next level
+		var overlapping []*TableEntry
+		if destLevelExists {
+			// note: rangeEnd param to getOverlappingTables is exclusive, so we need to increment
+			rangeEnd := common.IncBigEndianBytes(sourceRangeEnd)
+			var err error
+			overlapping, err = lm.getOverlappingTables(sourceRangeStart, rangeEnd, level+1, destLevelEntries)
+			if err != nil {
+				return 0, false, err
+			}
+		}
+		// calculate maximum possible overall range of results of compaction
+		destRangeStart := sourceRangeStart
+		destRangeEnd := sourceRangeEnd
+		if len(overlapping) > 0 {
+			destRangeStart, destRangeEnd = lm.calculateOverallRange(append(tables, overlapping...))
+		}
+		destRange := lockedRange{
+			level: level + 1,
+			start: destRangeStart,
+			end:   destRangeEnd,
+		}
+		// Now check if overall result range is already locked in destination level - note that we lock ranges instead
+		// of locking destination tables, as when compacting into an empty level we still need to lock the destination
+		// range to prevent more than once concurrent compaction compacting into the same destination range
+		if lm.isRangeLocked(destRange) {
+			// there's already a job that includes this table - we can't compact this slice
+			hasLocked = true
+			continue outer
+		}
+		hasDeadVersionRanges := false
+		canCompact := true
+		// create the job
+		var tableIDs []sst.SSTableID
+		// Note that tables in a slice must be added in order from newest to earliest - this is critical as the exact same key
+		// can be in different tables, and when a compaction merging iterator is created and finds same keys it will
+		// take the leftmost one - this must be the latest one!
+		hasPotentialExpiredEntries := false
+		hasDeletes := false
+		for i := len(tables) - 1; i >= 0; i-- {
+			st := tables[i].copy()
+			tablesToCompact = append(tablesToCompact, []tableToCompact{{
+				level: level,
+				table: st,
+			}})
+			tableIDs = append(tableIDs, st.SSTableID)
+			if !hasPotentialExpiredEntries {
+				hasPotentialExpiredEntries = lm.hasPotentialExpiredEntries(st, now)
+			}
+			if !hasDeletes {
+				hasDeletes = st.DeleteRatio > 0
+			}
+			if int64(st.MaxVersion) > lfv {
+				// can't remove tombstones if there are any entries with version that's not flushed yet, otherwise
+				// when compacting into last level could end up not removing key as non compactable but removing
+				// tombstone as preserveTombstones = false as last level, thus ending up with data not getting deleted
+				canCompact = false
+			}
+			if len(st.DeadVersionRanges) > 0 {
+				hasDeadVersionRanges = true
+			}
+		}
+		if len(overlapping) > 0 {
+			var nextLevelTables []tableToCompact
+			for _, st := range overlapping {
+				nextLevelTables = append(nextLevelTables, tableToCompact{
+					level: level + 1,
+					table: st.copy(),
+				})
+				if int64(st.MaxVersion) > lfv {
+					canCompact = false
+				}
+				if len(st.DeadVersionRanges) > 0 {
+					hasDeadVersionRanges = true
+				}
+			}
+			tablesToCompact = append(tablesToCompact, nextLevelTables)
+		}
+		// We move tables directly if all the following are true:
+		// 1. There's only a single source table in the job (otherwise there could be overlap between source tables)
+		// 2. There are definitely no expired entries that would need removing
+		// 3. There are no dead version ranges to remove
+		// 4. There is no overlap with tables in the next level
+		// 5. We're not moving to the last level or there are no deletes in the table (we want to remove deletes on the last
+		// level, so we can't move in that case)
+		move := len(tables) == 1 && !hasPotentialExpiredEntries && !hasDeadVersionRanges && len(overlapping) == 0 &&
+			(level+1 != lm.getLastLevel() || !hasDeletes)
+		id := uuid.New().String()
+		destLevel := level + 1
+		// We preserve tombstones if we're not compacting into the last level or there are entries in any table
+		// in the compaction with a non compactable version (> last flushed version)
+		preserveTombstones := !canCompact || lm.getLastLevel() > destLevel
+		job := CompactionJob{
+			id:                 id,
+			levelFrom:          level,
+			tables:             tablesToCompact,
+			isMove:             move,
+			preserveTombstones: preserveTombstones,
+			scheduleTime:       arista.NanoTime(),
+			serverTime:         uint64(time.Now().UTC().UnixMilli()),
+			lastFlushedVersion: lm.masterRecord.lastFlushedVersion,
+			sourceRange:        sourceRange,
+			destRange:          destRange,
+		}
+		log.Debugf("created compaction job %s from level %d last level is %d, preserve tombstones is %t",
+			id, level, lm.getLastLevel(), preserveTombstones)
+		jobs = append(jobs, job)
+		lm.lockTablesForJob(job)
+	}
+	var complFunc func(error)
+	if completionFunc != nil {
+		complFunc = common.NewCountDownFuture(len(jobs), completionFunc).CountDown
+	}
+	for _, job := range jobs {
+		if log.DebugEnabled {
+			sb := strings.Builder{}
+			for _, no := range job.tables {
+				for _, ttc := range no {
+					sb.WriteString(fmt.Sprintf("level:%d table:%v, ", ttc.level, ttc.table.SSTableID))
+				}
+			}
+			log.Debugf("compaction created job %s %s", job.id, sb.String())
+		}
+		lm.queueOrDespatchJob(job, complFunc)
+	}
+	// return number of jobs, whether any tables were locked
+	return len(jobs), hasLocked, nil
+}
+
+func (lm *Manager) isRangeLocked(rng lockedRange) bool {
+	rngs, ok := lm.lockedRanges[rng.level]
+	if !ok {
+		return false
+	}
+	for _, r := range rngs {
+		if r.overlaps(&rng) {
+			return true
+		}
+	}
+	return false
+}
+
+func (lm *Manager) hasPotentialExpiredEntries(te *TableEntry, now uint64) bool {
+	if len(lm.masterRecord.slabRetentions) == 0 {
+		return false
+	}
+	// If all the entries in the table are for the same partition hash then we can directly look at the slab id
+	// to see if entries are expired
+	partitionHash1 := te.RangeStart[:16]
+	partitionHash2 := te.RangeEnd[:16]
+	same := bytes.Equal(partitionHash1, partitionHash2)
+	if !same {
+		// Might not have expired entries but we err on the side of caution and return true, which will prevent a move
+		return true
+	}
+	slabID1 := binary.BigEndian.Uint64(te.RangeStart[16:])
+	slabID2 := binary.BigEndian.Uint64(te.RangeEnd[16:])
+	for slabID, ret := range lm.masterRecord.slabRetentions {
+		retMillis := uint64(time.Duration(ret).Milliseconds())
+		if slabID >= slabID1 && slabID <= slabID2 {
+			age := now - te.AddedTime
+			if age >= retMillis {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (lm *Manager) queueOrDespatchJob(job CompactionJob, complFunc func(error)) {
+	if lm.pollers.Len() > 0 {
+		// We have a waiting poller - hand the job to the poller straightaway
+		holder := jobHolder{
+			job:            job,
+			completionFunc: complFunc,
+		}
+		lm.stats.InProgressJobs++
+		poller := lm.pollers.pop()
+		poller.timer.Stop()
+		poller.timer = nil
+		timer := lm.scheduleJobTimeout(holder, poller.connectionID)
+		lm.inProgress[job.id] = inProgressCompaction{
+			timer:        timer,
+			jobHolder:    holder,
+			connectionID: poller.connectionID,
+		}
+		theJob := job
+		poller.completionFunc(&theJob, nil)
+	} else {
+		// append the job to the job queue
+		lm.jobQueue = append(lm.jobQueue, jobHolder{
+			job:            job,
+			completionFunc: complFunc,
+		})
+		lm.stats.QueuedJobs++
+	}
+	lm.pendingCompactions[job.levelFrom]++
+}
+
+func (lm *Manager) lockTablesForJob(job CompactionJob) {
+	lm.lockRange(job.sourceRange)
+	lm.lockRange(job.destRange)
+}
+
+func (lm *Manager) unlockTablesForJob(job CompactionJob) {
+	lm.unlockRange(job.sourceRange)
+	lm.unlockRange(job.destRange)
+}
+
+func (lm *Manager) LockRange(rng lockedRange) {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	lm.lockRange(rng)
+}
+
+func (lm *Manager) lockRange(rng lockedRange) {
+	lm.lockedRanges[rng.level] = append(lm.lockedRanges[rng.level], rng)
+}
+
+func (lm *Manager) UnlockRange(rng lockedRange) {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	lm.unlockRange(rng)
+}
+
+func (lm *Manager) unlockRange(r lockedRange) {
+	levelRanges, ok := lm.lockedRanges[r.level]
+	if ok {
+		var newRanges []lockedRange
+		found := false
+		for _, rng := range levelRanges {
+			if !(bytes.Equal(r.start, rng.start) && bytes.Equal(r.end, rng.end)) {
+				newRanges = append(newRanges, rng)
+			} else {
+				found = true
+			}
+		}
+		if found {
+			lm.lockedRanges[r.level] = newRanges
+			return
+		}
+	}
+	panic(fmt.Sprintf("failed to unlock range %v - not found", r))
+}
+
+func (lm *Manager) calculateOverallRange(tables []*TableEntry) ([]byte, []byte) {
+	first := true
+	var rangeStart, rangeEnd []byte
+	for _, table := range tables {
+		if first {
+			rangeStart = table.RangeStart
+			rangeEnd = table.RangeEnd
+			first = false
+		} else {
+			if bytes.Compare(rangeStart, table.RangeStart) > 0 {
+				rangeStart = table.RangeStart
+			}
+			if bytes.Compare(table.RangeEnd, rangeEnd) > 0 {
+				rangeEnd = table.RangeEnd
+			}
+		}
+	}
+	// it's critical we calculate the overlap to exclude versions, so we make
+	// sure we capture overlapping keys of any version
+	return rangeStart[:len(rangeStart)-8], rangeEnd[:len(rangeEnd)-8]
+}
+
+func (lm *Manager) chooseLevelToCompact() (int, int) {
+	// We choose a level to compact based on ratio of number of tables / max tables trigger
+	toCompact := -1
+	var maxRatio float64
+	var numTables int
+	for level := range lm.masterRecord.levelTableCounts {
+		trigger := lm.levelMaxTablesTrigger(level)
+		tableCount := lm.tableCount(level)
+		// we take any already scheduled compactions for the level into account
+		pending := lm.pendingCompactions[level]
+		availableTables := tableCount - pending
+		if availableTables > trigger {
+			ratio := float64(availableTables) / float64(trigger)
+			if ratio > maxRatio {
+				maxRatio = ratio
+				toCompact = level
+				numTables = availableTables - trigger
+			}
+		}
+	}
+	return toCompact, numTables
+}
+
+func (lm *Manager) tableCount(level int) int {
+	return lm.masterRecord.levelTableCounts[level]
+}
+
+func (lm *Manager) chooseTablesToCompact(level int, maxTables int) ([][]*TableEntry, error) {
+	if level == 0 {
+		// We compact the whole level -this is done as a single job, as there can be overlap between L0 tables
+		return lm.getAllL0Tables()
+	}
+	levEntry := lm.getLevelEntry(level)
+	tables, err := chooseTablesToCompactFromLevel(levEntry, maxTables)
+	if err != nil {
+		return nil, err
+	}
+	// L > 0, no overlap between tables, so convert to one job per table as they can be processed in parallel
+	tableSlices := make([][]*TableEntry, len(tables))
+	for i, table := range tables {
+		tableSlices[i] = []*TableEntry{table}
+	}
+	return tableSlices, nil
+}
+
+func chooseTablesToCompactFromLevel(levelEntry *levelEntry, maxTables int) ([]*TableEntry, error) {
+	// Iterate through once to get min and max added time
+	var minAddedTime uint64 = math.MaxUint64
+	var maxAddedTime uint64
+	for _, lte := range levelEntry.tableEntries {
+		te := lte.Get(levelEntry)
+		if te.AddedTime < minAddedTime {
+			minAddedTime = te.AddedTime
+		}
+		if te.AddedTime > maxAddedTime {
+			maxAddedTime = te.AddedTime
+		}
+	}
+	// Iterate through again to calculate scores
+	h := scoreHeap{}
+	heap.Init(&h)
+	for _, lte := range levelEntry.tableEntries {
+		te := lte.Get(levelEntry)
+		heap.Push(&h, scoreEntry{
+			tableEntry: te,
+			score:      computeScore(te, minAddedTime, maxAddedTime),
+		})
+		if h.Len() > maxTables {
+			heap.Pop(&h)
+		}
+	}
+	entries := make([]*TableEntry, h.Len())
+	for i := len(entries) - 1; i >= 0; i-- {
+		scoreEntry := heap.Pop(&h).(scoreEntry)
+		entries[i] = scoreEntry.tableEntry
+	}
+	return entries, nil
+}
+
+func computeScore(te *TableEntry, minAddedTime uint64, maxAddedTime uint64) float64 {
+	/*
+		The score has three components.
+		1. From 0-1 as AddedTime varies linearly between maxAddedTime and minAddedTime
+		2. DeleteRatio, from 0-1
+		3. If there is one or more prefix tombstones then contribute 3 (this happens when table is dropped)
+	*/
+	var ageContrib float64
+	if maxAddedTime > minAddedTime {
+		// if AddedTime = minAddedTime then + 1, if AddedTime = maxAddedTime then -1
+		// So we prioritise compaction of older tables
+		ageContrib = 1 - float64(te.AddedTime-minAddedTime)/float64(maxAddedTime-minAddedTime)
+	}
+	var prefixDeleteContrib float64
+	if te.NumPrefixDeletes > 0 {
+		prefixDeleteContrib = 3
+	}
+	return ageContrib + te.DeleteRatio + prefixDeleteContrib
+}
+
+type scoreEntry struct {
+	tableEntry *TableEntry
+	score      float64
+}
+
+type scoreHeap []scoreEntry
+
+//goland:noinspection GoMixedReceiverTypes
+func (h scoreHeap) Len() int { return len(h) }
+
+//goland:noinspection GoMixedReceiverTypes
+func (h scoreHeap) Less(i, j int) bool { return h[i].score < h[j].score }
+
+//goland:noinspection GoMixedReceiverTypes
+func (h scoreHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+//goland:noinspection GoMixedReceiverTypes
+func (h *scoreHeap) Push(x interface{}) {
+	*h = append(*h, x.(scoreEntry))
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (h *scoreHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func (lm *Manager) jobInProgress(jobID string) bool {
+	_, ok := lm.inProgress[jobID]
+	return ok
+}
+
+func (lm *Manager) compactionComplete(jobID string) error {
+	compactionJob, ok := lm.inProgress[jobID]
+	if !ok {
+		panic("cannot find compactionJob")
+	}
+	job := compactionJob.jobHolder.job
+	delete(lm.inProgress, job.id)
+	lm.pendingCompactions[job.levelFrom]--
+	if compactionJob.timer != nil {
+		compactionJob.timer.Stop()
+	}
+	lm.unlockTablesForJob(job)
+	lm.stats.InProgressJobs--
+	lm.stats.CompletedJobs++
+	dur := time.Duration(arista.NanoTime() - job.scheduleTime)
+	log.Debugf("compaction complete job %s - time from schedule %d ms", job.id, dur.Milliseconds())
+	cf := compactionJob.jobHolder.completionFunc
+	if cf != nil {
+		log.Debugf("in compactionComplete %s calling completion", jobID)
+		cf(nil)
+	}
+	if log.DebugEnabled {
+		lm.dumpLevelInfo()
+	}
+	// After compaction, the dest level might need compaction, or we might have more dead entries to remove,
+	// so we trigger a check
+	return lm.maybeScheduleCompaction()
+}
+
+func (lm *Manager) pollForJob(connectionID int, completionFunc func(job *CompactionJob, err error)) {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if len(lm.jobQueue) > 0 {
+		holder := lm.jobQueue[0]
+		lm.jobQueue = lm.jobQueue[1:]
+		lm.stats.QueuedJobs--
+		job := holder.job
+		timer := lm.scheduleJobTimeout(holder, connectionID)
+		lm.inProgress[job.id] = inProgressCompaction{
+			timer:        timer,
+			jobHolder:    holder,
+			connectionID: connectionID,
+		}
+		lm.stats.InProgressJobs++
+		jobCopy := job
+		completionFunc(&jobCopy, nil)
+		return
+	}
+	poller := &poller{
+		addedTime:      arista.NanoTime(),
+		completionFunc: completionFunc,
+		connectionID:   connectionID,
+	}
+	lm.schedulePollerTimeout(poller)
+	lm.pollers.add(poller)
+}
+
+func (lm *Manager) schedulePollerTimeout(poller *poller) {
+	timer := common.ScheduleTimer(lm.conf.CompactionPollerTimeout, false, func() {
+		// run on separate GR to avoid deadlock with stopping timer when job dispatched and level manager lock
+		common.Go(func() {
+			lm.lock.Lock()
+			defer lm.lock.Unlock()
+			if poller.timer == nil {
+				// already complete
+				return
+			}
+			lm.pollers.remove(poller)
+			poller.completionFunc(nil, common.NewTektiteErrorf(common.CompactionPollTimeout, "no job available"))
+		})
+	})
+	poller.timer = timer
+}
+
+func (lm *Manager) scheduleJobTimeout(holder jobHolder, connectionID int) *time.Timer {
+	return time.AfterFunc(lm.conf.CompactionJobTimeout, func() {
+		lm.lock.Lock()
+		defer lm.lock.Unlock()
+		log.Debugf("compaction job timedout %s with connection id %d", holder.job.id, connectionID)
+		lm.cancelInProgressJob(holder)
+	})
+}
+
+func (lm *Manager) cancelInProgressJob(holder jobHolder) {
+	log.Debugf("cancelling in progress job: %s", holder.job.id)
+	job := holder.job
+	_, ok := lm.inProgress[job.id]
+	if !ok {
+		return // already complete
+	}
+	log.Debugf("compaction job: %s timed out, will be made available to pollers again", holder.job.id)
+	delete(lm.inProgress, job.id)
+
+	lm.pendingCompactions[job.levelFrom]--
+	lm.stats.InProgressJobs--
+	lm.stats.TimedOutJobs++
+
+	lm.queueOrDespatchJob(job, holder.completionFunc)
+}
+
+func (lm *Manager) connectionClosed(connectionID int) {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	log.Debugf("connectionClosed %d num inprog jobs:%d", connectionID, len(lm.inProgress))
+	// Cancel any in progress compactions that were polled for on the connection that was closed. This indicates
+	// the node has failed, cancelling them on close of connection is quicker than waiting for job timeout which can
+	// be a significant time. We don't want compaction to stall for a long time when a node dies, as this can cause
+	// L0 to reach max size and registrations to block.
+	for _, inProg := range lm.inProgress {
+		log.Debugf("inprogress job: %s connection id:%d", inProg.jobHolder.job.id, inProg.connectionID)
+		if inProg.connectionID == connectionID {
+			log.Debugf("cancelling inprogress job %s on connection close", inProg.jobHolder.job.id)
+			lm.cancelInProgressJob(inProg.jobHolder)
+		}
+	}
+}
+
+func (lm *Manager) checkForDeadEntries(rng VersionRange) bool {
+	for level, entry := range lm.masterRecord.levelEntries {
+		for _, lte := range entry.tableEntries {
+			te := lte.Get(entry)
+			// Only add the tables that match
+			if te.MaxVersion >= rng.VersionStart && te.MinVersion <= rng.VersionEnd {
+				log.Errorf("entry with dead version in sstable %s level %d", string(te.SSTableID), level)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (lm *Manager) forceCompaction(level int, maxTables int) error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	entries := lm.getLevelEntry(level)
+	if len(entries.tableEntries) == 0 {
+		return nil
+	}
+	tables, err := lm.chooseTablesToCompact(level, maxTables)
+	if err != nil {
+		return err
+	}
+	if len(tables) == 0 {
+		return nil
+	}
+	_, _, err = lm.scheduleCompaction(level, tables, nil)
+	return err
+}
+
+func (lm *Manager) GetCompactionStats() CompactionStats {
+	lm.lock.RLock()
+	defer lm.lock.RUnlock()
+	return lm.stats
+}
+
+type CompactionStats struct {
+	QueuedJobs     int
+	InProgressJobs int
+	CompletedJobs  int
+	TimedOutJobs   int
+}
+
+type LevelIterator interface {
+	Next() (*TableEntry, error)
+	Reset() error
+}
+
+type tableToCompact struct {
+	level int
+	table *TableEntry
+}
+
+type inProgressCompaction struct {
+	timer        *time.Timer
+	jobHolder    jobHolder
+	connectionID int
+}
+
+type CompactionJob struct {
+	id                 string
+	levelFrom          int
+	tables             [][]tableToCompact
+	isMove             bool
+	preserveTombstones bool
+	scheduleTime       uint64 // Used for timing jobs - we use nanoTime to avoid errors if clocks change
+	serverTime         uint64 // Unix millis past epoch - Used on compaction workers to determine if entries are expired
+	lastFlushedVersion int64
+	sourceRange        lockedRange // Not used on compaction worker so doesn't need to be serialized
+	destRange          lockedRange // Not used on compaction worker so doesn't need to be serialized
+}
+
+func (c *CompactionJob) Serialize(buff []byte) []byte {
+	buff = encoding.AppendStringToBufferLE(buff, c.id)
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(c.levelFrom))
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(c.tables)))
+	for _, tablesToCompact := range c.tables {
+		buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(tablesToCompact)))
+		for _, tableToCompact := range tablesToCompact {
+			buff = encoding.AppendUint32ToBufferLE(buff, uint32(tableToCompact.level))
+			buff = tableToCompact.table.serialize(buff)
+		}
+	}
+	buff = encoding.AppendBoolToBuffer(buff, c.isMove)
+	buff = encoding.AppendBoolToBuffer(buff, c.preserveTombstones)
+	buff = encoding.AppendUint64ToBufferLE(buff, c.scheduleTime)
+	buff = encoding.AppendUint64ToBufferLE(buff, c.serverTime)
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(c.lastFlushedVersion))
+	return buff
+}
+
+func (c *CompactionJob) Deserialize(buff []byte, offset int) int {
+	c.id, offset = encoding.ReadStringFromBufferLE(buff, offset)
+	var lf uint32
+	lf, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	c.levelFrom = int(lf)
+	var nt uint32
+	nt, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	c.tables = make([][]tableToCompact, int(nt))
+	for i := 0; i < int(nt); i++ {
+		var nt2 uint32
+		nt2, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+		tables2 := make([]tableToCompact, int(nt2))
+		for j := 0; j < int(nt2); j++ {
+			var l uint32
+			l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+			te := &TableEntry{}
+			offset = te.deserialize(buff, offset)
+			tables2[j] = tableToCompact{
+				level: int(l),
+				table: te,
+			}
+		}
+		c.tables[i] = tables2
+	}
+	c.isMove, offset = encoding.ReadBoolFromBuffer(buff, offset)
+	c.preserveTombstones, offset = encoding.ReadBoolFromBuffer(buff, offset)
+	c.scheduleTime, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	c.serverTime, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	var lfv uint64
+	lfv, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	c.lastFlushedVersion = int64(lfv)
+	return offset
+}
+
+type CompactionResult struct {
+	id        string
+	newTables []TableEntry
+}
+
+func (c *CompactionResult) Serialize(buff []byte) []byte {
+	buff = encoding.AppendStringToBufferLE(buff, c.id)
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(c.newTables)))
+	for _, nt := range c.newTables {
+		buff = nt.serialize(buff)
+	}
+	return buff
+}
+
+func (c *CompactionResult) Deserialize(buff []byte, offset int) int {
+	c.id, offset = encoding.ReadStringFromBufferLE(buff, offset)
+	var nt uint32
+	nt, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	c.newTables = make([]TableEntry, int(nt))
+	for i := 0; i < int(nt); i++ {
+		offset = c.newTables[i].deserialize(buff, offset)
+	}
+	return offset
+}
+
+// MergeSSTables takes a list of SSTables, and merges them to produce one or more output SSTables
+// Tables lower in the list take precedence to tables higher in the list when a common key is found
+
+type ssTableInfo struct {
+	sst              *sst.SSTable
+	rangeStart       []byte
+	rangeEnd         []byte
+	minVersion       uint64
+	maxVersion       uint64
+	deleteRatio      float64
+	numPrefixDeletes uint32
+}
+
+type poller struct {
+	addedTime      uint64
+	connectionID   int
+	completionFunc func(job *CompactionJob, err error)
+	index          int
+	timer          *common.TimerHandle
+}
+
+type pollerQueue []*poller
+
+//goland:noinspection GoMixedReceiverTypes
+func (pq pollerQueue) Len() int { return len(pq) }
+
+//goland:noinspection GoMixedReceiverTypes
+func (pq pollerQueue) Less(i, j int) bool {
+	return pq[i].addedTime < pq[j].addedTime
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (pq pollerQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (pq *pollerQueue) Push(x interface{}) {
+	item := x.(*poller)
+	item.index = len(*pq)
+	*pq = append(*pq, item)
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (pq *pollerQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[0 : n-1]
+	item.index = -1
+	return item
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (pq *pollerQueue) add(item *poller) {
+	heap.Push(pq, item)
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (pq *pollerQueue) remove(item *poller) {
+	heap.Remove(pq, item.index)
+}
+
+//goland:noinspection GoMixedReceiverTypes
+func (pq *pollerQueue) pop() *poller {
+	item := pq.Pop()
+	return item.(*poller)
+}

--- a/lsm/compaction_test.go
+++ b/lsm/compaction_test.go
@@ -1,0 +1,2002 @@
+package lsm
+
+import (
+	"container/heap"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/asl/conf"
+	encoding2 "github.com/spirit-labs/tektite/asl/encoding"
+	"github.com/spirit-labs/tektite/asl/errwrap"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/iteration"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/spirit-labs/tektite/testutils"
+	"github.com/stretchr/testify/require"
+	"math"
+	"sync"
+	"testing"
+	"time"
+)
+
+const maxTableSize = 1300
+
+func TestPollerTimeout(t *testing.T) {
+	pollerTimeout := 250 * time.Millisecond
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.CompactionPollerTimeout = pollerTimeout
+	})
+	defer tearDown(t)
+
+	start := time.Now()
+	numPolls := 10
+	chans := make([]chan error, 0, numPolls)
+	for i := 0; i < numPolls; i++ {
+		ch := make(chan error, 1)
+		chans = append(chans, ch)
+		lm.pollForJob(-1, func(job *CompactionJob, err error) {
+			ch <- err
+		})
+	}
+	for _, ch := range chans {
+		err := <-ch
+		require.Error(t, err)
+		require.True(t, time.Now().Sub(start) >= pollerTimeout)
+		var perr common.TektiteError
+		isTektiteError := errwrap.As(err, &perr)
+		require.True(t, isTektiteError)
+		require.Equal(t, common.CompactionPollTimeout, perr.Code)
+	}
+}
+
+func TestPollForJobWhenAlreadyInQueue(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+	// populate level 1 and 2 with an overlap and level 1 having reached L1CompactionTrigger
+	populateLevel(t, lm, 1, createTableEntry("sst1", 0, 9),
+		createTableEntry("sst2", 10, 19))
+	populateLevel(t, lm, 2, createTableEntry("sst3", 0, 19))
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 1, stats.QueuedJobs)
+	require.Equal(t, 0, stats.InProgressJobs)
+	job, err := getJob(lm)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	require.Equal(t, 1, job.levelFrom)
+	require.Equal(t, 2, len(job.tables))
+	require.Equal(t, 1, len(job.tables[0]))
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 0, stats.QueuedJobs)
+	require.Equal(t, 1, stats.InProgressJobs)
+}
+
+func TestPollForJobWhenNotAlreadyInQueue(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+	// populate level 1 and 2 with an overlap and level 1 having reached L1CompactionTrigger
+	populateLevel(t, lm, 1, createTableEntry("sst1", 0, 9),
+		createTableEntry("sst2", 10, 19))
+	populateLevel(t, lm, 2, createTableEntry("sst3", 0, 19))
+
+	ch := make(chan pollResult, 1)
+	lm.pollForJob(-1, func(job *CompactionJob, err error) {
+		ch <- pollResult{job, err}
+	})
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 0, stats.QueuedJobs)
+	require.Equal(t, 0, stats.InProgressJobs)
+
+	go func() {
+		time.Sleep(conf.DefaultCompactionPollerTimeout / 4)
+		err := lm.MaybeScheduleCompaction()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	res := <-ch
+	require.NoError(t, res.err)
+	require.NotNil(t, res.job)
+	require.Equal(t, 1, res.job.levelFrom)
+	require.Equal(t, 2, len(res.job.tables))
+	require.Equal(t, 1, len(res.job.tables[0]))
+
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 0, stats.QueuedJobs)
+	require.Equal(t, 1, stats.InProgressJobs)
+}
+
+func TestPollersGetJobsInOrder(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+
+	populateLevel(t, lm, 1, createTableEntry("sst1", 0, 9))
+
+	numPollers := 8
+
+	for i := 0; i < numPollers; i++ {
+		populateLevel(t, lm, 2, createTableEntry(fmt.Sprintf("sst-dest-%d", i+2), (i+1)*10,
+			(i+1)*10+9))
+	}
+
+	var chans []chan pollResult
+	for i := 0; i < numPollers; i++ {
+		ch := make(chan pollResult, 1)
+		lm.pollForJob(-1, func(job *CompactionJob, err error) {
+			ch <- pollResult{job, err}
+		})
+		chans = append(chans, ch)
+	}
+
+	// Add more tables and schedule compaction - this should create jobs - these should be given direct to
+	// the waiting pollers, so nothing should be in the job queue
+	for i := 0; i < numPollers; i++ {
+		populateLevel(t, lm, 1, createTableEntry(fmt.Sprintf("sst-%d", i+2),
+			(i+1)*10, (i+1)*10+9))
+	}
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 0, stats.QueuedJobs)
+	require.Equal(t, numPollers, stats.InProgressJobs)
+
+	for _, ch := range chans {
+		res := <-ch
+		require.NoError(t, res.err)
+		require.NotNil(t, res.job)
+		require.Equal(t, 1, res.job.levelFrom)
+		require.Equal(t, 2, len(res.job.tables))
+		require.Equal(t, 1, len(res.job.tables[0]))
+	}
+}
+
+func TestPollJobAndCompleteItLevel0To1(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = 1
+		cfg.L1CompactionTrigger = 10
+	})
+	defer tearDown(t)
+
+	// create a bunch of overlapping tables on L0
+
+	sst11 := createTableEntryWithDeleteRatio("sst1-1", 11, 50, 0.1)
+
+	sst12 := createTableEntryWithDeleteRatio("sst1-2", 35, 40, 0.1)
+
+	sst13 := createTableEntryWithDeleteRatio("sst1-3", 9, 22, 0.1)
+
+	sst14 := createTableEntryWithDeleteRatio("sst1-4", 33, 48, 0.1)
+
+	sst15 := createTableEntryWithDeleteRatio("sst1-5", 8, 31, 0.11)
+
+	populateLevel(t, lm, 0, sst11, sst12, sst13, sst14, sst15)
+
+	sst21 := createTableEntryWithDeleteRatio("sst2-1", 0, 3, 0.5)
+
+	sst22 := createTableEntryWithDeleteRatio("sst2-2", 4, 7, 0.5)
+
+	sst23 := createTableEntryWithDeleteRatio("sst2-3", 15, 30, 0.5)
+
+	sst24 := createTableEntryWithDeleteRatio("sst2-4", 33, 45, 0.5)
+
+	sst25 := createTableEntryWithDeleteRatio("sst2-5", 52, 99, 0.5)
+
+	populateLevel(t, lm, 1, sst21, sst22, sst23, sst24, sst25)
+	err := lm.MaybeScheduleCompaction()
+	// this should create job with everything in L0 merging into sst23 and sst24
+	require.NoError(t, err)
+
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 1, stats.QueuedJobs)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 1, stats.InProgressJobs)
+	require.Equal(t, 0, stats.QueuedJobs)
+
+	require.False(t, job.isMove)
+	require.Equal(t, 0, job.levelFrom)
+
+	require.Equal(t, 6, len(job.tables))
+
+	require.Equal(t, 1, len(job.tables[0]))
+	require.Equal(t, "sst1-5", string(job.tables[0][0].table.SSTableID))
+	require.Equal(t, []byte("key00008"), trimVersion(job.tables[0][0].table.RangeStart))
+	require.Equal(t, []byte("key00031"), trimVersion(job.tables[0][0].table.RangeEnd))
+
+	require.Equal(t, 1, len(job.tables[1]))
+	require.Equal(t, "sst1-4", string(job.tables[1][0].table.SSTableID))
+	require.Equal(t, []byte("key00033"), trimVersion(job.tables[1][0].table.RangeStart))
+	require.Equal(t, []byte("key00048"), trimVersion(job.tables[1][0].table.RangeEnd))
+
+	require.Equal(t, 1, len(job.tables[2]))
+	require.Equal(t, "sst1-3", string(job.tables[2][0].table.SSTableID))
+	require.Equal(t, []byte("key00009"), trimVersion(job.tables[2][0].table.RangeStart))
+	require.Equal(t, []byte("key00022"), trimVersion(job.tables[2][0].table.RangeEnd))
+
+	require.Equal(t, 1, len(job.tables[3]))
+	require.Equal(t, "sst1-2", string(job.tables[3][0].table.SSTableID))
+	require.Equal(t, []byte("key00035"), trimVersion(job.tables[3][0].table.RangeStart))
+	require.Equal(t, []byte("key00040"), trimVersion(job.tables[3][0].table.RangeEnd))
+
+	require.Equal(t, 1, len(job.tables[4]))
+	require.Equal(t, "sst1-1", string(job.tables[4][0].table.SSTableID))
+	require.Equal(t, []byte("key00011"), trimVersion(job.tables[4][0].table.RangeStart))
+	require.Equal(t, []byte("key00050"), trimVersion(job.tables[4][0].table.RangeEnd))
+
+	require.Equal(t, 2, len(job.tables[5]))
+	require.Equal(t, "sst2-3", string(job.tables[5][0].table.SSTableID))
+	require.Equal(t, []byte("key00015"), trimVersion(job.tables[5][0].table.RangeStart))
+	require.Equal(t, []byte("key00030"), trimVersion(job.tables[5][0].table.RangeEnd))
+
+	require.Equal(t, "sst2-4", string(job.tables[5][1].table.SSTableID))
+	require.Equal(t, []byte("key00033"), trimVersion(job.tables[5][1].table.RangeStart))
+	require.Equal(t, []byte("key00045"), trimVersion(job.tables[5][1].table.RangeEnd))
+
+	newTables := []TableEntry{
+		{
+			SSTableID:   []byte("sst2-6"),
+			RangeStart:  encoding2.EncodeVersion([]byte("key00008"), 0),
+			RangeEnd:    encoding2.EncodeVersion([]byte("key00033"), 0),
+			DeleteRatio: 1.23,
+		},
+		{
+			SSTableID:   []byte("sst2-7"),
+			RangeStart:  encoding2.EncodeVersion([]byte("key00034"), 0),
+			RangeEnd:    encoding2.EncodeVersion([]byte("key00050"), 0),
+			DeleteRatio: 1.33,
+		},
+	}
+
+	sendCompactionComplete(t, lm, job, newTables)
+
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 0, stats.InProgressJobs)
+	require.Equal(t, 0, stats.QueuedJobs)
+
+	// should be nothing left in level 0
+	checkLevelEntries(t, lm, 0)
+
+	expectedTables := []TableEntry{sst21, sst22, newTables[0], newTables[1], sst25}
+
+	checkLevelEntries(t, lm, 1, expectedTables...)
+}
+
+func sendCompactionComplete(t *testing.T, lm *Manager, job *CompactionJob, newTables []TableEntry) {
+	registrations, deRegistrations := changesToApply(newTables, job)
+	regBatch := RegistrationBatch{
+		ClusterName:     "test_cluster",
+		Compaction:      true,
+		JobID:           job.id,
+		Registrations:   registrations,
+		DeRegistrations: deRegistrations,
+	}
+	err := lm.ApplyChanges(regBatch)
+	require.NoError(t, err)
+}
+
+func TestPollJobAndCompleteItLevel0To1EmptyL1(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = 1
+	})
+	defer tearDown(t)
+	// create a bunch of overlapping tables on L0
+
+	sst11 := TableEntry{
+		SSTableID:   []byte("sst1-1"),
+		RangeStart:  encoding2.EncodeVersion([]byte("key00011"), 0),
+		RangeEnd:    encoding2.EncodeVersion([]byte("key00050"), 0),
+		DeleteRatio: 0.1,
+	}
+	sst12 := TableEntry{
+		SSTableID:   []byte("sst1-2"),
+		RangeStart:  encoding2.EncodeVersion([]byte("key00035"), 0),
+		RangeEnd:    encoding2.EncodeVersion([]byte("key00040"), 0),
+		DeleteRatio: 0.1,
+	}
+	sst13 := TableEntry{
+		SSTableID:   []byte("sst1-3"),
+		RangeStart:  encoding2.EncodeVersion([]byte("key00009"), 0),
+		RangeEnd:    encoding2.EncodeVersion([]byte("key00022"), 0),
+		DeleteRatio: 0.1,
+	}
+	sst14 := TableEntry{
+		SSTableID:   []byte("sst1-4"),
+		RangeStart:  encoding2.EncodeVersion([]byte("key00033"), 0),
+		RangeEnd:    encoding2.EncodeVersion([]byte("key00048"), 0),
+		DeleteRatio: 0.1,
+	}
+	sst15 := TableEntry{
+		SSTableID:   []byte("sst1-5"),
+		RangeStart:  encoding2.EncodeVersion([]byte("key00008"), 0),
+		RangeEnd:    encoding2.EncodeVersion([]byte("key00031"), 0),
+		DeleteRatio: 0.11,
+	}
+	populateLevel(t, lm, 0, sst11, sst12, sst13, sst14, sst15)
+
+	err := lm.MaybeScheduleCompaction()
+	// this should create job with everything in L0
+	require.NoError(t, err)
+
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 1, stats.QueuedJobs)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 1, stats.InProgressJobs)
+	require.Equal(t, 0, stats.QueuedJobs)
+
+	require.False(t, job.isMove)
+	require.Equal(t, 0, job.levelFrom)
+
+	require.Equal(t, 5, len(job.tables))
+
+	require.Equal(t, 1, len(job.tables[0]))
+	require.Equal(t, "sst1-5", string(job.tables[0][0].table.SSTableID))
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00008"), 0), job.tables[0][0].table.RangeStart)
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00031"), 0), job.tables[0][0].table.RangeEnd)
+
+	require.Equal(t, 1, len(job.tables[1]))
+	require.Equal(t, "sst1-4", string(job.tables[1][0].table.SSTableID))
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00033"), 0), job.tables[1][0].table.RangeStart)
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00048"), 0), job.tables[1][0].table.RangeEnd)
+
+	require.Equal(t, 1, len(job.tables[2]))
+	require.Equal(t, "sst1-3", string(job.tables[2][0].table.SSTableID))
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00009"), 0), job.tables[2][0].table.RangeStart)
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00022"), 0), job.tables[2][0].table.RangeEnd)
+
+	require.Equal(t, 1, len(job.tables[3]))
+	require.Equal(t, "sst1-2", string(job.tables[3][0].table.SSTableID))
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00035"), 0), job.tables[3][0].table.RangeStart)
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00040"), 0), job.tables[3][0].table.RangeEnd)
+
+	require.Equal(t, 1, len(job.tables[4]))
+	require.Equal(t, "sst1-1", string(job.tables[4][0].table.SSTableID))
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00011"), 0), job.tables[4][0].table.RangeStart)
+	require.Equal(t, encoding2.EncodeVersion([]byte("key00050"), 0), job.tables[4][0].table.RangeEnd)
+
+	newTables := []TableEntry{
+		createTableEntryWithDeleteRatio("sst2-6", 8, 33, 1.23),
+		createTableEntryWithDeleteRatio("sst2-7", 34, 50, 1.33),
+	}
+
+	sendCompactionComplete(t, lm, job, newTables)
+
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 0, stats.InProgressJobs)
+	require.Equal(t, 0, stats.QueuedJobs)
+
+	// should be nothing left in level 0
+	checkLevelEntries(t, lm, 0)
+
+	checkLevelEntries(t, lm, 1, newTables...)
+}
+
+func TestPollJobAndCompleteItLevel1To2(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = 2
+		cfg.LevelMultiplier = 2
+	})
+	defer tearDown(t)
+
+	sst11 := createTableEntryWithDeleteRatio("sst1-1", 0, 1, 0.1)
+	sst12 := createTableEntryWithDeleteRatio("sst1-2", 2, 3, 0.1)
+	sst13 := createTableEntryWithDeleteRatio("sst1-3", 4, 5, 0.1)
+	sst14 := createTableEntryWithDeleteRatio("sst1-4", 6, 7, 0.1)
+	sst15 := createTableEntryWithDeleteRatio("sst1-5", 10, 19, 0.11)
+
+	populateLevel(t, lm, 1, sst11, sst12, sst13, sst14, sst15)
+
+	sst21 := createTableEntryWithDeleteRatio("sst2-1", 0, 4, 0.5)
+	sst22 := createTableEntryWithDeleteRatio("sst2-2", 5, 9, 0.3)
+	sst23 := createTableEntryWithDeleteRatio("sst2-3", 10, 14, 0.45)
+	sst24 := createTableEntryWithDeleteRatio("sst2-4", 15, 20, 0.8)
+	sst25 := createTableEntryWithDeleteRatio("sst2-5", 21, 24, 0.34)
+
+	populateLevel(t, lm, 2, sst21, sst22, sst23, sst24, sst25)
+	err := lm.MaybeScheduleCompaction()
+	// this should create job from sst1-5 as has highest delete ratio and overlaps with next level
+	require.NoError(t, err)
+
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 1, stats.QueuedJobs)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 1, stats.InProgressJobs)
+	require.Equal(t, 0, stats.QueuedJobs)
+
+	require.False(t, job.isMove)
+	require.Equal(t, 2, len(job.tables))
+	require.Equal(t, 1, len(job.tables[0]))
+	require.Equal(t, "sst1-5", string(job.tables[0][0].table.SSTableID))
+	require.Equal(t, []byte("key00010"), trimVersion(job.tables[0][0].table.RangeStart))
+	require.Equal(t, []byte("key00019"), trimVersion(job.tables[0][0].table.RangeEnd))
+
+	require.Equal(t, 2, len(job.tables[1]))
+
+	require.Equal(t, "sst2-3", string(job.tables[1][0].table.SSTableID))
+	require.Equal(t, []byte("key00010"), trimVersion(job.tables[1][0].table.RangeStart))
+	require.Equal(t, []byte("key00014"), trimVersion(job.tables[1][0].table.RangeEnd))
+
+	require.Equal(t, "sst2-4", string(job.tables[1][1].table.SSTableID))
+	require.Equal(t, []byte("key00015"), trimVersion(job.tables[1][1].table.RangeStart))
+	require.Equal(t, []byte("key00020"), trimVersion(job.tables[1][1].table.RangeEnd))
+
+	// try and complete with wrong id
+	regBatch := RegistrationBatch{
+		ClusterName: "test_cluster",
+		Compaction:  true,
+		JobID:       "unknown",
+	}
+	err = lm.ApplyChanges(regBatch)
+	require.Error(t, err)
+
+	newTables := []TableEntry{
+		createTableEntryWithDeleteRatio("sst2-6", 10, 15, 1.23),
+		createTableEntryWithDeleteRatio("sst2-7", 16, 20, 1.23),
+	}
+
+	sendCompactionComplete(t, lm, job, newTables)
+
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 0, stats.InProgressJobs)
+	require.Equal(t, 0, stats.QueuedJobs)
+
+	checkLevelEntries(t, lm, 1, sst11, sst12, sst13, sst14)
+
+	expectedTables := []TableEntry{sst21, sst22, newTables[0], newTables[1], sst25}
+
+	checkLevelEntries(t, lm, 2, expectedTables...)
+}
+
+func TestCompactionTimeout(t *testing.T) {
+	compactionTimeout := 100 * time.Millisecond
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = 1
+		cfg.L1CompactionTrigger = 1
+		cfg.LevelMultiplier = 1
+		cfg.CompactionJobTimeout = compactionTimeout
+	})
+	defer tearDown(t)
+
+	sst1 := TableEntry{
+		SSTableID:   []byte("sst1"),
+		RangeStart:  encoding2.EncodeVersion([]byte("key00000"), 0),
+		RangeEnd:    encoding2.EncodeVersion([]byte("key00009"), 0),
+		DeleteRatio: 0.1,
+	}
+	sst2 := TableEntry{
+		SSTableID:   []byte("sst2"),
+		RangeStart:  encoding2.EncodeVersion([]byte("key00010"), 0),
+		RangeEnd:    encoding2.EncodeVersion([]byte("key00019"), 0),
+		DeleteRatio: 0.11,
+	}
+	populateLevel(t, lm, 1, sst1, sst2)
+
+	sst3 := TableEntry{
+		SSTableID:   []byte("sst3"),
+		RangeStart:  encoding2.EncodeVersion([]byte("key00010"), 0),
+		RangeEnd:    encoding2.EncodeVersion([]byte("key00019"), 0),
+		DeleteRatio: 0.5,
+	}
+	populateLevel(t, lm, 2, sst3)
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	ch := make(chan pollResult, 1)
+	lm.pollForJob(-1, func(job *CompactionJob, err error) {
+		ch <- pollResult{job, err}
+	})
+	res := <-ch
+	require.NoError(t, res.err)
+
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 1, stats.InProgressJobs)
+	require.Equal(t, 0, stats.QueuedJobs)
+
+	// Make job timeout
+	time.Sleep(2 * compactionTimeout)
+
+	// should be added back on to queue
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 0, stats.InProgressJobs)
+	require.Equal(t, 1, stats.QueuedJobs)
+	require.Equal(t, 1, stats.TimedOutJobs)
+}
+
+func TestTablesMovedToLastLevelWhenNoOverlapAndNoDeletes(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+
+	sst1 := createTableEntryWithDeleteRatio("sst1", 0, 9, 0.0)
+	sst2 := createTableEntryWithDeleteRatio("sst2", 10, 19, 0.0)
+
+	populateLevel(t, lm, 1, sst1, sst2)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	stats := lm.GetCompactionStats()
+
+	require.Equal(t, 1, stats.QueuedJobs)
+	require.Equal(t, 0, stats.InProgressJobs)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	require.Equal(t, true, job.isMove)
+}
+
+func TestTablesNotMovedToLastLevelWhenNoOverlapAndDeletes(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+
+	sst1 := createTableEntryWithDeleteRatio("sst1", 0, 9, 0.1)
+	sst2 := createTableEntryWithDeleteRatio("sst2", 10, 19, 0.1)
+
+	populateLevel(t, lm, 1, sst1, sst2)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	stats := lm.GetCompactionStats()
+
+	require.Equal(t, 1, stats.QueuedJobs)
+	require.Equal(t, 0, stats.InProgressJobs)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	require.Equal(t, false, job.isMove)
+}
+
+func TestTablesMovedToNonLastLevelWhenNoOverlapAndDeletes(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+
+	sst1 := createTableEntryWithDeleteRatio("sst1", 0, 9, 0.1)
+	sst2 := createTableEntryWithDeleteRatio("sst2", 10, 19, 0.1)
+	populateLevel(t, lm, 1, sst1, sst2)
+
+	sst3 := createTableEntryWithDeleteRatio("sst3", 20, 29, 0.0)
+	populateLevel(t, lm, 2, sst3)
+
+	sst4 := createTableEntryWithDeleteRatio("sst4", 30, 39, 0.0)
+	populateLevel(t, lm, 3, sst4)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	stats := lm.GetCompactionStats()
+
+	require.Equal(t, 1, stats.QueuedJobs)
+	require.Equal(t, 0, stats.InProgressJobs)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	require.Equal(t, true, job.isMove)
+}
+
+func TestFileLockingOnNextLevel(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+
+	sst11 := createTableEntryWithDeleteRatio("sst1-1", 0, 9, 0.1)
+	// level 1
+	// overlaps with sst21 and sst22
+	sst12 := createTableEntryWithDeleteRatio("sst1-2", 10, 19, 0.3)
+	// overlaps with sst22
+	sst13 := createTableEntryWithDeleteRatio("sst1-3", 20, 29, 0.5)
+
+	populateLevel(t, lm, 1, sst11, sst12, sst13)
+
+	sst21 := createTableEntryWithDeleteRatio("sst2-1", 5, 17, 0.4)
+
+	sst22 := createTableEntryWithDeleteRatio("sst2-2", 18, 35, 0.4)
+
+	populateLevel(t, lm, 2, sst21, sst22)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	// should be a single job from for sst1-3, as sst1-2 overlaps with same table and sst1-3 has higher delete ratio
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 1, stats.QueuedJobs)
+	require.Equal(t, 0, stats.InProgressJobs)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(job.tables))
+	require.Equal(t, 1, len(job.tables[0]))
+	require.Equal(t, "sst1-3", string(job.tables[0][0].table.SSTableID))
+
+	// complete the job - this should release locks and then sst13 will have a job created as next highest delete ratio
+	sendCompactionComplete(t, lm, job, nil)
+
+	job, err = getJob(lm)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(job.tables))
+	require.Equal(t, 1, len(job.tables[0]))
+	require.Equal(t, "sst1-2", string(job.tables[0][0].table.SSTableID))
+}
+
+func TestFileLocking(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+
+	sst11 := createTableEntryWithDeleteRatio("sst1-1", 0, 9, 0.1)
+	// level 1
+	// overlaps with sst21 and sst22
+	sst12 := createTableEntryWithDeleteRatio("sst1-2", 10, 19, 0.3)
+	// overlaps with sst22
+	sst13 := createTableEntryWithDeleteRatio("sst1-3", 20, 29, 0.5)
+	populateLevel(t, lm, 1, sst11, sst12, sst13)
+
+	sst21 := createTableEntryWithDeleteRatio("sst2-1", 5, 17, 0.4)
+	sst22 := createTableEntryWithDeleteRatio("sst2-2", 18, 35, 0.4)
+
+	populateLevel(t, lm, 2, sst21, sst22)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	// should be a single job from for sst1-3, as sst1-2 overlaps with same table and sst1-3 has higher delete ratio
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 1, stats.QueuedJobs)
+	require.Equal(t, 0, stats.InProgressJobs)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(job.tables))
+	require.Equal(t, 1, len(job.tables[0]))
+	require.Equal(t, "sst1-3", string(job.tables[0][0].table.SSTableID))
+
+	// complete the job - this should release locks and then sst13 will have a job created as next highest delete ratio
+	sendCompactionComplete(t, lm, job, nil)
+
+	job, err = getJob(lm)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(job.tables))
+	require.Equal(t, 1, len(job.tables[0]))
+	require.Equal(t, "sst1-2", string(job.tables[0][0].table.SSTableID))
+}
+
+func TestDeleteSSTablesAfterCompaction(t *testing.T) {
+	deleteCheckPeriod := 100 * time.Millisecond
+	deleteDelay := 100 * time.Millisecond
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = 2
+		cfg.LevelMultiplier = 2
+		cfg.SSTableDeleteCheckInterval = deleteCheckPeriod
+		cfg.SSTableDeleteDelay = deleteDelay
+	})
+	defer tearDown(t)
+
+	err := lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst1-1", []byte("foo"))
+	require.NoError(t, err)
+	err = lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst1-2", []byte("foo"))
+	require.NoError(t, err)
+	err = lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst1-3", []byte("foo"))
+	require.NoError(t, err)
+	err = lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst1-4", []byte("foo"))
+	require.NoError(t, err)
+	err = lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst1-5", []byte("foo"))
+	require.NoError(t, err)
+
+	err = lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst2-1", []byte("foo"))
+	require.NoError(t, err)
+	err = lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst2-2", []byte("foo"))
+	require.NoError(t, err)
+	err = lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst2-3", []byte("foo"))
+	require.NoError(t, err)
+	err = lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst2-4", []byte("foo"))
+	require.NoError(t, err)
+	err = lm.objStore.Put(context.Background(), conf.DefaultBucketName, "sst2-5", []byte("foo"))
+	require.NoError(t, err)
+
+	sst11 := createTableEntryWithDeleteRatio("sst1-1", 0, 1, 0.1)
+	sst12 := createTableEntryWithDeleteRatio("sst1-2", 2, 3, 0.1)
+	sst13 := createTableEntryWithDeleteRatio("sst1-3", 4, 5, 0.1)
+	sst14 := createTableEntryWithDeleteRatio("sst1-4", 6, 7, 0.1)
+	sst15 := createTableEntryWithDeleteRatio("sst1-5", 10, 19, 0.11)
+
+	populateLevel(t, lm, 1, sst11, sst12, sst13, sst14, sst15)
+
+	sst21 := createTableEntryWithDeleteRatio("sst2-1", 0, 4, 0.5)
+	sst22 := createTableEntryWithDeleteRatio("sst2-2", 5, 9, 0.3)
+	sst23 := createTableEntryWithDeleteRatio("sst2-3", 10, 14, 0.45)
+	sst24 := createTableEntryWithDeleteRatio("sst2-4", 15, 20, 0.8)
+	sst25 := createTableEntryWithDeleteRatio("sst2-5", 21, 24, 0.34)
+
+	populateLevel(t, lm, 2, sst21, sst22, sst23, sst24, sst25)
+	err = lm.MaybeScheduleCompaction()
+	// this should create job from sst1-5 as has highest delete ratio and overlaps with next level
+	require.NoError(t, err)
+	stats := lm.GetCompactionStats()
+
+	require.Equal(t, 1, stats.QueuedJobs)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	newTables := []TableEntry{
+		createTableEntryWithDeleteRatio("sst2-6", 10, 15, 1.23),
+		createTableEntryWithDeleteRatio("sst2-7", 16, 20, 1.23),
+	}
+
+	sendCompactionComplete(t, lm, job, newTables)
+
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 0, stats.InProgressJobs)
+	require.Equal(t, 0, stats.QueuedJobs)
+
+	checkLevelEntries(t, lm, 1, sst11, sst12, sst13, sst14)
+
+	expectedTables := []TableEntry{sst21, sst22, newTables[0], newTables[1], sst25}
+
+	checkLevelEntries(t, lm, 2, expectedTables...)
+
+	// sst15, sst23, sst24 should be deleted after a delay
+
+	time.Sleep(2*deleteCheckPeriod + 2*deleteDelay)
+
+	v, err := lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst1-5")
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst2-3")
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst2-4")
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	// others should still be there
+
+	v, err = lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst1-1")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	v, err = lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst1-2")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	v, err = lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst1-3")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	v, err = lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst1-4")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	v, err = lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst2-1")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	v, err = lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst2-2")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	v, err = lm.objStore.Get(context.Background(), conf.DefaultBucketName, "sst2-5")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+}
+
+func TestChooseLevelToCompact0(t *testing.T) {
+	testChooseLevelToCompact(t, 0, func(lm *Manager) {
+		addTablesToLevel(t, lm, 0, 10, 0, 10)
+		addTablesToLevel(t, lm, 1, 8, 0, 10)
+		addTablesToLevel(t, lm, 2, 5, 0, 10)
+	})
+}
+
+func TestChooseLevelToCompact1(t *testing.T) {
+	testChooseLevelToCompact(t, 1, func(lm *Manager) {
+		addTablesToLevel(t, lm, 0, 5, 0, 10)
+		addTablesToLevel(t, lm, 1, 11, 0, 10)
+		addTablesToLevel(t, lm, 2, 4, 0, 10)
+	})
+}
+
+func testChooseLevelToCompact(t *testing.T, level int, adderFunc func(lm *Manager)) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = 1
+		cfg.L1CompactionTrigger = 1
+		cfg.LevelMultiplier = 1
+	})
+	defer tearDown(t)
+
+	adderFunc(lm)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	require.Equal(t, level, job.levelFrom)
+}
+
+func TestChooseTableToCompact(t *testing.T) {
+	testChooseTableToCompact(t, 0.7, 0.3, 0.1, 0.7, 0.4, 0.25)
+	testChooseTableToCompact(t, 0.8, 0.8, 0.2, 0.6, 0.3, 0.25)
+	testChooseTableToCompact(t, 0.5, 0.1, 0.2, 0.5, 0.3, 0.25)
+}
+
+func testChooseTableToCompact(t *testing.T, expectedRatio float64, deleteRatios ...float64) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = 1
+		cfg.L1CompactionTrigger = 1
+		cfg.LevelMultiplier = 1
+	})
+	defer tearDown(t)
+
+	addTablesToLevel(t, lm, 0, 3, 0, 10)
+	addTablesToLevel(t, lm, 1, 5, 0, 10, deleteRatios...)
+	addTablesToLevel(t, lm, 2, 4, 0, 10)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, job.levelFrom)
+	require.Equal(t, expectedRatio, job.tables[0][0].table.DeleteRatio)
+}
+
+func addTablesToLevel(t *testing.T, lm *Manager, level int, numTables int, rangeStart int, rangePerLevel int, deleteRatios ...float64) {
+	var entries []TableEntry
+	for i := 0; i < numTables; i++ {
+		var dr float64
+		if len(deleteRatios) == 0 {
+			dr = 0.0
+		} else {
+			dr = deleteRatios[i]
+		}
+		te := TableEntry{
+			SSTableID:   []byte(fmt.Sprintf("sst-%d-%d", level, i)),
+			RangeStart:  encoding2.EncodeVersion([]byte(fmt.Sprintf("key-%05d", rangeStart)), 0),
+			RangeEnd:    encoding2.EncodeVersion([]byte(fmt.Sprintf("key-%05d", rangeStart+rangePerLevel-1)), 0),
+			DeleteRatio: dr,
+		}
+		entries = append(entries, te)
+	}
+	populateLevel(t, lm, level, entries...)
+}
+
+func getJob(lm *Manager) (*CompactionJob, error) {
+	ch := make(chan pollResult, 1)
+	lm.pollForJob(-1, func(job *CompactionJob, err error) {
+		ch <- pollResult{job, err}
+	})
+	res := <-ch
+	return res.job, res.err
+}
+
+func checkLevelEntries(t *testing.T, lm *Manager, level int, entries ...TableEntry) {
+	levEntry := lm.GetLevelEntry(level)
+	require.Equal(t, len(entries), len(levEntry.tableEntries))
+	for i, expectedTe := range entries {
+		te := levEntry.tableEntries[i].Get(levEntry)
+		require.Equal(t, expectedTe, *te)
+	}
+}
+
+type pollResult struct {
+	job *CompactionJob
+	err error
+}
+
+func populateLevel(t *testing.T, lm *Manager, level int, entries ...TableEntry) {
+	var registrations []RegistrationEntry
+	for _, te := range entries {
+		registrations = append(registrations, RegistrationEntry{
+			Level:       level,
+			TableID:     te.SSTableID,
+			KeyStart:    te.RangeStart,
+			KeyEnd:      te.RangeEnd,
+			DeleteRatio: te.DeleteRatio,
+		})
+	}
+	regBatch := RegistrationBatch{Registrations: registrations}
+	err := lm.ApplyChangesNoCheck(regBatch)
+	require.NoError(t, err)
+}
+
+func TestMergeInterleaved(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	for i := 0; i < 50; i += 2 {
+		builder1.addEntry(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i))
+	}
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+
+	builder2 := newSSTableBuilder()
+	for i := 50; i < 100; i += 2 {
+		builder2.addEntry(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i))
+	}
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	builder3 := newSSTableBuilder()
+	for i := 1; i < 50; i += 2 {
+		builder3.addEntry(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i))
+	}
+	sst3, err := builder3.build()
+	require.NoError(t, err)
+
+	builder4 := newSSTableBuilder()
+	for i := 51; i < 100; i += 2 {
+		builder4.addEntry(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i))
+	}
+	sst4, err := builder4.build()
+	require.NoError(t, err)
+
+	res, err := mergeSSTables(common.DataFormatV1,
+		[][]tableToMerge{{{sst: sst1}, {sst: sst2}}, {{sst: sst3}, {sst: sst4}}}, true,
+		1300, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(res))
+	for i := 0; i < 4; i++ {
+		require.Equal(t, 25, res[i].sst.NumEntries())
+	}
+
+	checkKVsInRange(t, "val", res[0].sst, 0, 25)
+	checkKVsInRange(t, "val", res[1].sst, 25, 50)
+	checkKVsInRange(t, "val", res[2].sst, 50, 75)
+	checkKVsInRange(t, "val", res[3].sst, 75, 100)
+}
+
+func TestMergeNoOverlap(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	for i := 0; i < 25; i++ {
+		builder1.addEntry(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i))
+	}
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+
+	builder2 := newSSTableBuilder()
+	for i := 25; i < 50; i++ {
+		builder2.addEntry(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i))
+	}
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	builder3 := newSSTableBuilder()
+	for i := 50; i < 75; i++ {
+		builder3.addEntry(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i))
+	}
+	sst3, err := builder3.build()
+	require.NoError(t, err)
+
+	builder4 := newSSTableBuilder()
+	for i := 75; i < 100; i++ {
+		builder4.addEntry(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i))
+	}
+	sst4, err := builder4.build()
+	require.NoError(t, err)
+
+	res, err := mergeSSTables(common.DataFormatV1,
+		[][]tableToMerge{{{sst: sst1}, {sst: sst2}}, {{sst: sst3}, {sst: sst4}}}, true,
+		1300, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(res))
+	for i := 0; i < 4; i++ {
+		require.Equal(t, 25, res[i].sst.NumEntries())
+	}
+
+	checkKVsInRange(t, "val", res[0].sst, 0, 25)
+	checkKVsInRange(t, "val", res[1].sst, 25, 50)
+	checkKVsInRange(t, "val", res[2].sst, 50, 75)
+	checkKVsInRange(t, "val", res[3].sst, 75, 100)
+}
+
+func TestOverwriteEntriesWithLaterVersionFirst(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	for i := 0; i < 25; i++ {
+		builder1.addEntryWithVersion(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i), 10)
+	}
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+
+	builder2 := newSSTableBuilder()
+	for i := 25; i < 50; i++ {
+		builder2.addEntryWithVersion(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i), 10)
+	}
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	builder3 := newSSTableBuilder()
+	for i := 25; i < 50; i++ {
+		builder3.addEntryWithVersion(fmt.Sprintf("key%05d", i), fmt.Sprintf("bal%05d", i), 20)
+	}
+	sst3, err := builder3.build()
+	require.NoError(t, err)
+
+	builder4 := newSSTableBuilder()
+	for i := 50; i < 75; i++ {
+		builder4.addEntryWithVersion(fmt.Sprintf("key%05d", i), fmt.Sprintf("bal%05d", i), 20)
+	}
+	sst4, err := builder4.build()
+	require.NoError(t, err)
+
+	res, err := mergeSSTables(common.DataFormatV1,
+		[][]tableToMerge{{{sst: sst1}, {sst: sst2}}, {{sst: sst3}, {sst: sst4}}}, true,
+		maxTableSize, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(res))
+	for i := 0; i < 3; i++ {
+		require.Equal(t, 25, res[i].sst.NumEntries())
+	}
+
+	checkKVsInRange(t, "val", res[0].sst, 0, 25)
+	checkKVsInRange(t, "bal", res[1].sst, 25, 50)
+	checkKVsInRange(t, "bal", res[2].sst, 50, 75)
+}
+
+func TestOverwriteEntriesWithLaterVersionLast(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	for i := 0; i < 25; i++ {
+		builder1.addEntryWithVersion(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i), 10)
+	}
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+
+	builder2 := newSSTableBuilder()
+	for i := 25; i < 50; i++ {
+		builder2.addEntryWithVersion(fmt.Sprintf("key%05d", i), fmt.Sprintf("val%05d", i), 10)
+	}
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	builder3 := newSSTableBuilder()
+	for i := 25; i < 50; i++ {
+		builder3.addEntryWithVersion(fmt.Sprintf("key%05d", i), fmt.Sprintf("bal%05d", i), 20)
+	}
+	sst3, err := builder3.build()
+	require.NoError(t, err)
+
+	builder4 := newSSTableBuilder()
+	for i := 50; i < 75; i++ {
+		builder4.addEntryWithVersion(fmt.Sprintf("key%05d", i), fmt.Sprintf("bal%05d", i), 20)
+	}
+	sst4, err := builder4.build()
+	require.NoError(t, err)
+
+	res, err := mergeSSTables(common.DataFormatV1, [][]tableToMerge{{{sst: sst1}, {sst: sst2}}, {{sst: sst3}, {sst: sst4}}},
+		true, maxTableSize, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(res))
+	for i := 0; i < 3; i++ {
+		require.Equal(t, 25, res[i].sst.NumEntries())
+	}
+
+	checkKVsInRange(t, "val", res[0].sst, 0, 25)
+	checkKVsInRange(t, "bal", res[1].sst, 25, 50)
+	checkKVsInRange(t, "bal", res[2].sst, 50, 75)
+}
+
+func TestMergePreserveTombstones(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	builder1.addEntry("key00000", "val00000")
+	builder1.addTombstone("key00001")
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+
+	builder2 := newSSTableBuilder()
+	builder2.addEntry("key00002", "val00002")
+	builder2.addTombstone("key00003")
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	builder3 := newSSTableBuilder()
+	builder3.addTombstone("key00000")
+	builder3.addEntry("key00001", "val00001")
+	sst3, err := builder3.build()
+	require.NoError(t, err)
+
+	builder4 := newSSTableBuilder()
+	builder4.addTombstone("key00002")
+	builder4.addEntry("key00003", "val00003")
+	sst4, err := builder4.build()
+	require.NoError(t, err)
+
+	res, err := mergeSSTables(common.DataFormatV1,
+		[][]tableToMerge{{{sst: sst1}, {sst: sst2}}, {{sst: sst3}, {sst: sst4}}}, true, maxTableSize,
+		math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	checkKVs(t, res[0].sst, "val", 0, 0, 1, -1, 2, 2, 3, -1)
+}
+
+func TestMergePreserveTombstonesAllEntriesRemoved(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	builder1.addEntryWithVersion("key00000", "val00000", 1)
+	builder1.addTombstoneWithVersion("key00001", 3)
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+
+	builder2 := newSSTableBuilder()
+	builder2.addEntryWithVersion("key00002", "val00002", 1)
+	builder2.addTombstoneWithVersion("key00003", 3)
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	builder3 := newSSTableBuilder()
+	builder3.addTombstoneWithVersion("key00000", 2)
+	builder3.addEntryWithVersion("key00001", "val00001", 2)
+	sst3, err := builder3.build()
+	require.NoError(t, err)
+
+	builder4 := newSSTableBuilder()
+	builder4.addTombstoneWithVersion("key00002", 2)
+	builder4.addEntryWithVersion("key00003", "val00003", 2)
+	sst4, err := builder4.build()
+	require.NoError(t, err)
+
+	res, err := mergeSSTables(common.DataFormatV1, [][]tableToMerge{{{sst: sst1}, {sst: sst2}}, {{sst: sst3}, {sst: sst4}}},
+		true, maxTableSize, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+
+	// just the tombstones should remain
+	checkKVs(t, res[0].sst, "val", 0, -1, 1, -1, 2, -1, 3, -1)
+}
+
+func TestMergePreserveTombstonesNotAllEntriesRemoved(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	builder1.addEntryWithVersion("key00000", "val00000", 1)
+	builder1.addTombstoneWithVersion("key00001", 1)
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+
+	builder2 := newSSTableBuilder()
+	builder2.addEntryWithVersion("key00002", "val00002", 1)
+	builder2.addTombstoneWithVersion("key00003", 1)
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	builder3 := newSSTableBuilder()
+	builder3.addTombstoneWithVersion("key00000", 2)
+	builder3.addEntryWithVersion("key00001", "val00001", 2)
+	sst3, err := builder3.build()
+	require.NoError(t, err)
+
+	builder4 := newSSTableBuilder()
+	builder4.addTombstoneWithVersion("key00002", 2)
+	builder4.addEntryWithVersion("key00003", "val00003", 2)
+	sst4, err := builder4.build()
+	require.NoError(t, err)
+
+	res, err := mergeSSTables(common.DataFormatV1, [][]tableToMerge{{{sst: sst1}, {sst: sst2}}, {{sst: sst3}, {sst: sst4}}},
+		true, maxTableSize, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+
+	checkKVs(t, res[0].sst, "val", 0, -1, 1, 1, 2, -1, 3, 3)
+}
+
+func TestMergeIntoMultipleTables(t *testing.T) {
+	maxTableSize := 1000
+	numTables := 10
+
+	var ssts []*sst.SSTable
+	var tablesToMerge []tableToMerge
+	i := 0
+	for len(ssts) < numTables {
+		builder := newSSTableBuilder()
+		size := 0
+		for {
+			key := fmt.Sprintf("xxxxxxxxxxxxxxxxsssssssskey%05d", i)
+			value := fmt.Sprintf("val%05d", i)
+			builder.addEntryWithVersion(key, value, 1)
+			i++
+			size += 12 + 2*(len(key)+8) + len(value)
+			if size >= maxTableSize {
+				break
+			}
+		}
+		ssTable, err := builder.build()
+		require.NoError(t, err)
+		ssts = append(ssts, ssTable)
+		tablesToMerge = append(tablesToMerge, tableToMerge{sst: ssTable})
+	}
+
+	res, err := mergeSSTables(common.DataFormatV1, [][]tableToMerge{tablesToMerge}, true, maxTableSize, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, numTables, len(res))
+
+	i = 0
+	for j := 0; j < numTables; j++ {
+		iter, err := res[j].sst.NewIterator(nil, nil)
+		require.NoError(t, err)
+		for {
+			valid, curr, err := iter.Next()
+			require.NoError(t, err)
+			if !valid {
+				break
+			}
+			expectedKey := encoding2.EncodeVersion([]byte(fmt.Sprintf("xxxxxxxxxxxxxxxxsssssssskey%05d", i)), 1)
+			expectedValue := []byte(fmt.Sprintf("val%05d", i))
+			require.Equal(t, expectedKey, curr.Key)
+			require.Equal(t, expectedValue, curr.Value)
+			i++
+		}
+	}
+}
+
+func TestMergeSameKeysDifferentVersions(t *testing.T) {
+
+	maxTableSize := 1000
+	numTables := 10
+
+	var ssts []*sst.SSTable
+	var tablesToMerge []tableToMerge
+	i := 10000
+	key := "xxxxxxxxxxxxxxxxsssssssskey00001"
+	// We fill tables with same key but different versions
+	for len(ssts) < numTables {
+		builder := newSSTableBuilder()
+		size := 0
+		for {
+			value := fmt.Sprintf("val%05d", i)
+			builder.addEntryWithVersion(key, value, uint64(i))
+			i--
+			size += 12 + 2*(len(key)+8) + len(value)
+			if size >= maxTableSize {
+				break
+			}
+		}
+		ssTable, err := builder.build()
+		require.NoError(t, err)
+		ssts = append(ssts, ssTable)
+		tablesToMerge = append(tablesToMerge, tableToMerge{sst: ssTable})
+	}
+
+	res, err := mergeSSTables(common.DataFormatV1, [][]tableToMerge{tablesToMerge}, true, maxTableSize, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	// We never split different versions of same key across tables, so one table should be produced.
+	require.Equal(t, 1, len(res))
+
+	i = 10000
+	iter, err := res[0].sst.NewIterator(nil, nil)
+	require.NoError(t, err)
+	for {
+		valid, curr, err := iter.Next()
+		require.NoError(t, err)
+		if !valid {
+			break
+		}
+		expectedKey := encoding2.EncodeVersion([]byte(key), uint64(i))
+		expectedValue := []byte(fmt.Sprintf("val%05d", i))
+		require.Equal(t, expectedKey, curr.Key)
+		require.Equal(t, expectedValue, curr.Value)
+		i--
+	}
+}
+
+func TestMergeNotPreserveTombstonesAllEntriesRemoved(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	builder1.addEntryWithVersion("key00000", "val00000", 1)
+	builder1.addTombstoneWithVersion("key00001", 3)
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+
+	builder2 := newSSTableBuilder()
+	builder2.addEntryWithVersion("key00002", "val00002", 1)
+	builder2.addTombstoneWithVersion("key00003", 3)
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	builder3 := newSSTableBuilder()
+	builder3.addTombstoneWithVersion("key00000", 2)
+	builder3.addEntryWithVersion("key00001", "val00001", 2)
+	sst3, err := builder3.build()
+	require.NoError(t, err)
+
+	builder4 := newSSTableBuilder()
+	builder4.addTombstoneWithVersion("key00002", 2)
+	builder4.addEntryWithVersion("key00003", "val00003", 2)
+	sst4, err := builder4.build()
+	require.NoError(t, err)
+
+	res, err := mergeSSTables(common.DataFormatV1, [][]tableToMerge{{{sst: sst1}, {sst: sst2}}, {{sst: sst3}, {sst: sst4}}},
+		false, maxTableSize, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(res))
+}
+
+func TestMergeNotPreserveTombstonesNotAllEntriesRemoved(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	builder1.addEntryWithVersion("key00000", "val00000", 1)
+	builder1.addTombstoneWithVersion("key00001", 1)
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+
+	builder2 := newSSTableBuilder()
+	builder2.addEntryWithVersion("key00002", "val00002", 1)
+	builder2.addTombstoneWithVersion("key00003", 1)
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	builder3 := newSSTableBuilder()
+	builder3.addTombstoneWithVersion("key00000", 2)
+	builder3.addEntryWithVersion("key00001", "val00001", 2)
+	sst3, err := builder3.build()
+	require.NoError(t, err)
+
+	builder4 := newSSTableBuilder()
+	builder4.addTombstoneWithVersion("key00002", 2)
+	builder4.addEntryWithVersion("key00003", "val00003", 2)
+	sst4, err := builder4.build()
+	require.NoError(t, err)
+
+	res, err := mergeSSTables(common.DataFormatV1, [][]tableToMerge{{{sst: sst1}, {sst: sst2}}, {{sst: sst3}, {sst: sst4}}},
+		false, maxTableSize, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+
+	checkKVs(t, res[0].sst, "val", 1, 1, 3, 3)
+}
+
+func TestMergeDeadVersions(t *testing.T) {
+	builder1 := newSSTableBuilder()
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("key-%05d", i)
+		val := fmt.Sprintf("val-%05d", i)
+		builder1.addEntryWithVersion(key, val, uint64(i))
+	}
+	deadRange1 := VersionRange{
+		VersionStart: 3,
+		VersionEnd:   5,
+	}
+	deadRange2 := VersionRange{
+		VersionStart: 13,
+		VersionEnd:   17,
+	}
+	builder2 := newSSTableBuilder()
+	for i := 10; i < 20; i++ {
+		key := fmt.Sprintf("key-%05d", i)
+		val := fmt.Sprintf("val-%05d", i)
+		builder2.addEntryWithVersion(key, val, uint64(i))
+	}
+	sst1, err := builder1.build()
+	require.NoError(t, err)
+	sst2, err := builder2.build()
+	require.NoError(t, err)
+
+	tableToMerge1 := tableToMerge{
+		deadVersionRanges: []VersionRange{deadRange1, deadRange2},
+		sst:               sst1,
+	}
+	tableToMerge2 := tableToMerge{
+		deadVersionRanges: []VersionRange{deadRange1, deadRange2},
+		sst:               sst2,
+	}
+
+	res, err := mergeSSTables(common.DataFormatV1, [][]tableToMerge{{tableToMerge1}, {tableToMerge2}},
+		false, 3500, math.MaxInt64, "", nil, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+
+	iter, err := res[0].sst.NewIterator(nil, nil)
+	require.NoError(t, err)
+	i := 0
+	for i < 20 {
+		valid, entry, err := iter.Next()
+		require.NoError(t, err)
+		if !valid {
+			break
+		}
+		ver := math.MaxUint64 - binary.BigEndian.Uint64(entry.Key[len(entry.Key)-8:])
+		require.Equal(t, uint64(i), ver)
+
+		keyNoVer := entry.Key[:len(entry.Key)-8]
+		expectedKey := []byte(fmt.Sprintf("key-%05d", i))
+
+		require.Equal(t, expectedKey, keyNoVer)
+
+		i++
+
+		if i == 3 {
+			i = 6
+		} else if i == 13 {
+			i = 18
+		}
+	}
+	valid, _, _ := iter.Next()
+	require.False(t, valid)
+}
+
+func TestScoreHeap(t *testing.T) {
+	testScoreHeap(t, []float64{0.1, 0.5, 0.4, 0, 0.2, 0.3}, []float64{0.5, 0.4, 0.3}, 3)
+	testScoreHeap(t, []float64{0.1, 0.5, 0.4, 0, 0.2, 0.3, 0.7, 0.25, 0.6}, []float64{0.7, 0.6}, 2)
+	testScoreHeap(t, []float64{0.1, 0.5, 0.4, 0, 0.2, 0.3, 0.7, 0.25, 0.6}, []float64{0.7, 0.6, 0.5, 0.4, 0.3, 0.25, 0.2, 0.1, 0}, 9)
+}
+
+func testScoreHeap(t *testing.T, in []float64, expected []float64, n int) {
+	h := &scoreHeap{}
+	heap.Init(h)
+	for _, ratio := range in {
+		heap.Push(h, scoreEntry{
+			tableEntry: &TableEntry{DeleteRatio: ratio},
+			score:      ratio,
+		})
+		if h.Len() > n {
+			heap.Pop(h)
+		}
+	}
+	out := make([]float64, h.Len())
+	for i := h.Len() - 1; i >= 0; i-- {
+		se := heap.Pop(h).(scoreEntry)
+		out[i] = se.score
+	}
+
+	require.Equal(t, expected, out)
+}
+
+func TestRemoveDeadVersionsIterator(t *testing.T) {
+	si := &iteration.StaticIterator{}
+	numEntries := 1000
+	for i := 0; i < numEntries; i++ {
+		key := []byte(fmt.Sprintf("key-%05d", i))
+		val := []byte(fmt.Sprintf("val-%05d", i))
+		key = encoding2.EncodeVersion(key, uint64(i))
+		si.AddKV(key, val)
+	}
+	deadRange1 := VersionRange{
+		VersionStart: 333,
+		VersionEnd:   555,
+	}
+	deadRange2 := VersionRange{
+		VersionStart: 777,
+		VersionEnd:   888,
+	}
+	me := NewRemoveDeadVersionsIterator(si, []VersionRange{deadRange1, deadRange2})
+	i := 0
+	for i < numEntries {
+		valid, entry, err := me.Next()
+		require.NoError(t, err)
+		if !valid {
+			break
+		}
+		ver := math.MaxUint64 - binary.BigEndian.Uint64(entry.Key[len(entry.Key)-8:])
+		require.Equal(t, uint64(i), ver)
+
+		keyNoVer := entry.Key[:len(entry.Key)-8]
+		expectedKey := []byte(fmt.Sprintf("key-%05d", i))
+
+		require.Equal(t, expectedKey, keyNoVer)
+
+		i++
+
+		if i == 333 {
+			i = 556
+		} else if i == 777 {
+			i = 889
+		}
+	}
+}
+
+type testSlabRetentions struct {
+	lock       sync.Mutex
+	retentions map[int]time.Duration
+}
+
+func (t *testSlabRetentions) GetSlabRetention(slabID int) (time.Duration, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.retentions[slabID], nil
+}
+
+func createExpiredEntryKey(slabID int, i int) []byte {
+	key := []byte("xxxxxxxxxxxxxxxx")                           // partition hash
+	key = encoding2.AppendUint64ToBufferBE(key, uint64(slabID)) // slab id
+	return append(key, []byte(fmt.Sprintf("key-%04d", i))...)
+}
+
+func createExpiredValue(slabID int, i int) []byte {
+	return []byte(fmt.Sprintf("val-%d-%d", slabID, i))
+}
+
+func TestRemoveExpiredEntriesIterator(t *testing.T) {
+	si := &iteration.StaticIterator{}
+
+	retentions := &testSlabRetentions{retentions: map[int]time.Duration{}}
+
+	numSlabs := 10
+	entriesPerSlab := 10
+	for i := 0; i < numSlabs; i++ {
+		for j := 0; j < entriesPerSlab; j++ {
+			key := createExpiredEntryKey(i, j)
+			value := createExpiredValue(i, j)
+			si.AddKV(key, value)
+		}
+		// even numbered slabs have short retention, odd ones have a long retention
+		if i%2 == 0 {
+			retentions.retentions[i] = 1 * time.Hour
+		} else {
+			retentions.retentions[i] = 5 * time.Hour
+		}
+	}
+
+	// No entries expired
+	creationTime := time.Now().UTC().UnixMilli()
+	now := creationTime + 30*time.Minute.Milliseconds()
+	iter := NewRemoveExpiredEntriesIterator(si, uint64(creationTime), uint64(now), retentions)
+	for i := 0; i < numSlabs; i++ {
+		for j := 0; j < entriesPerSlab; j++ {
+			valid, curr, err := iter.Next()
+			require.NoError(t, err)
+			require.True(t, valid)
+			expectedKey := createExpiredEntryKey(i, j)
+			expectedVal := createExpiredValue(i, j)
+			require.Equal(t, expectedKey, curr.Key)
+			require.Equal(t, expectedVal, curr.Value)
+		}
+	}
+
+	// Even slabs expired
+	si.Reset()
+	now = creationTime + 1*time.Hour.Milliseconds()
+	iter = NewRemoveExpiredEntriesIterator(si, uint64(creationTime), uint64(now), retentions)
+	for i := 0; i < numSlabs; i++ {
+		if i%2 == 0 {
+			continue
+		}
+		for j := 0; j < entriesPerSlab; j++ {
+			valid, curr, err := iter.Next()
+			require.NoError(t, err)
+			require.True(t, valid)
+			expectedKey := createExpiredEntryKey(i, j)
+			expectedVal := createExpiredValue(i, j)
+			require.Equal(t, expectedKey, curr.Key)
+			require.Equal(t, expectedVal, curr.Value)
+		}
+	}
+
+	// All slabs expired
+	si.Reset()
+	now = creationTime + 5*time.Hour.Milliseconds()
+	iter = NewRemoveExpiredEntriesIterator(si, uint64(creationTime), uint64(now), retentions)
+	valid, _, _ := iter.Next()
+	require.False(t, valid)
+}
+
+func TestSerializeDeserializeCompactionJob(t *testing.T) {
+	job1 := CompactionJob{
+		id:        uuid.New().String(),
+		levelFrom: 3,
+		tables: [][]tableToCompact{
+			{
+				{level: 2, table: &TableEntry{
+					SSTableID:   []byte("sst1"),
+					RangeStart:  []byte("key0"),
+					RangeEnd:    []byte("key9"),
+					DeleteRatio: 0.43,
+				},
+				},
+				{level: 2, table: &TableEntry{
+					SSTableID:   []byte("sst2"),
+					RangeStart:  []byte("key9"),
+					RangeEnd:    []byte("key10"),
+					DeleteRatio: 0.12,
+				}},
+			},
+			{
+				{level: 3, table: &TableEntry{
+					SSTableID:   []byte("sst3"),
+					RangeStart:  []byte("key3"),
+					RangeEnd:    []byte("key12"),
+					DeleteRatio: 0.32,
+				}},
+				{level: 3, table: &TableEntry{
+					SSTableID:   []byte("sst4"),
+					RangeStart:  []byte("key20"),
+					RangeEnd:    []byte("key30"),
+					DeleteRatio: 0.14,
+				}},
+			},
+		},
+		isMove:             true,
+		preserveTombstones: true,
+		scheduleTime:       123456,
+		serverTime:         32476374634,
+	}
+
+	buff := job1.Serialize(nil)
+	var job2 CompactionJob
+	job2.Deserialize(buff, 0)
+	require.Equal(t, job1, job2)
+
+	job1.isMove = false
+	buff = job1.Serialize(nil)
+	var job3 CompactionJob
+	job3.Deserialize(buff, 0)
+	require.Equal(t, job1, job3)
+}
+
+func TestSerializeDeserializeCompactionResult(t *testing.T) {
+	res := CompactionResult{
+		id: uuid.New().String(),
+		newTables: []TableEntry{
+			{
+				SSTableID:   []byte("sst1"),
+				RangeStart:  []byte("key0"),
+				RangeEnd:    []byte("key9"),
+				DeleteRatio: 0.11,
+			},
+			{
+				SSTableID:   []byte("sst2"),
+				RangeStart:  []byte("key10"),
+				RangeEnd:    []byte("key19"),
+				DeleteRatio: 0.21,
+			},
+		},
+	}
+	var buff []byte
+	buff = res.Serialize(buff)
+
+	var res2 CompactionResult
+	res2.Deserialize(buff, 0)
+
+	require.Equal(t, res, res2)
+}
+
+func TestCompactionTriggers(t *testing.T) {
+	l0Trigger := 8
+	l1Trigger := 10
+	levelMult := 10
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = l0Trigger
+		cfg.L1CompactionTrigger = l1Trigger
+		cfg.LevelMultiplier = levelMult
+	})
+	defer tearDown(t)
+
+	require.Equal(t, l0Trigger, lm.levelMaxTablesTrigger(0))
+	require.Equal(t, l1Trigger, lm.levelMaxTablesTrigger(1))
+	expected := l1Trigger
+	for i := 2; i < 10; i++ {
+		expected *= levelMult
+		require.Equal(t, expected, lm.levelMaxTablesTrigger(i))
+	}
+}
+
+func checkKVsInRange(t *testing.T, valPrefix string, sst *sst.SSTable, keyStart int, keyEnd int) {
+	var r []int
+	for i := keyStart; i < keyEnd; i++ {
+		r = append(r, i, i)
+	}
+	checkKVs(t, sst, valPrefix, r...)
+}
+
+func checkKVs(t *testing.T, sst *sst.SSTable, valPrefix string, keys ...int) {
+	iter, err := sst.NewIterator(nil, nil)
+	require.NoError(t, err)
+	for i := 0; i < len(keys); i += 2 {
+		k := keys[i]
+		v := keys[i+1]
+		valid, curr, err := iter.Next()
+		require.NoError(t, err)
+		require.True(t, valid)
+		require.Equal(t, fmt.Sprintf("key%05d", k), string(curr.Key[:len(curr.Key)-8]))
+		if v == -1 {
+			// tombstone
+			require.Nil(t, curr.Value)
+		} else {
+			require.Equal(t, fmt.Sprintf("%s%05d", valPrefix, v), string(curr.Value))
+		}
+	}
+}
+
+func newSSTableBuilder() *ssTableBuilder {
+	return &ssTableBuilder{
+		si: &iteration.StaticIterator{},
+	}
+}
+
+type ssTableBuilder struct {
+	si *iteration.StaticIterator
+}
+
+func (tb *ssTableBuilder) addEntry(key string, val string) {
+	kb := encoding2.EncodeVersion([]byte(key), 0)
+	tb.si.AddKV(kb, []byte(val))
+}
+
+func (tb *ssTableBuilder) addEntryWithVersion(key string, val string, version uint64) {
+	kb := encoding2.EncodeVersion([]byte(key), version)
+	tb.si.AddKV(kb, []byte(val))
+}
+
+func (tb *ssTableBuilder) addTombstone(key string) {
+	kb := encoding2.EncodeVersion([]byte(key), 0)
+	tb.si.AddKV(kb, nil)
+}
+
+func (tb *ssTableBuilder) addTombstoneWithVersion(key string, version uint64) {
+	kb := encoding2.EncodeVersion([]byte(key), version)
+	tb.si.AddKV(kb, nil)
+}
+
+func (tb *ssTableBuilder) build() (*sst.SSTable, error) {
+	ssTable, _, _, _, _, err := sst.BuildSSTable(common.DataFormatV1, 0, 0, tb.si)
+	if err != nil {
+		return nil, err
+	}
+	return ssTable, nil
+}
+
+func createTableEntry(tableName string, rangeStart int, rangeEnd int) TableEntry {
+	return createTableEntryWithDeleteRatio(tableName, rangeStart, rangeEnd, 0)
+}
+
+func createTableEntryWithDeleteRatio(tableName string, rangeStart int, rangeEnd int, deleteRatio float64) TableEntry {
+	return TableEntry{
+		SSTableID:   []byte(tableName),
+		RangeStart:  encoding2.EncodeVersion([]byte(fmt.Sprintf("key%05d", rangeStart)), 0),
+		RangeEnd:    encoding2.EncodeVersion([]byte(fmt.Sprintf("key%05d", rangeEnd)), 0),
+		DeleteRatio: deleteRatio,
+	}
+}
+
+func trimVersion(key []byte) []byte {
+	return key[:len(key)-8]
+}
+
+func TestNoPreserveTombstonesWhenTableCompactedToLastLevelVersionsFlushed(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+
+	// We set last flushed to 1, so canCompact = true and tombstones are removed on last level
+	err := lm.StoreLastFlushedVersion(1)
+	require.NoError(t, err)
+
+	sst1 := createTableEntryWithDeleteRatio("sst1", 0, 9, 0.5)
+	sst2 := createTableEntryWithDeleteRatio("sst2", 10, 19, 0.5)
+
+	populateLevel(t, lm, 1, sst1, sst2)
+
+	err = lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, job.levelFrom)
+	require.Equal(t, false, job.preserveTombstones)
+}
+
+func TestNoPreserveTombstonesWhenTableCompactedToLastLevelVersionsNotFlushed(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+	})
+	defer tearDown(t)
+
+	// We don't store last flushed version, so it's == -1, so preserveTombstones will be true as we cannot compact
+	sst1 := createTableEntryWithDeleteRatio("sst1", 0, 9, 0.5)
+	sst2 := createTableEntryWithDeleteRatio("sst2", 10, 19, 0.5)
+
+	populateLevel(t, lm, 1, sst1, sst2)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	job, err := getJob(lm)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, job.levelFrom)
+	require.Equal(t, true, job.preserveTombstones)
+}
+
+func TestClosePollersForConnectionID(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+		cfg.CompactionJobTimeout = time.Hour
+	})
+	defer tearDown(t)
+
+	sst1 := createTableEntryWithDeleteRatio("sst1", 0, 9, 0.5)
+	sst2 := createTableEntryWithDeleteRatio("sst2", 10, 19, 0.5)
+
+	populateLevel(t, lm, 1, sst1, sst2)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	ch := make(chan pollResult, 1)
+	connectionID := 100
+	lm.pollForJob(connectionID, func(job *CompactionJob, err error) {
+		ch <- pollResult{job, err}
+	})
+
+	res := <-ch
+	require.NoError(t, res.err)
+	require.NotNil(t, res.job)
+
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 1, stats.InProgressJobs)
+	require.Equal(t, 0, stats.QueuedJobs)
+
+	lm.connectionClosed(connectionID)
+
+	// job should be cancelled and returned to queue
+	ok, err := testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.InProgressJobs == 0 && stats.QueuedJobs == 1, nil
+	}, 5*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestJobCreatedWithLastFlushedVersion(t *testing.T) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, func(cfg *conf.Config) {
+		cfg.L1CompactionTrigger = 1
+		cfg.CompactionJobTimeout = time.Hour
+	})
+	defer tearDown(t)
+
+	sst1 := createTableEntryWithDeleteRatio("sst1", 0, 9, 0.5)
+	sst2 := createTableEntryWithDeleteRatio("sst2", 10, 19, 0.5)
+	populateLevel(t, lm, 1, sst1, sst2)
+
+	err := lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	stats := lm.GetCompactionStats()
+	require.Equal(t, 1, stats.QueuedJobs)
+	job, err := getJob(lm)
+	require.NoError(t, err)
+	require.Equal(t, int64(-1), job.lastFlushedVersion)
+
+	err = lm.StoreLastFlushedVersion(100)
+	require.NoError(t, err)
+
+	sst3 := createTableEntryWithDeleteRatio("sst3", 20, 29, 0.5)
+	populateLevel(t, lm, 1, sst3)
+	err = lm.MaybeScheduleCompaction()
+	require.NoError(t, err)
+
+	stats = lm.GetCompactionStats()
+	require.Equal(t, 1, stats.QueuedJobs)
+	job, err = getJob(lm)
+	require.NoError(t, err)
+	require.Equal(t, int64(100), job.lastFlushedVersion)
+}
+
+func TestCompactionChooseOldestTablesToCompact(t *testing.T) {
+	entries := []*TableEntry{
+		createTE(0, 3000, 0),
+		createTE(0, 7000, 0),
+		createTE(0, 1000, 0),
+		createTE(0, 5000, 0),
+		createTE(0, 4000, 0),
+		createTE(0, 6000, 0),
+		createTE(0, 2000, 0),
+		createTE(0, 9000, 0),
+		createTE(0, 8000, 0),
+	}
+	levEntry := createLevelEntryForTableEntries(entries)
+	res, err := chooseTablesToCompactFromLevel(levEntry, 3)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(res))
+	require.Equal(t, entries[2], res[0])
+	require.Equal(t, entries[6], res[1])
+	require.Equal(t, entries[0], res[2])
+
+	res, err = chooseTablesToCompactFromLevel(levEntry, 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.Equal(t, entries[2], res[0])
+}
+
+func TestCompactionChooseHighestDeleteRatiosToCompact(t *testing.T) {
+	entries := []*TableEntry{
+		createTE(0.4, 0, 0),
+		createTE(0.1, 0, 0),
+		createTE(0.9, 0, 0),
+		createTE(0.7, 0, 0),
+		createTE(0, 0, 0),
+		createTE(0.3, 0, 0),
+		createTE(0.2, 0, 0),
+		createTE(0.6, 0, 0),
+		createTE(0.8, 0, 0),
+	}
+	levEntry := createLevelEntryForTableEntries(entries)
+	res, err := chooseTablesToCompactFromLevel(levEntry, 3)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(res))
+	require.Equal(t, entries[2], res[0])
+	require.Equal(t, entries[8], res[1])
+	require.Equal(t, entries[3], res[2])
+
+	res, err = chooseTablesToCompactFromLevel(levEntry, 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.Equal(t, entries[2], res[0])
+}
+
+func TestCompactionChooseHighestNumPrefixDeletesToCompact(t *testing.T) {
+	entries := []*TableEntry{
+		createTE(0, 0, 0),
+		createTE(0, 0, 0),
+		createTE(0, 0, 1),
+		createTE(0, 0, 0),
+	}
+	res, err := chooseTablesToCompactFromLevel(createLevelEntryForTableEntries(entries), 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.Equal(t, entries[2], res[0])
+}
+
+func TestCompactionChooseHighestScoreToCompact(t *testing.T) {
+	entries := []*TableEntry{
+		createTE(0, 1000, 0), // 1
+		createTE(0, 9000, 0), // 0
+		createTE(1, 1000, 0), // 2
+		createTE(1, 9000, 0), // 1
+		createTE(0, 9000, 1), // 3
+	}
+	res, err := chooseTablesToCompactFromLevel(createLevelEntryForTableEntries(entries), 5)
+	require.NoError(t, err)
+	require.Equal(t, 5, len(res))
+	require.Equal(t, entries[4], res[0])
+	require.Equal(t, entries[2], res[1])
+	require.Equal(t, entries[3], res[2])
+	require.Equal(t, entries[0], res[3])
+	require.Equal(t, entries[1], res[4])
+}
+
+func createTE(deleteRatio float64, addedTime uint64, numPrefixDeletes int) *TableEntry {
+	return &TableEntry{
+		SSTableID:        []byte(uuid.New().String()),
+		RangeStart:       []byte(uuid.New().String()),
+		RangeEnd:         []byte(uuid.New().String()),
+		MinVersion:       123,
+		MaxVersion:       345,
+		DeleteRatio:      deleteRatio,
+		AddedTime:        addedTime,
+		NumEntries:       23,
+		Size:             10191,
+		NumPrefixDeletes: uint32(numPrefixDeletes),
+	}
+}
+
+func createLevelEntryForTableEntries(entries []*TableEntry) *levelEntry {
+	levEntry := &levelEntry{}
+	for i, te := range entries {
+		levEntry.InsertAt(i, te)
+	}
+	return levEntry
+}

--- a/lsm/compaction_test.go
+++ b/lsm/compaction_test.go
@@ -905,7 +905,7 @@ func checkLevelEntries(t *testing.T, lm *Manager, level int, entries ...TableEnt
 	levEntry := lm.GetLevelEntry(level)
 	require.Equal(t, len(entries), len(levEntry.tableEntries))
 	for i, expectedTe := range entries {
-		te := levEntry.tableEntries[i].Get(levEntry)
+		te := getTableEntry(lm, levEntry.tableEntries[i], levEntry)
 		require.Equal(t, expectedTe, *te)
 	}
 }

--- a/lsm/compaction_worker.go
+++ b/lsm/compaction_worker.go
@@ -1,0 +1,530 @@
+package lsm
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/asl/conf"
+	"github.com/spirit-labs/tektite/asl/errwrap"
+	"github.com/spirit-labs/tektite/common"
+	iteration2 "github.com/spirit-labs/tektite/iteration"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/spirit-labs/tektite/tabcache"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+func NewCompactionWorkerService(cfg *conf.Config, levelMgrClientFactory ClientFactory, tableCache *tabcache.Cache,
+	objStoreClient objstore.Client, retentions bool) *CompactionWorkerService {
+	return &CompactionWorkerService{
+		cfg:                   cfg,
+		levelMgrClientFactory: levelMgrClientFactory,
+		tableCache:            tableCache,
+		objStoreClient:        objStoreClient,
+		retentions:            retentions,
+	}
+}
+
+type CompactionWorkerService struct {
+	cfg                   *conf.Config
+	levelMgrClientFactory ClientFactory
+	tableCache            *tabcache.Cache
+	objStoreClient        objstore.Client
+	workers               []*compactionWorker
+	started               bool
+	lock                  sync.Mutex
+	gotPrefixRetentions   bool
+	retentions            bool
+}
+
+const workerRetryInterval = 100 * time.Millisecond
+
+func (c *CompactionWorkerService) Start() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.started {
+		return nil
+	}
+	for i := 0; i < c.cfg.CompactionWorkerCount; i++ {
+		worker := &compactionWorker{
+			cws:            c,
+			client:         c.levelMgrClientFactory.CreateLevelManagerClient(),
+			slabRetentions: map[int]time.Duration{},
+		}
+		c.workers = append(c.workers, worker)
+		worker.start()
+	}
+	c.started = true
+	return nil
+}
+
+func (c *CompactionWorkerService) Stop() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if !c.started {
+		return nil
+	}
+	var chans []chan struct{}
+	for _, worker := range c.workers {
+		// stop them in parallel - for quicker shutdown
+		theWorker := worker
+		ch := make(chan struct{}, 1)
+		chans = append(chans, ch)
+		common.Go(func() {
+			theWorker.stop()
+			ch <- struct{}{}
+		})
+	}
+	for _, ch := range chans {
+		<-ch
+	}
+	c.started = false
+	return nil
+}
+
+type compactionWorker struct {
+	cws            *CompactionWorkerService
+	started        atomic.Bool
+	stopWg         sync.WaitGroup
+	client         Client
+	slabRetentions map[int]time.Duration
+}
+
+func (c *compactionWorker) GetSlabRetention(slabID int) (time.Duration, error) {
+	// we cache the slab retentions
+	ret, ok := c.slabRetentions[slabID]
+	if ok {
+		return ret, nil
+	}
+	ret, err := c.client.GetSlabRetention(slabID)
+	if err != nil {
+		return 0, err
+	}
+	c.slabRetentions[slabID] = ret
+	return ret, nil
+}
+
+func (c *compactionWorker) start() {
+	c.started.Store(true)
+	c.stopWg.Add(1)
+	common.Go(c.loop)
+}
+
+func (c *compactionWorker) stop() {
+	if err := c.client.Stop(); err != nil {
+		log.Warnf("failed to stop levelMgr client: %v", err)
+	}
+	c.started.Store(false)
+	c.stopWg.Wait()
+}
+
+func (c *compactionWorker) loop() {
+	defer c.stopWg.Done()
+	for c.started.Load() {
+		job, err := c.client.PollForJob()
+		if err != nil {
+			var tErr common.TektiteError
+			if errwrap.As(err, &tErr) {
+				if tErr.Code == common.Unavailable || tErr.Code == common.LevelManagerNotLeaderNode {
+					// transient unavailability
+					time.Sleep(workerRetryInterval)
+					continue
+				}
+				if tErr.Code == common.CompactionPollTimeout {
+					// OK
+					continue
+				}
+			}
+			log.Errorf("error in polling for compaction job: %v", err)
+			continue
+		}
+		for c.started.Load() {
+			registrations, deRegistrations, err := c.processJob(job)
+			if err == nil {
+				regBatch := RegistrationBatch{
+					Compaction:      true,
+					JobID:           job.id,
+					Registrations:   registrations,
+					DeRegistrations: deRegistrations,
+				}
+				err = c.client.ApplyChanges(regBatch)
+				if err == nil {
+					// success
+					break
+				}
+			}
+			var tErr common.TektiteError
+			if errwrap.As(err, &tErr) {
+				if tErr.Code == common.Unavailable || tErr.Code == common.LevelManagerNotLeaderNode {
+					// transient unavailability - retry after delay
+					log.Debugf("transient error in compaction. will retry: %v", err)
+					time.Sleep(workerRetryInterval)
+					continue
+				}
+			}
+			log.Warnf("failed to process compaction:%v", err)
+			break
+		}
+	}
+}
+
+func (c *compactionWorker) processJob(job *CompactionJob) ([]RegistrationEntry, []RegistrationEntry, error) {
+	if job.isMove {
+		if len(job.tables) != 1 {
+			panic("move requires single run to move")
+		}
+		registrations, deRegistrations := c.moveTables(job.tables[0], job.levelFrom, job.preserveTombstones)
+		return registrations, deRegistrations, nil
+	}
+	start := time.Now()
+	tablesInMerge := 0
+	for _, overlapping := range job.tables {
+		tablesInMerge += len(overlapping)
+	}
+	var maxAddedTime uint64
+	tablesToMerge := make([][]tableToMerge, len(job.tables))
+	for i, overlapping := range job.tables {
+		tables := make([]tableToMerge, len(overlapping))
+		for j, t := range overlapping {
+			ssTable, err := c.cws.tableCache.GetSSTable(t.table.SSTableID)
+			if err != nil {
+				return nil, nil, err
+			}
+			if ssTable == nil {
+				return nil, nil, errwrap.Errorf("cannot process compaction job as cannot find sstable: %v (%s)", t.table.SSTableID,
+					string(t.table.SSTableID))
+			}
+			tables[j] = tableToMerge{
+				deadVersionRanges: t.table.DeadVersionRanges,
+				sst:               ssTable,
+				id:                t.table.SSTableID,
+			}
+			if t.table.AddedTime > maxAddedTime {
+				// We compute the maxAddedTime time - this is used for the AddedTime of any new sstables created.
+				maxAddedTime = t.table.AddedTime
+			}
+		}
+		tablesToMerge[i] = tables
+	}
+	mergeStart := time.Now()
+	var retProvider RetentionProvider
+	if c.cws.retentions {
+		retProvider = c
+	}
+	infos, err := mergeSSTables(common.DataFormatV1, tablesToMerge, job.preserveTombstones,
+		c.cws.cfg.CompactionMaxSSTableSize, job.lastFlushedVersion, job.id, retProvider, job.serverTime)
+	if err != nil {
+		return nil, nil, err
+	}
+	mergeDur := time.Now().Sub(mergeStart)
+	log.Debugf("merge for job %s took %d ms", job.id, mergeDur.Milliseconds())
+	// Now push the tables to the cloud store
+	var ids []sst.SSTableID
+	for _, info := range infos {
+		id := []byte(fmt.Sprintf("sst-%s", uuid.New().String()))
+		log.Debugf("compaction job %s created sstable %v", job.id, id)
+		ids = append(ids, id)
+		for {
+			tableBytes := info.sst.Serialize()
+			// Add to object store
+			err := objstore.PutWithTimeout(c.cws.objStoreClient, c.cws.cfg.BucketName, string(id), tableBytes, objstore.DefaultCallTimeout)
+			if err == nil {
+				// Add to the local cache
+				err = c.cws.tableCache.AddSSTableWithMaxAge(id, info.sst)
+				if err != nil {
+					panic(err) // never happens
+				}
+				break
+			}
+			if !common.IsUnavailableError(err) {
+				return nil, nil, err
+			}
+			log.Debugf("failed to push compacted table, will retry: %v", err)
+			time.Sleep(c.cws.cfg.SSTablePushRetryDelay)
+		}
+	}
+	var tableEntries []TableEntry
+	for i, info := range infos {
+		tableEntries = append(tableEntries, TableEntry{
+			SSTableID:        ids[i],
+			RangeStart:       info.rangeStart,
+			RangeEnd:         info.rangeEnd,
+			MinVersion:       info.minVersion,
+			MaxVersion:       info.maxVersion,
+			DeleteRatio:      info.deleteRatio,
+			NumEntries:       uint64(info.sst.NumEntries()),
+			Size:             uint64(info.sst.SizeBytes()),
+			AddedTime:        maxAddedTime,
+			NumPrefixDeletes: info.numPrefixDeletes,
+		})
+		log.Debugf("compaction %s created table %v delete ratio %f preserve tombstones %t", job.id, ids[i], info.deleteRatio,
+			job.preserveTombstones)
+	}
+	registrations, deRegistrations := changesToApply(tableEntries, job)
+	dur := time.Now().Sub(start)
+	log.Debugf("compaction job %s took %d ms to process on worker %p", job.id, dur.Milliseconds(), c)
+	return registrations, deRegistrations, nil
+}
+
+func changesToApply(newTables []TableEntry, job *CompactionJob) ([]RegistrationEntry, []RegistrationEntry) {
+	var registrations []RegistrationEntry
+	for _, newTable := range newTables {
+		registrations = append(registrations, RegistrationEntry{
+			Level:            job.levelFrom + 1,
+			TableID:          newTable.SSTableID,
+			KeyStart:         newTable.RangeStart,
+			KeyEnd:           newTable.RangeEnd,
+			MinVersion:       newTable.MinVersion,
+			MaxVersion:       newTable.MaxVersion,
+			DeleteRatio:      newTable.DeleteRatio,
+			NumEntries:       newTable.NumEntries,
+			TableSize:        newTable.Size,
+			AddedTime:        newTable.AddedTime,
+			NumPrefixDeletes: newTable.NumPrefixDeletes,
+		})
+	}
+	var deRegistrations []RegistrationEntry
+	for _, overlapping := range job.tables {
+		for _, ssTable := range overlapping {
+			deRegistrations = append(deRegistrations, RegistrationEntry{
+				Level:            ssTable.level,
+				TableID:          ssTable.table.SSTableID,
+				KeyStart:         ssTable.table.RangeStart,
+				KeyEnd:           ssTable.table.RangeEnd,
+				MinVersion:       ssTable.table.MinVersion,
+				MaxVersion:       ssTable.table.MaxVersion,
+				DeleteRatio:      ssTable.table.DeleteRatio,
+				NumEntries:       ssTable.table.NumEntries,
+				TableSize:        ssTable.table.Size,
+				NumPrefixDeletes: ssTable.table.NumPrefixDeletes,
+			})
+		}
+	}
+	return registrations, deRegistrations
+}
+
+// no overlap, so we can move tables directly from one level to another without merging anything
+func (c *compactionWorker) moveTables(tables []tableToCompact, fromLevel int, preserveTombstones bool) ([]RegistrationEntry, []RegistrationEntry) {
+	var registrations []RegistrationEntry
+	for _, tableToCompact := range tables {
+		if tableToCompact.table.DeleteRatio == float64(1) && !preserveTombstones {
+			// The table is just deletes, and we're moving it into the last level - we can just drop it
+		} else {
+			registrations = append(registrations, RegistrationEntry{
+				Level:       fromLevel + 1,
+				TableID:     tableToCompact.table.SSTableID,
+				KeyStart:    tableToCompact.table.RangeStart,
+				KeyEnd:      tableToCompact.table.RangeEnd,
+				MinVersion:  tableToCompact.table.MinVersion,
+				MaxVersion:  tableToCompact.table.MaxVersion,
+				DeleteRatio: tableToCompact.table.DeleteRatio,
+				NumEntries:  tableToCompact.table.NumEntries,
+				TableSize:   tableToCompact.table.Size,
+				AddedTime:   tableToCompact.table.AddedTime,
+			})
+		}
+	}
+	var deRegistrations []RegistrationEntry
+	for _, tableToCompact := range tables {
+		deRegistrations = append(deRegistrations, RegistrationEntry{
+			Level:       fromLevel,
+			TableID:     tableToCompact.table.SSTableID,
+			KeyStart:    tableToCompact.table.RangeStart,
+			KeyEnd:      tableToCompact.table.RangeEnd,
+			DeleteRatio: tableToCompact.table.DeleteRatio,
+			NumEntries:  tableToCompact.table.NumEntries,
+			TableSize:   tableToCompact.table.Size,
+		})
+	}
+	return registrations, deRegistrations
+}
+
+type tableToMerge struct {
+	deadVersionRanges []VersionRange
+	sst               *sst.SSTable
+	id                sst.SSTableID
+}
+
+func mergeSSTables(format common.DataFormat, tables [][]tableToMerge, preserveTombstones bool, maxTableSize int,
+	lastFlushedVersion int64, jobID string, retentionProvider RetentionProvider, serverTime uint64) ([]ssTableInfo, error) {
+
+	totEntries := 0
+	chainIters := make([]iteration2.Iterator, len(tables))
+	for i, overlapping := range tables {
+		sourceIters := make([]iteration2.Iterator, len(overlapping))
+		for j, table := range overlapping {
+			sstIter, err := table.sst.NewIterator(nil, nil)
+			log.Debugf("mergingSSTables with dead version range %v", table.deadVersionRanges)
+			if len(table.deadVersionRanges) > 0 {
+				sstIter = NewRemoveDeadVersionsIterator(sstIter, table.deadVersionRanges)
+			}
+			if retentionProvider != nil {
+				sstIter = NewRemoveExpiredEntriesIterator(sstIter, table.sst.CreationTime(), serverTime, retentionProvider)
+			}
+			sourceIters[j] = sstIter
+
+			if err != nil {
+				return nil, err
+			}
+			totEntries += table.sst.NumEntries()
+		}
+		chainIter := iteration2.NewChainingIterator(sourceIters)
+		chainIters[i] = chainIter
+	}
+
+	var minNonCompactableVersion uint64
+	if lastFlushedVersion == -1 {
+		// Nothing flushed yet, no versions can be overwritten
+		minNonCompactableVersion = 0
+	} else {
+		// We can only overwrite older versions of same key if version < lastFlushedVersion
+		// This ensures we don't lose any keys that we need after rolling back to lastFlushedVersion on failure
+		minNonCompactableVersion = uint64(lastFlushedVersion)
+	}
+	mi, err := iteration2.NewCompactionMergingIterator(chainIters, preserveTombstones, minNonCompactableVersion)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("compaction created merging iterator: %p with minnoncompactable version %d for job %s",
+		mi, minNonCompactableVersion, jobID)
+
+	mergeResults := make([]common.KV, 0, totEntries)
+	for {
+		valid, curr, err := mi.Next()
+		if err != nil {
+			return nil, err
+		}
+		if !valid {
+			break
+		}
+		mergeResults = append(mergeResults, curr)
+	}
+
+	size := 0
+	iLast := 0
+	var outTables []ssTableInfo
+	var lastKeyNoVersion []byte
+	for i, curr := range mergeResults {
+
+		k := curr.Key
+		size += 12 + 2*len(k) + len(curr.Value)
+
+		isLast := i == len(mergeResults)-1
+
+		keyNoVersion := k[:len(k)-8]
+		if lastKeyNoVersion != nil && bytes.Equal(lastKeyNoVersion, keyNoVersion) && !isLast {
+			// If keys only differ by version they must not be split across different sstables
+			continue
+		}
+		lastKeyNoVersion = keyNoVersion
+
+		// estimate of how much space an entry takes up in the sstable (data and index)
+
+		if size >= maxTableSize || isLast {
+			iter := newSliceIterator(mergeResults[iLast : i+1])
+			ssTable, smallestKey, largestKey, minVersion, maxVersion, err := sst.BuildSSTable(format, size, i+1-iLast,
+				iter)
+			if err != nil {
+				return nil, err
+			}
+			outTables = append(outTables, ssTableInfo{
+				sst:              ssTable,
+				rangeStart:       smallestKey,
+				rangeEnd:         largestKey,
+				minVersion:       minVersion,
+				maxVersion:       maxVersion,
+				deleteRatio:      ssTable.DeleteRatio(),
+				numPrefixDeletes: uint32(ssTable.NumPrefixDeletes()),
+			})
+			iLast = i + 1
+			size = 0
+		}
+	}
+
+	log.Debugf("compaction job merged %d entries into %d entries", totEntries, len(mergeResults))
+
+	return outTables, nil
+}
+
+func validateRegBatch(regBatch RegistrationBatch, objStore objstore.Client, bucketName string) {
+	for _, entry := range regBatch.Registrations {
+		validateRegEntry(entry, objStore, bucketName)
+	}
+	for _, entry := range regBatch.DeRegistrations {
+		validateRegEntry(entry, objStore, bucketName)
+	}
+}
+
+func validateRegEntry(entry RegistrationEntry, objStore objstore.Client, bucketName string) {
+	buff, err := objstore.GetWithTimeout(objStore, bucketName, string(entry.TableID), objstore.DefaultCallTimeout)
+	if err != nil {
+		panic(err)
+	}
+	table := &sst.SSTable{}
+	table.Deserialize(buff, 0)
+	iter, err := table.NewIterator(nil, nil)
+	if err != nil {
+		panic(err)
+	}
+	var firstKey []byte
+	var lastKey []byte
+	for {
+		valid, curr, err := iter.Next()
+		if err != nil {
+			panic(err)
+		}
+		if !valid {
+			break
+		}
+		if lastKey != nil && bytes.Compare(curr.Key, lastKey) <= 0 {
+			panic(fmt.Sprintf("key out of order or duplicate %s", string(curr.Key)))
+		}
+		if firstKey == nil {
+			firstKey = curr.Key
+		}
+		lastKey = curr.Key
+	}
+	if !bytes.Equal(firstKey, entry.KeyStart) {
+		panic(fmt.Sprintf("first key %v (%s) and range start %v (%s) are not equal",
+			firstKey, string(firstKey), entry.KeyStart, string(entry.KeyStart)))
+	}
+	if !bytes.Equal(lastKey, entry.KeyEnd) {
+		panic(fmt.Sprintf("last key %v (%s) and range end %v (%s) are not equal",
+			lastKey, string(lastKey), entry.KeyEnd, string(entry.KeyEnd)))
+	}
+}
+
+func newSliceIterator(kvs []common.KV) *sliceIterator {
+	return &sliceIterator{kvs: kvs, lkvs: len(kvs)}
+}
+
+type sliceIterator struct {
+	lkvs int
+	kvs  []common.KV
+	pos  int
+}
+
+func (s *sliceIterator) Next() (bool, common.KV, error) {
+	if s.pos >= s.lkvs {
+		s.pos = -1
+	}
+	if s.pos == -1 {
+		return false, common.KV{}, nil
+	}
+	result := s.kvs[s.pos]
+	s.pos++
+	return true, result, nil
+}
+
+func (s *sliceIterator) Current() common.KV {
+	if s.pos <= 0 {
+		return common.KV{}
+	}
+	return s.kvs[s.pos-1]
+}
+
+func (s *sliceIterator) Close() {
+}

--- a/lsm/compaction_worker_test.go
+++ b/lsm/compaction_worker_test.go
@@ -1,0 +1,903 @@
+package lsm
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/asl/conf"
+	"github.com/spirit-labs/tektite/asl/encoding"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/iteration"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/spirit-labs/tektite/tabcache"
+	"github.com/spirit-labs/tektite/testutils"
+	"github.com/stretchr/testify/require"
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestCompactionIncrementingData(t *testing.T) {
+
+	l0CompactionTrigger := 4
+	l1CompactionTrigger := 4
+	levelMultiplier := 10
+	lm, tearDown := setup(t, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = l0CompactionTrigger
+		cfg.L1CompactionTrigger = l1CompactionTrigger
+		cfg.L0MaxTablesBeforeBlocking = 2 * l0CompactionTrigger
+		cfg.LevelMultiplier = levelMultiplier
+	})
+	defer tearDown(t)
+
+	// Make sure all entries get compacted
+	err := lm.StoreLastFlushedVersion(math.MaxInt64)
+	require.NoError(t, err)
+
+	rangeStart := 0
+	numEntriesPerTable := 10
+	tableCount := 0
+	numLevels := 4
+	// we will generate sufficient tables to fill approx numLevels levels
+	numTables := getNumTablesToFill(numLevels, l0CompactionTrigger, l1CompactionTrigger, levelMultiplier)
+	numTables-- // subtract one as we don't want l0 to be completely full and thus trigger a compaction at the end
+
+	prefix := []byte("xxxxxxxxxxxxxxxx") // partition hash
+	prefix = append(prefix, []byte("prefix1_")...)
+
+	for tableCount < numTables {
+		tableName := fmt.Sprintf("sst-%05d", tableCount)
+		rangeEnd := rangeStart + numEntriesPerTable - 1
+		smallestKey, largestKey := buildAndRegisterTableWithKeyRangeWithPrefix(t, tableName, rangeStart, rangeEnd,
+			lm.GetObjectStore(), prefix)
+		addTable(t, lm, tableName, smallestKey, largestKey)
+		rangeStart += numEntriesPerTable
+		tableCount++
+	}
+
+	// Now we wait for all in-progress jobs to complete
+	ok, err := testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.GreaterOrEqual(t, lm.getLastLevel(), numLevels-1)
+
+	// Now we verify the data - generate a merging iterator over all the data in the lsm
+	mi := createIterator(t, lm, nil, nil)
+	for i := 0; i < numTables*numEntriesPerTable; i++ {
+		valid, curr, err := mi.Next()
+		require.NoError(t, err)
+		require.True(t, valid)
+		pref := common.ByteSliceCopy(prefix)
+		expectedKey := append(pref, []byte(fmt.Sprintf("key%06d", i))...)
+		expectedVal := fmt.Sprintf("val%06d", i)
+		require.Equal(t, expectedKey, curr.Key[:len(curr.Key)-8]) // trim version
+		require.Equal(t, expectedVal, string(curr.Value))
+	}
+	valid, _, err := mi.Next()
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	err = lm.Validate(true)
+	require.NoError(t, err)
+}
+
+func TestCompactionOverwritingData(t *testing.T) {
+	l0CompactionTrigger := 4
+	l1CompactionTrigger := 4
+	levelMultiplier := 10
+	lm, tearDown := setup(t, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = l0CompactionTrigger
+		cfg.L1CompactionTrigger = l1CompactionTrigger
+		cfg.L0MaxTablesBeforeBlocking = 2 * l0CompactionTrigger
+		cfg.LevelMultiplier = levelMultiplier
+	})
+	defer tearDown(t)
+
+	numKeys := 10000
+	numTables := 2000
+	numEntriesPerTable := 10
+	startVersion := 100
+	versionsMap := map[int]int{}
+	keysMap := map[int]int{}
+
+	// We set last flushed to a high value to make sure all entries get compacted
+	err := lm.StoreLastFlushedVersion(math.MaxInt64)
+	require.NoError(t, err)
+
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+
+	prefix := []byte("xxxxxxxxxxxxxxxx") // partition hash
+	prefix = append(prefix, []byte("prefix1_")...)
+
+	for i := 0; i < numTables; i++ {
+		si := &iteration.StaticIterator{}
+		randKeys := make([]int, numEntriesPerTable)
+
+		// choose some rand keys (no duplicates allowed) and sort them
+		randKeysMap := make(map[int]struct{}, numEntriesPerTable)
+		for j := 0; j < numEntriesPerTable; j++ {
+			for {
+				r := random.Intn(numKeys)
+				_, exists := randKeysMap[r]
+				if !exists {
+					randKeys[j] = r
+					randKeysMap[r] = struct{}{}
+					break
+				}
+			}
+		}
+		sort.Ints(randKeys)
+
+		for _, k := range randKeys {
+			prefixCopy := common.ByteSliceCopy(prefix)
+			key := append(prefixCopy, []byte(fmt.Sprintf("key%06d", k))...)
+			v := random.Intn(numKeys)
+			val := fmt.Sprintf("val%06d", v)
+			ver, ok := versionsMap[k]
+			if !ok {
+				ver = startVersion
+				versionsMap[k] = startVersion + 1
+			} else {
+				versionsMap[k]++
+			}
+			si.AddKV(encoding.EncodeVersion(key, uint64(ver)), []byte(val))
+			keysMap[k] = v
+		}
+
+		table, smallestKey, largestKey, _, _, err := sst.BuildSSTable(common.DataFormatV1, 0, 0, si)
+		require.NoError(t, err)
+		buff := table.Serialize()
+
+		sstName := fmt.Sprintf("sst-%06d", i)
+		err = lm.GetObjectStore().Put(context.Background(), conf.DefaultBucketName, sstName, buff)
+		require.NoError(t, err)
+
+		addTable(t, lm, sstName, smallestKey, largestKey)
+	}
+
+	// Now we wait for all in-progress jobs to complete
+	ok, err := testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Check the data
+	expectedKeys := make([]int, len(keysMap))
+	i := 0
+	for k := range keysMap {
+		expectedKeys[i] = k
+		i++
+	}
+	sort.Ints(expectedKeys)
+
+	mi := createIterator(t, lm, nil, nil)
+	for _, k := range expectedKeys {
+
+		valid, curr, err := mi.Next()
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		v, ok := keysMap[k]
+		require.True(t, ok)
+		expectedVersion, ok := versionsMap[k]
+		require.True(t, ok)
+		expectedVersion--
+
+		prefixCopy := common.ByteSliceCopy(prefix)
+		expectedKey := append(prefixCopy, []byte(fmt.Sprintf("key%06d", k))...)
+		expectedVal := fmt.Sprintf("val%06d", v)
+
+		require.Equal(t, expectedKey, curr.Key[:len(curr.Key)-8]) // trim version
+		require.Equal(t, expectedVal, string(curr.Value))
+
+		ver := math.MaxUint64 - binary.BigEndian.Uint64(curr.Key[len(curr.Key)-8:])
+		require.Equal(t, expectedVersion, int(ver))
+	}
+	valid, _, err := mi.Next()
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	err = lm.Validate(true)
+	require.NoError(t, err)
+}
+
+func TestCompactionTombstones(t *testing.T) {
+
+	l0CompactionTrigger := 4
+	l1CompactionTrigger := 4
+	levelMultiplier := 10
+	lm, tearDown := setup(t, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = l0CompactionTrigger
+		cfg.L1CompactionTrigger = l1CompactionTrigger
+		cfg.L0MaxTablesBeforeBlocking = 2 * l0CompactionTrigger
+		cfg.LevelMultiplier = levelMultiplier
+	})
+	defer tearDown(t)
+
+	// Make sure all entries get compacted
+	err := lm.StoreLastFlushedVersion(math.MaxInt64)
+	require.NoError(t, err)
+
+	rangeStart := 0
+	numEntriesPerTable := 10
+	tableCount := 0
+	numLevels := 4
+	numTables := getNumTablesToFill(numLevels, l0CompactionTrigger, l1CompactionTrigger, levelMultiplier)
+	numTables-- // subtract one as we don't want l0 to be completely full and thus trigger a compaction at the end
+
+	prefix := []byte("xxxxxxxxxxxxxxxx") // partition hash
+	prefix = append(prefix, []byte("prefix1_")...)
+
+	for tableCount < numTables {
+		tableName := uuid.New().String()
+		rangeEnd := rangeStart + numEntriesPerTable - 1
+		smallestKey, largestKey := buildAndRegisterTableWithKeyRangeWithPrefix(t, tableName, rangeStart, rangeEnd,
+			lm.GetObjectStore(), prefix)
+		addTable(t, lm, tableName, smallestKey, largestKey)
+		rangeStart += numEntriesPerTable
+		tableCount++
+	}
+
+	ok, err := testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	lm.dumpLevelInfo()
+
+	require.GreaterOrEqual(t, lm.getLastLevel(), numLevels-1)
+
+	totSize := lm.GetStats().TotBytes
+
+	// Now we will write tombstones for all this data
+	rangeStart = 0
+	tableCount = 0
+	for tableCount < numTables {
+		tableName := uuid.New().String()
+		rangeEnd := rangeStart + numEntriesPerTable - 1
+		smallestKey, largestKey := buildAndRegisterTombstoneTableWithKeyRangeAndPrefix(t, tableName, rangeStart, rangeEnd,
+			lm.GetObjectStore(), prefix)
+		addTable(t, lm, tableName, smallestKey, largestKey)
+		rangeStart += numEntriesPerTable
+		tableCount++
+	}
+	endRangeStart := rangeStart
+
+	// Now we wait for all in-progress jobs to complete
+	ok, err = testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// iterator shouldn't show anything
+	mi := createIterator(t, lm, nil, nil)
+	valid, _, err := mi.Next()
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	// now we add more data, this should push all the expired entries out, as we prioritise compaction of older
+	// tables
+	rangeStart = endRangeStart
+	tableCount = 0
+	// we add some extra tables here to make sure all deletes are pushed out
+	for tableCount < numTables {
+		tableName := uuid.New().String()
+		rangeEnd := rangeStart + numEntriesPerTable - 1
+		smallestKey, largestKey := buildAndRegisterTableWithKeyRangeWithPrefix(t, tableName, rangeStart, rangeEnd,
+			lm.GetObjectStore(), prefix)
+		addTable(t, lm, tableName, smallestKey, largestKey)
+		rangeStart += numEntriesPerTable
+		tableCount++
+	}
+
+	// Now we wait for all in-progress jobs to complete
+	ok, err = testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	size := lm.GetStats().TotBytes
+
+	// Not always exactly equal as can have some deletes in last level
+	require.Less(t, size, int(float64(totSize)*1.05))
+
+	err = lm.Validate(true)
+	require.NoError(t, err)
+}
+
+func TestRandomUpdateDeleteData(t *testing.T) {
+
+	l0CompactionTrigger := 4
+	l1CompactionTrigger := 4
+	levelMultiplier := 10
+	lm, tearDown := setup(t, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = l0CompactionTrigger
+		cfg.L1CompactionTrigger = l1CompactionTrigger
+		cfg.L0MaxTablesBeforeBlocking = 2 * l0CompactionTrigger
+		cfg.LevelMultiplier = levelMultiplier
+	})
+	defer tearDown(t)
+
+	// Make sure all entries get compacted
+	err := lm.StoreLastFlushedVersion(math.MaxInt64)
+	require.NoError(t, err)
+
+	numKeys := 10000
+	numTables := 3000
+	numEntriesPerTable := 10
+
+	type entry struct {
+		val     int
+		ver     int
+		updated bool
+		deleted bool
+	}
+
+	keys := make([]entry, numKeys)
+
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+
+	prefix := []byte("xxxxxxxxxxxxxxxx") // partition hash
+	prefix = append(prefix, []byte("prefix1_")...)
+
+	for i := 0; i < numTables; i++ {
+		si := &iteration.StaticIterator{}
+		randKeys := make([]int, numEntriesPerTable)
+
+		// choose some rand keys (no duplicates allowed) and sort them
+		randKeysMap := make(map[int]struct{}, numEntriesPerTable) // dedupper
+		for j := 0; j < numEntriesPerTable; j++ {
+			for {
+				r := random.Intn(numKeys)
+				_, exists := randKeysMap[r]
+				if !exists {
+					randKeys[j] = r
+					randKeysMap[r] = struct{}{}
+					break
+				}
+			}
+		}
+		sort.Ints(randKeys)
+
+		m := map[int]struct{}{}
+		for _, k := range randKeys {
+			_, exists := m[k]
+			if exists {
+				panic("duplicate")
+			}
+			m[k] = struct{}{}
+		}
+
+		for _, k := range randKeys {
+			prefixCopy := common.ByteSliceCopy(prefix)
+			key := append(prefixCopy, []byte(fmt.Sprintf("key%06d", k))...)
+
+			entry := &keys[k]
+
+			update := true
+			if entry.updated {
+				// choose update or delete by tossing a coin
+				update = random.Intn(2) == 1
+			}
+			ver := entry.ver
+
+			if update {
+				v := random.Intn(numKeys)
+				val := fmt.Sprintf("val%06d", v)
+				si.AddKV(encoding.EncodeVersion(key, uint64(ver)), []byte(val))
+				entry.updated = true
+				entry.deleted = false
+				entry.val = v
+			} else {
+				// delete
+				si.AddKV(encoding.EncodeVersion(key, uint64(ver)), nil)
+				entry.updated = false
+				entry.deleted = true
+				entry.val = 0
+			}
+			entry.ver = ver + 1
+		}
+
+		table, smallestKey, largestKey, _, _, err := sst.BuildSSTable(common.DataFormatV1, 0, 0, si)
+		require.NoError(t, err)
+		buff := table.Serialize()
+
+		sstName := fmt.Sprintf("sst-%06d", i)
+		err = lm.GetObjectStore().Put(context.Background(), conf.DefaultBucketName, sstName, buff)
+		require.NoError(t, err)
+
+		addTable(t, lm, sstName, smallestKey, largestKey)
+	}
+
+	// Now we wait for all in-progress jobs to complete
+	ok, err := testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Check the data
+
+	mi := createIterator(t, lm, nil, nil)
+	for k, entry := range keys {
+		if entry.deleted {
+			continue
+		}
+		if !entry.updated {
+			// unused entry
+			continue
+		}
+
+		valid, curr, err := mi.Next()
+		require.NoError(t, err)
+		require.True(t, valid)
+
+		ver := math.MaxUint64 - binary.BigEndian.Uint64(curr.Key[len(curr.Key)-8:])
+
+		expectedVersion := entry.ver - 1
+		prefixCopy := common.ByteSliceCopy(prefix)
+		expectedKey := append(prefixCopy, []byte(fmt.Sprintf("key%06d", k))...)
+		expectedVal := fmt.Sprintf("val%06d", entry.val)
+
+		require.Equal(t, expectedKey, curr.Key[:len(curr.Key)-8]) // trim version
+		require.Equal(t, expectedVal, string(curr.Value))
+
+		require.Equal(t, expectedVersion, int(ver))
+	}
+	valid, _, err := mi.Next()
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	err = lm.Validate(true)
+	require.NoError(t, err)
+}
+
+func getNumTablesToFill(numLevels int, l0Trigger int, l1Trigger int, multiplier int) int {
+	if numLevels == 1 {
+		return l0Trigger
+	}
+	levelTables := l1Trigger
+	numTables := l1Trigger
+	for i := 2; i < numLevels; i++ {
+		levelTables = levelTables * multiplier
+		numTables += levelTables
+	}
+	return numTables + l0Trigger
+}
+
+func TestCompactionExpiredPrefix(t *testing.T) {
+	l0CompactionTrigger := 4
+	l1CompactionTrigger := 4
+	levelMultiplier := 10
+	lm, tearDown := setup(t, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = l0CompactionTrigger
+		cfg.L1CompactionTrigger = l1CompactionTrigger
+		cfg.L0MaxTablesBeforeBlocking = 2 * l0CompactionTrigger
+		cfg.LevelMultiplier = levelMultiplier
+	})
+	defer tearDown(t)
+
+	// Make sure all entries get compacted
+	err := lm.StoreLastFlushedVersion(math.MaxInt64)
+	require.NoError(t, err)
+
+	retention := 2 * time.Second
+	prefix1 := []byte("xxxxxxxxxxxxxxxx") // partition hash
+	prefix1 = append(prefix1, []byte("prefix1_")...)
+	expiredSlabID := int(binary.BigEndian.Uint64(prefix1[16:]))
+	err = lm.RegisterSlabRetention(expiredSlabID, retention)
+	require.NoError(t, err)
+
+	rangeStart := 0
+	numEntriesPerTable := 10
+	tableCount := 0
+	numLevels := 4
+	// we will generate sufficient tables to fill approx numLevels levels
+	numTables := getNumTablesToFill(numLevels, l0CompactionTrigger, l1CompactionTrigger, levelMultiplier)
+	numTables-- // subtract one as we don't want l0 to be completely full and thus trigger a compaction at the end
+
+	for tableCount < numTables {
+		tableName := uuid.New().String()
+		rangeEnd := rangeStart + numEntriesPerTable - 1
+		smallestKey, largestKey := buildAndRegisterTableWithKeyRangeWithPrefix(t, tableName, rangeStart, rangeEnd,
+			lm.GetObjectStore(), prefix1)
+		addTable(t, lm, tableName, smallestKey, largestKey)
+		rangeStart += numEntriesPerTable
+		tableCount++
+	}
+
+	// wait for compaction jobs to complete
+	ok, err := testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Wait for retention to expire
+	time.Sleep(retention)
+
+	// Add more keys - different prefix - this should cause the expired prefixes to be compacted out
+
+	prefix2 := []byte("xxxxxxxxxxxxxxxx") // partition hash
+	prefix2 = append(prefix2, []byte("prefix2_")...)
+
+	rangeStart = 0
+	tableCount = 0
+	for tableCount < numTables {
+		tableName := uuid.New().String()
+		rangeEnd := rangeStart + numEntriesPerTable - 1
+		smallestKey, largestKey := buildAndRegisterTableWithKeyRangeWithPrefix(t, tableName, rangeStart, rangeEnd,
+			lm.GetObjectStore(), prefix2)
+		addTable(t, lm, tableName, smallestKey, largestKey)
+		rangeStart += numEntriesPerTable
+		tableCount++
+	}
+
+	// Wait for compactions to complete
+	ok, err = testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// There should be no prefix1 in any levels apart from the last - when the lsm is originally loaded with prefix1,
+	// there will be some prefix1 tables in the last level which won't be full and prefix1 won't be expired.
+	// when we add prefix2 some will get pushed to last level but it won't be full yet and there is no overlap between
+	// prefix1 and prefix2 tables so a merge won't occur, thus leaving prefix1 in last level. This is OK - it will
+	// get removed once that level becomes full, and it gets pushed to next level.
+
+	endRange := common.IncBigEndianBytes(prefix1)
+	for i := 0; i < lm.getLastLevel(); i++ {
+		levEntry := lm.getLevelEntry(i)
+		tableEntries := levEntry.tableEntries
+		for _, lte := range tableEntries {
+			te := lte.Get(levEntry)
+			overlap := hasOverlap(prefix1, endRange, te.RangeStart, te.RangeEnd)
+			require.False(t, overlap)
+		}
+	}
+}
+
+func TestCompactionDeadVersions(t *testing.T) {
+	l0CompactionTrigger := 2
+	l1CompactionTrigger := 20
+	levelMultiplier := 10
+	lm, tearDown := setup(t, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = l0CompactionTrigger
+		cfg.L1CompactionTrigger = l1CompactionTrigger
+		cfg.L0MaxTablesBeforeBlocking = 2 * l0CompactionTrigger
+		cfg.LevelMultiplier = levelMultiplier
+	})
+	defer tearDown(t)
+
+	// Make sure all entries get compacted
+	err := lm.StoreLastFlushedVersion(math.MaxInt64)
+	require.NoError(t, err)
+
+	prefix := []byte("xxxxxxxxxxxxxxxx") // partition hash
+	prefix = append(prefix, []byte("prefix1_")...)
+
+	tableName1 := uuid.New().String()
+	smallestKey, largestKey := buildAndRegisterTableWithKeyRangeAndVersion(t, tableName1, 0, 9,
+		lm.GetObjectStore(), false, prefix, 1000)
+	addTableWithMinMaxVersion(t, lm, tableName1, smallestKey, largestKey, 1000, 1100)
+
+	tableName2 := uuid.New().String()
+	smallestKey, largestKey = buildAndRegisterTableWithKeyRangeAndVersion(t, tableName2, 10, 19,
+		lm.GetObjectStore(), false, prefix, 1000)
+	addTableWithMinMaxVersion(t, lm, tableName2, smallestKey, largestKey, 1500, 1600)
+
+	tableName3 := uuid.New().String()
+	smallestKey, largestKey = buildAndRegisterTableWithKeyRangeAndVersion(t, tableName3, 20, 29,
+		lm.GetObjectStore(), false, prefix, 1000)
+	addTableWithMinMaxVersion(t, lm, tableName3, smallestKey, largestKey, 1700, 1800)
+
+	// Now register deadversions which includes 1500
+	rng := VersionRange{
+		VersionStart: 1500,
+		VersionEnd:   1550,
+	}
+	err = lm.RegisterDeadVersionRange(rng, "test_cluster", 0)
+	require.NoError(t, err)
+
+	// Add a couple more tables to force the previous once out
+
+	tableName4 := uuid.New().String()
+	smallestKey, largestKey = buildAndRegisterTableWithKeyRangeAndVersion(t, tableName4, 30, 39,
+		lm.GetObjectStore(), false, prefix, 1000)
+	addTableWithMinMaxVersion(t, lm, tableName4, smallestKey, largestKey, 10000, 20000)
+
+	tableName5 := uuid.New().String()
+	smallestKey, largestKey = buildAndRegisterTableWithKeyRangeAndVersion(t, tableName5, 40, 49,
+		lm.GetObjectStore(), false, prefix, 1000)
+	addTableWithMinMaxVersion(t, lm, tableName5, smallestKey, largestKey, 10000, 20000)
+
+	err = lm.forceCompaction(0, 3)
+	require.NoError(t, err)
+
+	// Should be no data in range 10-19 (incl)
+	keyStart := []byte(fmt.Sprintf("%skey%05d", string(prefix), 10))
+	keyEnd := []byte(fmt.Sprintf("%skey%05d", string(prefix), 20))
+
+	tables, err := lm.QueryTablesInRange(keyStart, keyEnd)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(tables))
+
+	// Should be no dead versions
+	for i := 0; i <= lm.getLastLevel(); i++ {
+		levEntry := lm.getLevelEntry(i)
+		tableEntries := levEntry.tableEntries
+		for _, lte := range tableEntries {
+			te := lte.Get(levEntry)
+			require.Nil(t, te.DeadVersionRanges)
+		}
+	}
+}
+
+func TestCompactionPrefixDeletions(t *testing.T) {
+	l0CompactionTrigger := 4
+	l1CompactionTrigger := 4
+	levelMultiplier := 10
+	lm, tearDown := setup(t, func(cfg *conf.Config) {
+		cfg.L0CompactionTrigger = l0CompactionTrigger
+		cfg.L1CompactionTrigger = l1CompactionTrigger
+		cfg.L0MaxTablesBeforeBlocking = 2 * l0CompactionTrigger
+		cfg.LevelMultiplier = levelMultiplier
+	})
+	defer tearDown(t)
+
+	// Make sure all entries get compacted
+	err := lm.StoreLastFlushedVersion(math.MaxInt64)
+	require.NoError(t, err)
+
+	rangeStart := 0
+	numEntriesPerTable := 10
+	tableCount := 0
+	numLevels := 4
+	// we will generate sufficient tables to fill approx numLevels levels
+	numTables := getNumTablesToFill(numLevels, l0CompactionTrigger, l1CompactionTrigger, levelMultiplier)
+	numTables-- // subtract one as we don't want l0 to be completely full and thus trigger a compaction at the end
+
+	var prefixes [][]byte
+	for i := 0; i < 3; i++ {
+		prefix := []byte("xxxxxxxxxxxxxxxx") // partition hash
+		prefix = append(prefix, []byte(fmt.Sprintf("prefix%d_", i))...)
+		prefixes = append(prefixes, prefix)
+	}
+
+	// Build and add tables with 3 different prefixes
+	for tableCount < numTables {
+		tableName := uuid.New().String()
+		rangeEnd := rangeStart + numEntriesPerTable - 1
+		smallestKey, largestKey := buildAndRegisterTableWithKeyRangeWithPrefix(t, tableName, rangeStart, rangeEnd,
+			lm.GetObjectStore(), prefixes[tableCount%3])
+		addTable(t, lm, tableName, smallestKey, largestKey)
+		rangeStart += numEntriesPerTable
+		tableCount++
+	}
+
+	// wait for compaction jobs to complete
+	ok, err := testutils.WaitUntilWithError(func() (bool, error) {
+		stats := lm.GetCompactionStats()
+		return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Make sure L0 is empty
+	err = lm.forceCompaction(0, 1)
+	require.NoError(t, err)
+	ok, err = testutils.WaitUntilWithError(func() (bool, error) {
+		l0Stats := lm.GetStats().LevelStats[0]
+		return l0Stats.Tables == 0, nil
+	}, 30*time.Second, 1*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	log.Debug("adding deletion bomb")
+
+	// Now we'll add a deletion bomb
+	si := &iteration.StaticIterator{}
+	tombstone := common.ByteSliceCopy(prefixes[1])
+	endMarker := append(common.IncBigEndianBytes(tombstone), 0)
+	si.AddKV(encoding.EncodeVersion(tombstone, math.MaxUint64), nil)
+	si.AddKV(encoding.EncodeVersion(endMarker, math.MaxUint64), []byte{'x'})
+	log.Debugf("added tombstone:%s", tombstone)
+	log.Debugf("added endmarker:%s", endMarker)
+
+	table, smallestKey, largestKey, _, _, err := sst.BuildSSTable(common.DataFormatV1, 0, 0, si)
+	require.NoError(t, err)
+	buff := table.Serialize()
+	tableName := uuid.New().String()
+	log.Debugf("deletion bomb table is %s", tableName)
+	err = lm.GetObjectStore().Put(context.Background(), conf.DefaultBucketName, tableName, buff)
+	require.NoError(t, err)
+	addTable(t, lm, tableName, smallestKey, largestKey)
+
+	ok, err = testutils.WaitUntilWithError(func() (bool, error) {
+		lastLevel := lm.getLastLevel()
+		for level := 0; level < lastLevel; level++ {
+			// Force compaction at each level to let the delete bomb progress
+			log.Debugf("forcing compaction at level %d", level)
+			err = lm.forceCompaction(level, 1)
+			require.NoError(t, err)
+
+			// wait for compaction jobs to complete
+			ok, err = testutils.WaitUntilWithError(func() (bool, error) {
+				stats := lm.GetCompactionStats()
+				return stats.QueuedJobs == 0 && stats.InProgressJobs == 0, nil
+			}, 30*time.Second, 1*time.Millisecond)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			log.Debugf("compaction complete at level %d", level)
+		}
+
+		// There should be no prefix1 in any levels
+		endRange := common.IncBigEndianBytes(prefixes[1])
+		for i := 0; i < lm.getLastLevel(); i++ {
+			levEntry := lm.getLevelEntry(i)
+			tableEntries := levEntry.tableEntries
+			for _, lte := range tableEntries {
+				te := lte.Get(levEntry)
+				if hasOverlap(prefixes[1], endRange, te.RangeStart, te.RangeEnd) {
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	}, 10*time.Second, 100*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+}
+
+func setup(t *testing.T, cfgFunc func(cfg *conf.Config)) (*Manager, func(t *testing.T)) {
+	lm, tearDown := setupLevelManagerWithConfigSetter(t, true, true, cfgFunc)
+
+	cfg := &conf.Config{}
+	cfg.ApplyDefaults()
+	cfg.CompactionWorkerCount = 4
+	// we set this small to get about 10 entries per table so we can fill up levels
+	cfg.CompactionMaxSSTableSize = 550
+
+	lmClientFactory := &inMemClientFactory{lm: lm}
+	tableCache, err := tabcache.NewTableCache(lm.GetObjectStore(), cfg)
+	require.NoError(t, err)
+	err = tableCache.Start()
+	require.NoError(t, err)
+	cws := NewCompactionWorkerService(cfg, lmClientFactory, tableCache, lm.GetObjectStore(), true)
+	err = cws.Start()
+	require.NoError(t, err)
+	tearDown2 := func(t *testing.T) {
+		err := cws.Stop()
+		require.NoError(t, err)
+		tearDown(t)
+	}
+	return lm, tearDown2
+}
+
+type inMemClientFactory struct {
+	lm *Manager
+}
+
+func (i *inMemClientFactory) CreateLevelManagerClient() Client {
+	return &InMemClient{LevelManager: i.lm}
+}
+
+func createIterator(t *testing.T, lm *Manager, keyStart []byte, keyEnd []byte) *iteration.MergingIterator {
+	otids, err := lm.QueryTablesInRange(keyStart, keyEnd)
+	require.NoError(t, err)
+	var chainIters []iteration.Iterator
+	for _, notids := range otids {
+		var iters []iteration.Iterator
+		for _, info := range notids {
+			buff, err := lm.GetObjectStore().Get(context.Background(), conf.DefaultBucketName, string(info.ID))
+			require.NoError(t, err)
+			require.NotNil(t, buff)
+			sstable := &sst.SSTable{}
+			sstable.Deserialize(buff, 0)
+			iter, err := sstable.NewIterator(nil, nil)
+			require.NoError(t, err)
+			iters = append(iters, iter)
+		}
+		chainIter := iteration.NewChainingIterator(iters)
+		chainIters = append(chainIters, chainIter)
+	}
+	mi, err := iteration.NewMergingIterator(chainIters, false, math.MaxUint64)
+	require.NoError(t, err)
+	return mi
+}
+
+func buildAndRegisterTableWithKeyRangeWithPrefix(t *testing.T, name string, rangeStart int, rangeEnd int,
+	cloudStore objstore.Client, keyPrefix []byte) ([]byte, []byte) {
+	return buildAndRegisterTableWithKeyRangeAndVersion(t, name, rangeStart, rangeEnd, cloudStore, false, keyPrefix, 0)
+}
+
+func buildAndRegisterTombstoneTableWithKeyRangeAndPrefix(t *testing.T, name string, rangeStart int, rangeEnd int,
+	cloudStore objstore.Client, keyPrefix []byte) ([]byte, []byte) {
+	return buildAndRegisterTableWithKeyRangeAndVersion(t, name, rangeStart, rangeEnd, cloudStore, true, keyPrefix, 0)
+}
+
+func buildAndRegisterTableWithKeyRangeAndVersion(t *testing.T, name string, rangeStart int, rangeEnd int,
+	cloudStore objstore.Client, tombstones bool, keyPrefix []byte, version int) ([]byte, []byte) {
+	si := &iteration.StaticIterator{}
+	for i := rangeStart; i <= rangeEnd; i++ {
+		key := common.ByteSliceCopy(keyPrefix)
+		key = append(key, []byte(fmt.Sprintf("key%06d", i))...)
+		var val []byte
+		if !tombstones {
+			val = []byte(fmt.Sprintf("val%06d", i))
+		}
+		si.AddKV(encoding.EncodeVersion(key, uint64(version)), val)
+	}
+	table, smallestKey, largestKey, _, _, err := sst.BuildSSTable(common.DataFormatV1, 0, 0, si)
+	require.NoError(t, err)
+	buff := table.Serialize()
+	err = cloudStore.Put(context.Background(), conf.DefaultBucketName, name, buff)
+	require.NoError(t, err)
+	return smallestKey, largestKey
+}
+
+func addTable(t *testing.T, lm *Manager, tableName string, rangeStart []byte, rangeEnd []byte) {
+	addTableWithMinMaxVersion(t, lm, tableName, rangeStart, rangeEnd, 0, 0)
+}
+
+func addTableWithMinMaxVersion(t *testing.T, lm *Manager, tableName string, rangeStart []byte, rangeEnd []byte,
+	minVersion int, maxVersion int) {
+	addedTime := uint64(time.Now().UTC().UnixMilli())
+	regBatch := RegistrationBatch{
+		ClusterName: "test_cluster",
+		Registrations: []RegistrationEntry{
+			{
+				Level:      0,
+				TableID:    []byte(tableName),
+				KeyStart:   rangeStart,
+				KeyEnd:     rangeEnd,
+				MinVersion: uint64(minVersion),
+				MaxVersion: uint64(maxVersion),
+				AddedTime:  addedTime,
+			},
+		},
+	}
+	validateRegBatch(regBatch, lm.GetObjectStore(), conf.DefaultBucketName)
+	for {
+		ch := make(chan error, 1)
+		lm.RegisterL0Tables(regBatch, func(err error) {
+			ch <- err
+		})
+		err := <-ch
+		if err == nil {
+			break
+		}
+		if common.IsUnavailableError(err) {
+			require.Equal(t,
+				"TEK1001 - unable to accept L0 add - L0 is full", err.Error())
+			time.Sleep(1 * time.Millisecond)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}

--- a/lsm/compaction_worker_test.go
+++ b/lsm/compaction_worker_test.go
@@ -570,7 +570,7 @@ func TestCompactionExpiredPrefix(t *testing.T) {
 
 	endRange := common.IncBigEndianBytes(prefix1)
 	for i := 0; i < lm.getLastLevel(); i++ {
-		levEntry := lm.getLevelEntry(i)
+		levEntry := lm.GetLevelEntry(i)
 		tableEntries := levEntry.tableEntries
 		for _, lte := range tableEntries {
 			te := lte.Get(levEntry)
@@ -647,7 +647,7 @@ func TestCompactionDeadVersions(t *testing.T) {
 
 	// Should be no dead versions
 	for i := 0; i <= lm.getLastLevel(); i++ {
-		levEntry := lm.getLevelEntry(i)
+		levEntry := lm.GetLevelEntry(i)
 		tableEntries := levEntry.tableEntries
 		for _, lte := range tableEntries {
 			te := lte.Get(levEntry)
@@ -758,7 +758,7 @@ func TestCompactionPrefixDeletions(t *testing.T) {
 		// There should be no prefix1 in any levels
 		endRange := common.IncBigEndianBytes(prefixes[1])
 		for i := 0; i < lm.getLastLevel(); i++ {
-			levEntry := lm.getLevelEntry(i)
+			levEntry := lm.GetLevelEntry(i)
 			tableEntries := levEntry.tableEntries
 			for _, lte := range tableEntries {
 				te := lte.Get(levEntry)

--- a/lsm/in_mem.go
+++ b/lsm/in_mem.go
@@ -1,0 +1,72 @@
+package lsm
+
+import "time"
+
+type InMemClient struct {
+	LevelManager *Manager
+}
+
+func (c *InMemClient) StoreLastFlushedVersion(int64) error {
+	return nil
+}
+
+func (c *InMemClient) LoadLastFlushedVersion() (int64, error) {
+	return -1, nil
+}
+
+func (c *InMemClient) QueryTablesInRange(keyStart []byte, keyEnd []byte) (OverlappingTables, error) {
+	return c.LevelManager.QueryTablesInRange(keyStart, keyEnd)
+}
+
+func (c *InMemClient) RegisterL0Tables(registrationBatch RegistrationBatch) error {
+	ch := make(chan error, 1)
+	c.LevelManager.RegisterL0Tables(registrationBatch, func(err error) {
+		ch <- err
+	})
+	return <-ch
+}
+
+func (c *InMemClient) ApplyChanges(registrationBatch RegistrationBatch) error {
+	return c.LevelManager.ApplyChanges(registrationBatch)
+}
+
+func (c *InMemClient) RegisterDeadVersionRange(versionRange VersionRange, clusterName string, clusterVersion int) error {
+	return c.LevelManager.RegisterDeadVersionRange(versionRange, clusterName, clusterVersion)
+}
+
+func (c *InMemClient) PollForJob() (*CompactionJob, error) {
+	type pollRes struct {
+		job *CompactionJob
+		err error
+	}
+	ch := make(chan pollRes, 1)
+	c.LevelManager.pollForJob(-1, func(job *CompactionJob, err error) {
+		ch <- pollRes{job, err}
+	})
+	res := <-ch
+	return res.job, res.err
+}
+
+func (c *InMemClient) GetStats() (Stats, error) {
+	return c.LevelManager.GetStats(), nil
+}
+
+func (c *InMemClient) RegisterSlabRetention(slabID int, retention time.Duration) error {
+	return c.LevelManager.RegisterSlabRetention(slabID, retention)
+}
+
+func (c *InMemClient) UnregisterSlabRetention(slabID int) error {
+	return c.LevelManager.UnregisterSlabRetention(slabID)
+}
+
+func (c *InMemClient) GetSlabRetention(slabID int) (time.Duration, error) {
+	return c.LevelManager.GetSlabRetention(slabID)
+}
+
+func (c *InMemClient) Start() error {
+	return nil
+}
+
+func (c *InMemClient) Stop() error {
+	return nil
+}

--- a/lsm/iters.go
+++ b/lsm/iters.go
@@ -1,0 +1,121 @@
+package lsm
+
+import (
+	"encoding/binary"
+	"github.com/spirit-labs/tektite/common"
+	iteration2 "github.com/spirit-labs/tektite/iteration"
+	log "github.com/spirit-labs/tektite/logger"
+	"math"
+	"time"
+)
+
+// RemoveExpiredEntriesIterator filters out any keys which have expired due to retention time being exceeded
+type RemoveExpiredEntriesIterator struct {
+	iter              iteration2.Iterator
+	sstCreationTime   uint64
+	now               uint64
+	retentionProvider RetentionProvider
+}
+
+type RetentionProvider interface {
+	GetSlabRetention(slabID int) (time.Duration, error)
+}
+
+func NewRemoveExpiredEntriesIterator(iter iteration2.Iterator, sstCreationTime uint64, now uint64,
+	retentionProvider RetentionProvider) *RemoveExpiredEntriesIterator {
+	return &RemoveExpiredEntriesIterator{
+		iter:              iter,
+		sstCreationTime:   sstCreationTime,
+		now:               now,
+		retentionProvider: retentionProvider,
+	}
+}
+
+func (r *RemoveExpiredEntriesIterator) Next() (bool, common.KV, error) {
+	for {
+		valid, curr, err := r.iter.Next()
+		if err != nil || !valid {
+			return false, curr, err
+		}
+		expired, err := r.isExpired(curr.Key)
+		if err != nil {
+			return false, common.KV{}, err
+		}
+		if !expired {
+			return true, curr, nil
+		}
+		if log.DebugEnabled {
+			log.Debugf("RemoveExpiredEntriesIterator removed key %v (%s) value %v (%s)", curr.Key, string(curr.Key),
+				curr.Value, string(curr.Value))
+		}
+	}
+}
+
+func (r *RemoveExpiredEntriesIterator) Current() common.KV {
+	return r.iter.Current()
+}
+
+func (r *RemoveExpiredEntriesIterator) Close() {
+	r.iter.Close()
+}
+
+func (r *RemoveExpiredEntriesIterator) isExpired(key []byte) (bool, error) {
+	slabID := int(binary.BigEndian.Uint64(key[16:]))
+	retention, err := r.retentionProvider.GetSlabRetention(slabID)
+	if err != nil {
+		return false, err
+	}
+	if retention == 0 {
+		return false, nil
+	}
+	expired := r.sstCreationTime+uint64(retention.Milliseconds()) <= r.now
+	return expired, nil
+}
+
+// RemoveDeadVersionsIterator filters out any dead version ranges
+type RemoveDeadVersionsIterator struct {
+	iter              iteration2.Iterator
+	deadVersionRanges []VersionRange
+}
+
+func NewRemoveDeadVersionsIterator(iter iteration2.Iterator, deadVersionRanges []VersionRange) *RemoveDeadVersionsIterator {
+	return &RemoveDeadVersionsIterator{
+		iter:              iter,
+		deadVersionRanges: deadVersionRanges,
+	}
+}
+
+func (r *RemoveDeadVersionsIterator) Next() (bool, common.KV, error) {
+	for {
+		valid, curr, err := r.iter.Next()
+		if err != nil || !valid {
+			return false, curr, err
+		}
+		dead := r.hasDeadVersion(curr.Key)
+		if !dead {
+			return true, curr, nil
+		}
+		if log.DebugEnabled {
+			log.Debugf("RemoveDeadVersionsIterator removed key %v (%s) value %v (%s)", curr.Key, string(curr.Key),
+				curr.Value, string(curr.Value))
+		}
+	}
+}
+
+func (r *RemoveDeadVersionsIterator) Current() common.KV {
+	return r.iter.Current()
+}
+
+func (r *RemoveDeadVersionsIterator) Close() {
+	r.iter.Close()
+}
+
+func (r *RemoveDeadVersionsIterator) hasDeadVersion(key []byte) bool {
+	ver := math.MaxUint64 - binary.BigEndian.Uint64(key[len(key)-8:])
+	for _, versionRange := range r.deadVersionRanges {
+		if ver >= versionRange.VersionStart && ver <= versionRange.VersionEnd {
+			return true
+		}
+	}
+	return false
+}

--- a/lsm/level_manager.go
+++ b/lsm/level_manager.go
@@ -1,0 +1,789 @@
+package lsm
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/spirit-labs/tektite/asl/arista"
+	"github.com/spirit-labs/tektite/asl/conf"
+	"github.com/spirit-labs/tektite/asl/errwrap"
+	"github.com/spirit-labs/tektite/common"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/sst"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Manager struct {
+	compactionState
+	lock                      sync.RWMutex
+	started                   bool
+	conf                      *conf.Config
+	format                    common.MetadataFormat
+	objStore                  objstore.Client
+	masterRecord              *MasterRecord
+	hasChanges                bool
+	clusterVersions           map[string]int
+	enableCompaction          bool
+	validateOnEachStateChange bool
+	pendingAddsQueue          []pendingL0Add
+}
+
+type pendingL0Add struct {
+	regBatch       RegistrationBatch
+	completionFunc func(error)
+}
+
+type deleteTableEntry struct {
+	tableID   sst.SSTableID
+	addedTime uint64
+}
+
+func NewManager(conf *conf.Config, cloudStore objstore.Client, enableCompaction bool,
+	validateOnEachStateChange bool) *Manager {
+	lm := &Manager{
+		compactionState:           newCompactionState(),
+		format:                    conf.RegistryFormat,
+		objStore:                  cloudStore,
+		conf:                      conf,
+		clusterVersions:           map[string]int{},
+		enableCompaction:          enableCompaction,
+		validateOnEachStateChange: validateOnEachStateChange,
+	}
+	return lm
+}
+
+func (lm *Manager) Start(masterRecord *MasterRecord) error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if lm.started {
+		return nil
+	}
+	lm.masterRecord = masterRecord
+	lm.scheduleTableDeleteTimer()
+	// Maybe trigger a compaction as levels could be full
+	if err := lm.maybeScheduleCompaction(); err != nil {
+		return err
+	}
+	lm.started = true
+	return nil
+}
+
+func (lm *Manager) Stop() error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		return nil
+	}
+	lm.tableDeleteTimer.Stop()
+	for _, inProg := range lm.inProgress {
+		if inProg.timer != nil {
+			inProg.timer.Stop()
+		}
+	}
+	lm.started = false
+	return nil
+}
+
+func (lm *Manager) QueryTablesInRange(keyStart []byte, keyEnd []byte) (OverlappingTables, error) {
+	lm.lock.RLock()
+	defer lm.lock.RUnlock()
+	if !lm.started {
+		return nil, errors.New("not started")
+	}
+	var overlapping OverlappingTables
+	for level, entry := range lm.masterRecord.levelEntries {
+		tables, err := lm.getOverlappingTables(keyStart, keyEnd, level, entry)
+		if err != nil {
+			return nil, err
+		}
+		if level == 0 {
+			// Level 0 is overlapping
+			for _, table := range tables {
+				overlapping = append(overlapping, []QueryTableInfo{{ID: table.SSTableID, DeadVersions: table.DeadVersionRanges}})
+			}
+		} else if tables != nil {
+			// Other levels are non overlapping
+			tableInfos := make([]QueryTableInfo, len(tables))
+			for i, table := range tables {
+				tableInfos[i] = QueryTableInfo{
+					ID:           table.SSTableID,
+					DeadVersions: table.DeadVersionRanges,
+				}
+			}
+			overlapping = append(overlapping, tableInfos)
+		}
+	}
+	return overlapping, nil
+}
+
+func (lm *Manager) RegisterL0Tables(registrationBatch RegistrationBatch, completionFunc func(error)) {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		completionFunc(common.NewTektiteErrorf(common.Unavailable, "not started"))
+		return
+	}
+	if !(len(registrationBatch.DeRegistrations) == 0 && len(registrationBatch.Registrations) == 1) ||
+		registrationBatch.Registrations[0].Level != 0 || registrationBatch.Compaction {
+		completionFunc(errwrap.Errorf("not an L0 registration %v", registrationBatch))
+		return
+	}
+	// we check cluster version - this protects against network partition where node is lost but is still running, new
+	// node takes over, but old store tries to register tables after new node is active.
+	lowestVersion := lm.clusterVersions[registrationBatch.ClusterName]
+	if registrationBatch.ClusterVersion < lowestVersion {
+		completionFunc(common.NewTektiteErrorf(common.Unavailable, "registration batch version is too low"))
+		return
+	}
+	lm.clusterVersions[registrationBatch.ClusterName] = registrationBatch.ClusterVersion
+	if lm.getL0FreeSpace() >= 1 {
+		log.Debugf("in lsm.Manager RegisterL0Tables - enough free space so applying now")
+		completionFunc(lm.doApplyChangesAndMaybeCompact(registrationBatch))
+		return
+	}
+	// queue the request
+	log.Debugf("in lsm.Manager RegisterL0Tables - not enough free space so queuing- %d", lm.getL0FreeSpace())
+	lm.pendingAddsQueue = append(lm.pendingAddsQueue, pendingL0Add{
+		regBatch:       registrationBatch,
+		completionFunc: completionFunc,
+	})
+}
+
+func (lm *Manager) ApplyChanges(regBatch RegistrationBatch) error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		return errors.New("not started")
+	}
+	if regBatch.Compaction {
+		return lm.applyCompactionChanges(regBatch)
+	}
+	if err := lm.doApplyChanges(regBatch); err != nil {
+		return err
+	}
+	log.Debugf("registered l0 table: %v now dumping, reprocess? %t", regBatch.Registrations[0].TableID)
+	if log.DebugEnabled {
+		lm.dump()
+	}
+	if lm.enableCompaction {
+		return lm.maybeScheduleCompaction()
+	}
+	return nil
+}
+
+func (lm *Manager) ApplyChangesNoCheck(regBatch RegistrationBatch) error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	return lm.doApplyChanges(regBatch)
+}
+
+func (lm *Manager) MaybeScheduleCompaction() error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		return errors.New("not started")
+	}
+	return lm.maybeScheduleCompaction()
+}
+
+// RegisterDeadVersionRange - registers a range of versions as dead - versions in the dead range will be removed from
+// the store via compaction, asynchronously. Note the version range is inclusive.
+func (lm *Manager) RegisterDeadVersionRange(versionRange VersionRange, clusterName string, clusterVersion int) error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		return errors.New("not started")
+	}
+	lowestVersion := lm.clusterVersions[clusterName]
+	if clusterVersion < lowestVersion {
+		// Note we send back RegisterDeadVersionWrongClusterVersion as we do not want the sender to retry - failure
+		// should be cancelled
+		return common.NewTektiteErrorf(common.RegisterDeadVersionWrongClusterVersion,
+			"RegisterDeadVersionRange - cluster version is too low %d expected %d", clusterVersion, lowestVersion)
+	}
+	requiresMasterRecordUpdate := false
+	// Find all tables that possibly might have entries in the dead range and update the table entry to include that
+	for _, entry := range lm.masterRecord.levelEntries {
+		if entry.maxVersion < versionRange.VersionStart {
+			continue
+		}
+		for i, lte := range entry.tableEntries {
+			te := lte.Get(entry)
+			dontOverlapRight := versionRange.VersionStart > te.MaxVersion
+			dontOverlapLeft := versionRange.VersionEnd < te.MinVersion
+			overlaps := !(dontOverlapLeft || dontOverlapRight)
+			if overlaps {
+				dvrs := te.DeadVersionRanges
+				// Make sure dvr is not already there
+				exists := false
+				for _, dvr := range dvrs {
+					if dvr.VersionStart == versionRange.VersionStart && dvr.VersionEnd == versionRange.VersionEnd {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					dvrs = append(dvrs, versionRange)
+					te.DeadVersionRanges = dvrs
+					entry.SetAt(i, te)
+					requiresMasterRecordUpdate = true
+				}
+			}
+		}
+	}
+	// We update the cluster version - this prevents L0 tables with a dead version range being pushed after this has been
+	// called - as we clear the local store when we get the new cluster version in proc mgr.
+	lm.clusterVersions[clusterName] = clusterVersion
+	if requiresMasterRecordUpdate {
+		lm.hasChanges = true
+	}
+	return nil
+}
+
+func (lm *Manager) GetSlabRetention(slabID int) (time.Duration, error) {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		return 0, errors.New("not started")
+	}
+	ret := time.Duration(lm.masterRecord.slabRetentions[uint64(slabID)])
+	return ret, nil
+}
+
+func (lm *Manager) RegisterSlabRetention(slabID int, retention time.Duration) error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		return errors.New("not started")
+	}
+	lm.masterRecord.slabRetentions[uint64(slabID)] = uint64(retention)
+	lm.masterRecord.version++
+	lm.hasChanges = true
+	return nil
+}
+
+func (lm *Manager) UnregisterSlabRetention(slabID int) error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		return errors.New("not started")
+	}
+	delete(lm.masterRecord.slabRetentions, uint64(slabID))
+	lm.masterRecord.version++
+	lm.hasChanges = true
+	return nil
+}
+
+func (lm *Manager) StoreLastFlushedVersion(lastFlushedVersion int64) error {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		return errors.New("not started")
+	}
+	lm.masterRecord.lastFlushedVersion = lastFlushedVersion
+	lm.hasChanges = true
+	return nil
+}
+
+func (lm *Manager) getOverlappingTables(keyStart []byte, keyEnd []byte, level int,
+	levEntry *levelEntry) ([]*TableEntry, error) {
+	numTableEntries := len(levEntry.tableEntries)
+	// Note that keyEnd is exclusive!
+	var tables []*TableEntry
+	if level == 0 {
+		// can't use binary search in L0 as not ordered
+		for i := numTableEntries - 1; i >= 0; i-- {
+			te := levEntry.tableEntries[i].Get(levEntry)
+			// We must add the overlapping entries from newest to oldest
+			if hasOverlap(keyStart, keyEnd, te.RangeStart, te.RangeEnd) {
+				tables = append(tables, te)
+			}
+		}
+	} else {
+		// Find the start index of overlap with binary search
+		startIndex := 0
+		if keyEnd != nil {
+			startIndex = sort.Search(numTableEntries, func(i int) bool {
+				return bytes.Compare(levEntry.tableEntries[i].Get(levEntry).RangeEnd, keyStart) >= 0
+			})
+		}
+		if startIndex == numTableEntries {
+			// no overlap
+			return nil, nil
+		}
+		for _, entry := range levEntry.tableEntries[startIndex:] {
+			te := entry.Get(levEntry)
+			if hasOverlap(keyStart, keyEnd, te.RangeStart, te.RangeEnd) {
+				tables = append(tables, te)
+			} else {
+				break
+			}
+		}
+	}
+	return tables, nil
+}
+
+func (lm *Manager) levelMaxTablesTrigger(level int) int {
+	if level == 0 {
+		return lm.conf.L0CompactionTrigger
+	}
+	mt := lm.conf.L1CompactionTrigger
+	for i := 1; i < level; i++ {
+		mt *= lm.conf.LevelMultiplier
+	}
+	return mt
+}
+
+func (lm *Manager) getL0FreeSpace() int {
+	return lm.conf.L0MaxTablesBeforeBlocking - lm.masterRecord.levelTableCounts[0]
+}
+
+func (lm *Manager) applyCompactionChanges(regBatch RegistrationBatch) error {
+	jobExists := lm.jobInProgress(regBatch.JobID)
+	if !jobExists {
+		return common.NewTektiteErrorf(common.CompactionJobNotFound, "job not found %s", regBatch.JobID)
+	}
+	if err := lm.doApplyChanges(regBatch); err != nil {
+		return err
+	}
+	registeredTables := make(map[string]struct{}, len(regBatch.Registrations))
+	for _, registration := range regBatch.Registrations {
+		registeredTables[string(registration.TableID)] = struct{}{}
+	}
+	tablesToDelete := make([]deleteTableEntry, 0, len(regBatch.DeRegistrations))
+	now := arista.NanoTime()
+	// For each deRegistration we add the table id to the tables to delete UNLESS the same table has also been
+	// registered in the batch - this can happen when a table is moved from one level to the next - we do not want to
+	// delete it then.
+	l0DeRegs := 0
+	for _, deRegistration := range regBatch.DeRegistrations {
+		if deRegistration.Level == 0 {
+			l0DeRegs++
+		}
+		_, registered := registeredTables[string(deRegistration.TableID)]
+		if !registered {
+			tablesToDelete = append(tablesToDelete, deleteTableEntry{
+				tableID:   deRegistration.TableID,
+				addedTime: now,
+			})
+		}
+	}
+	// ss-tables are deleted after a delay - this allows any queries currently in execution some time
+	lm.tablesToDelete = append(lm.tablesToDelete, tablesToDelete...)
+	if err := lm.compactionComplete(regBatch.JobID); err != nil {
+		return err
+	}
+	lm.maybeDespatchPendingL0Adds()
+	return nil
+}
+
+func (lm *Manager) maybeDespatchPendingL0Adds() {
+	freeSpace := lm.getL0FreeSpace()
+	log.Debugf("in levelmanager maybeDespatchPendingL0Adds, freespace is %d", freeSpace)
+	if freeSpace <= 0 {
+		return
+	}
+	toDespatch := freeSpace
+	if len(lm.pendingAddsQueue) < toDespatch {
+		toDespatch = len(lm.pendingAddsQueue)
+	}
+	log.Debugf("sending %d queueing l0 add", toDespatch)
+	for i := 0; i < toDespatch; i++ {
+		pending := lm.pendingAddsQueue[i]
+		pending.completionFunc(lm.doApplyChangesAndMaybeCompact(pending.regBatch))
+	}
+	lm.pendingAddsQueue = lm.pendingAddsQueue[toDespatch:]
+}
+
+func (lm *Manager) getLastLevel() int {
+	return len(lm.masterRecord.levelEntries) - 1
+}
+
+func (lm *Manager) doApplyChangesAndMaybeCompact(regBatch RegistrationBatch) error {
+	if err := lm.doApplyChanges(regBatch); err != nil {
+		return err
+	}
+	return lm.maybeScheduleCompaction()
+}
+
+func (lm *Manager) doApplyChanges(regBatch RegistrationBatch) error {
+	if log.DebugEnabled {
+		var dsb strings.Builder
+		for _, dereg := range regBatch.DeRegistrations {
+			dsb.WriteString(fmt.Sprintf("%v", []byte(dereg.TableID)))
+			dsb.WriteRune(',')
+		}
+		var rsb strings.Builder
+		for _, reg := range regBatch.Registrations {
+			rsb.WriteString(fmt.Sprintf("%v", []byte(reg.TableID)))
+			rsb.WriteRune(',')
+		}
+		log.Debugf("applychanges: deregistering: %s registering: %s", dsb.String(), rsb.String())
+	}
+	// We must process the de-registrations before registrations, or we can temporarily have overlapping keys
+	if err := lm.applyDeRegistrations(regBatch.DeRegistrations); err != nil {
+		return err
+	}
+	if err := lm.applyRegistrations(regBatch.Registrations); err != nil {
+		return err
+	}
+	if lm.validateOnEachStateChange {
+		if err := lm.Validate(false); err != nil {
+			return err
+		}
+	}
+	lm.masterRecord.version++
+	lm.hasChanges = true
+	return nil
+}
+
+func (lm *Manager) applyDeRegistrations(deRegistrations []RegistrationEntry) error { //nolint:gocyclo
+	for _, deRegistration := range deRegistrations {
+		if len(deRegistration.KeyStart) == 0 || len(deRegistration.KeyEnd) <= 8 {
+			return errwrap.Errorf("deregistration, key start/end does not have a version: %v", deRegistration)
+		}
+		entry := lm.getLevelEntry(deRegistration.Level)
+		if len(entry.tableEntries) == 0 {
+			// Can occur if deRegistration applied more than once - we need to be idempotent
+			continue
+		}
+		// Find the table entry in the level
+		pos := getTableEntryForDeregistration(entry, deRegistration)
+		if pos == -1 {
+			// This can occur if deRegistration is applied more than once - we are idempotent.
+			// E.g. during reprocessing or if the client resubmits after a network error but it had actually been
+			// applied already
+			continue
+		}
+		// Now remove it
+		//newTableEntries := make([]*TableEntry, pos)
+		//copy(newTableEntries, entry.tableEntries[:pos])
+		//newTableEntries = append(newTableEntries, entry.tableEntries[pos+1:]...)
+		entry.RemoveAt(pos)
+
+		// Find the new overall start and end range
+		var newStart, newEnd []byte
+		if deRegistration.Level == 0 {
+			// Level 0 is not ordered so we need to scan through all of them
+			for _, lte := range entry.tableEntries {
+				te := lte.Get(entry)
+				if newStart == nil || bytes.Compare(te.RangeStart, newStart) < 0 {
+					newStart = te.RangeStart
+				}
+				if newEnd == nil || bytes.Compare(te.RangeEnd, newEnd) > 0 {
+					newEnd = te.RangeEnd
+				}
+			}
+		} else if len(entry.tableEntries) > 0 {
+			newStart = entry.tableEntries[0].Get(entry).RangeStart
+			newEnd = entry.tableEntries[len(entry.tableEntries)-1].Get(entry).RangeEnd
+		}
+		entry.rangeStart = newStart
+		entry.rangeEnd = newEnd
+
+		// Update stats
+		lm.masterRecord.levelTableCounts[deRegistration.Level]--
+		lm.masterRecord.stats.TotTables--
+		lm.masterRecord.stats.TotBytes -= int(deRegistration.TableSize)
+		lm.masterRecord.stats.TotEntries -= int(deRegistration.NumEntries)
+		levStats := lm.getLevelStats(deRegistration.Level)
+		levStats.Tables--
+		levStats.Bytes -= int(deRegistration.TableSize)
+		levStats.Entries -= int(deRegistration.NumEntries)
+	}
+	return nil
+}
+
+// use pointers here - no need to copy
+func (lm *Manager) getLevelEntry(level int) *levelEntry {
+	lm.maybeResizeLevelEntries(level)
+	return lm.masterRecord.levelEntries[level]
+}
+
+func (lm *Manager) maybeResizeLevelEntries(level int) {
+	if level >= len(lm.masterRecord.levelEntries) {
+		newEntries := make([]*levelEntry, level+1)
+		copy(newEntries, lm.masterRecord.levelEntries)
+		for j := len(lm.masterRecord.levelEntries); j < level+1; j++ {
+			newEntries[j] = &levelEntry{}
+		}
+		lm.masterRecord.levelEntries = newEntries
+	}
+}
+
+func (lm *Manager) applyRegistrations(registrations []RegistrationEntry) error { //nolint:gocyclo
+	for _, registration := range registrations {
+		log.Debugf("got reg keystart %v keyend %v", registration.KeyStart, registration.KeyEnd)
+		if len(registration.KeyStart) == 0 || len(registration.KeyEnd) <= 8 {
+			return errwrap.Errorf("registration, key start/end does not have a version: %v", registration)
+		}
+		log.Debugf("LevelManager registering new table %v (%s) from %s to %s in level %d",
+			registration.TableID, string(registration.TableID), string(registration.KeyStart), string(registration.KeyEnd), registration.Level)
+		// The new table entry that we're going to add
+		tabEntry := &TableEntry{
+			SSTableID:        registration.TableID,
+			RangeStart:       registration.KeyStart,
+			RangeEnd:         registration.KeyEnd,
+			MinVersion:       registration.MinVersion,
+			MaxVersion:       registration.MaxVersion,
+			DeleteRatio:      registration.DeleteRatio,
+			AddedTime:        registration.AddedTime,
+			NumEntries:       registration.NumEntries,
+			Size:             registration.TableSize,
+			NumPrefixDeletes: registration.NumPrefixDeletes,
+		}
+		entry := lm.getLevelEntry(registration.Level)
+		if registration.MaxVersion > entry.maxVersion {
+			entry.maxVersion = registration.MaxVersion
+		}
+		// Note, that if the same table is added more than once by a client if it retries after transient error, this
+		// does not matter, as when an iterator sees keys of the same version it will only take the first and ignore the
+		// others
+		if registration.Level == 0 {
+			// We have overlapping keys in L0, so we just append to the last table entry
+			entry.InsertAt(len(entry.tableEntries), tabEntry)
+		} else {
+			// L > 0
+			// Table entries in these levels are non overlapping
+			numTableEntries := len(entry.tableEntries)
+			if numTableEntries == 0 {
+				// The first table entry
+				entry.InsertAt(0, tabEntry)
+			} else {
+				// Find the insert before point
+				insertPoint := -1
+				index := sort.Search(numTableEntries, func(i int) bool {
+					te := entry.tableEntries[i].Get(entry)
+					return bytes.Compare(registration.KeyEnd, te.RangeStart) < 0
+				})
+				if index < numTableEntries {
+					insertPoint = index
+				}
+				if insertPoint > 0 {
+					// check no overlap with previous table entry
+					l := entry.tableEntries[insertPoint-1]
+					te := l.Get(entry)
+					if bytes.Compare(te.RangeEnd, registration.KeyStart) >= 0 {
+						msg := fmt.Sprintf("got overlap with previous table id %s, prev key end %s inserting key start %s inserting key end %s",
+							string(te.SSTableID), string(te.RangeEnd), string(registration.KeyStart),
+							string(registration.KeyEnd))
+						return common.Error(msg)
+					}
+				}
+				if insertPoint == -1 {
+					// insert at end
+					insertPoint = len(entry.tableEntries)
+				}
+				// Insert the new entry in the table entries in the right place
+				entry.InsertAt(insertPoint, tabEntry)
+				//var newTableEntries []*TableEntry
+				//if insertPoint >= 0 {
+				//	left := entry.tableEntries[:insertPoint]
+				//	right := entry.tableEntries[insertPoint:]
+				//	newTableEntries = append(newTableEntries, left...)
+				//	newTableEntries = append(newTableEntries, tabEntry)
+				//	newTableEntries = append(newTableEntries, right...)
+				//} else if insertPoint == -1 {
+				//	newTableEntries = append(newTableEntries, entry.tableEntries...)
+				//	newTableEntries = append(newTableEntries, tabEntry)
+				//}
+				//entry.tableEntries = newTableEntries
+			}
+		}
+		// Update the ranges
+		if entry.rangeStart == nil || bytes.Compare(registration.KeyStart, entry.rangeStart) < 0 {
+			entry.rangeStart = registration.KeyStart
+		}
+		if bytes.Compare(registration.KeyEnd, entry.rangeEnd) > 0 {
+			entry.rangeEnd = registration.KeyEnd
+		}
+		lm.masterRecord.levelTableCounts[registration.Level]++
+		// Update stats
+		if registration.Level == 0 {
+			lm.masterRecord.stats.TablesIn++
+			lm.masterRecord.stats.BytesIn += int(registration.TableSize)
+			lm.masterRecord.stats.EntriesIn += int(registration.NumEntries)
+		}
+		lm.masterRecord.stats.TotTables++
+		lm.masterRecord.stats.TotBytes += int(registration.TableSize)
+		lm.masterRecord.stats.TotEntries += int(registration.NumEntries)
+		levStats := lm.getLevelStats(registration.Level)
+		levStats.Tables++
+		levStats.Bytes += int(registration.TableSize)
+		levStats.Entries += int(registration.NumEntries)
+	}
+	return nil
+}
+
+func (lm *Manager) getLevelStats(level int) *LevelStats {
+	levStats, ok := lm.masterRecord.stats.LevelStats[level]
+	if !ok {
+		levStats = &LevelStats{}
+		lm.masterRecord.stats.LevelStats[level] = levStats
+	}
+	return levStats
+}
+
+func (lm *Manager) scheduleTableDeleteTimer() {
+	lm.tableDeleteTimer = time.AfterFunc(lm.conf.SSTableDeleteCheckInterval, func() {
+		lm.maybeDeleteTables()
+	})
+}
+
+func (lm *Manager) maybeDeleteTables() {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	if !lm.started {
+		return
+	}
+	pos := -1
+	now := arista.NanoTime()
+	for i, entry := range lm.tablesToDelete {
+		age := time.Duration(now - entry.addedTime)
+		if age < lm.conf.SSTableDeleteDelay {
+			break
+		}
+		log.Debugf("deleted sstable %v", entry.tableID)
+		if err := objstore.DeleteWithTimeout(lm.objStore, lm.conf.BucketName, string(entry.tableID), objstore.DefaultCallTimeout); err != nil {
+			log.Errorf("failed to delete ss-table from cloud store: %v", err)
+			break
+		}
+		pos = i
+	}
+	if pos != -1 {
+		lm.tablesToDelete = lm.tablesToDelete[pos+1:]
+	}
+	lm.scheduleTableDeleteTimer()
+}
+
+func hasOverlap(keyStart []byte, keyEnd []byte, blockKeyStart []byte, blockKeyEnd []byte) bool {
+	// Note! keyStart is inclusive, keyEnd is exclusive
+	// LevelManager keyStart and keyEnd are inclusive!
+	dontOverlapRight := bytes.Compare(keyStart, blockKeyEnd) > 0                  // Range starts after end of block
+	dontOverlapLeft := keyEnd != nil && bytes.Compare(keyEnd, blockKeyStart) <= 0 // Range ends before beginning of block
+	dontOverlap := dontOverlapLeft || dontOverlapRight
+	return !dontOverlap
+}
+
+func (lm *Manager) DumpLevelInfo() {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	lm.dumpLevelInfo()
+}
+
+func (lm *Manager) dumpLevelInfo() {
+	builder := strings.Builder{}
+	for level := range lm.masterRecord.levelEntries {
+		tableCount := lm.masterRecord.levelTableCounts[level]
+		builder.WriteString(fmt.Sprintf("level:%d table_count:%d, ", level, tableCount))
+	}
+	log.Info(builder.String())
+}
+
+func (lm *Manager) Dump() {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	lm.dump()
+}
+
+func (lm *Manager) dump() {
+	log.Infof("Dumping LevelManager ====================")
+	for level, entry := range lm.masterRecord.levelEntries {
+		log.Infof("Dumping level %d. Max version %d. Range Start: %v Range End: %v. There are %d table entries",
+			level, entry.maxVersion, entry.rangeStart, entry.rangeEnd, len(entry.tableEntries))
+		for _, lte := range entry.tableEntries {
+			te := lte.Get(entry)
+			log.Infof("table entry sstableid %v (%s) range start %s range end %s deleteRatio %.2f hasDeletes %t", te.SSTableID, string(te.SSTableID),
+				string(te.RangeStart), string(te.RangeEnd), te.DeleteRatio, te.DeleteRatio > 0)
+		}
+	}
+	for prefix := range lm.masterRecord.slabRetentions {
+		log.Infof("prefix %v", prefix)
+	}
+}
+
+func getTableEntryForDeregistration(levEntry *levelEntry, deRegistration RegistrationEntry) int {
+	pos := -1
+	if deRegistration.Level == 0 {
+		// Level 0 is not ordered so we need to scan
+		for i, lte := range levEntry.tableEntries {
+			te := lte.Get(levEntry)
+			if bytes.Equal(te.SSTableID, deRegistration.TableID) {
+				pos = i
+				break
+			}
+		}
+		return pos
+	}
+	// Search in L > 0 - these are ordered so we can use binary search
+	n := len(levEntry.tableEntries)
+	// if the ids are equal their ranges will be as well
+	pos = sort.Search(n, func(i int) bool {
+		lte := levEntry.tableEntries[i].Get(levEntry)
+		return bytes.Compare(lte.RangeStart, deRegistration.KeyStart) >= 0
+	})
+	if pos >= n {
+		pos = -1
+	}
+	// it's also possible for multiple table entries to have the same range
+	for i := pos; i < n; i++ {
+		lte := levEntry.tableEntries[i]
+		te := lte.Get(levEntry)
+		if bytes.Equal(te.SSTableID, deRegistration.TableID) {
+			pos = i
+			break
+		}
+	}
+	return pos
+}
+
+func (lm *Manager) GetObjectStore() objstore.Client {
+	return lm.objStore
+}
+
+func (lm *Manager) GetLevelTableCounts() map[int]int {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	counts := map[int]int{}
+	for level, count := range lm.masterRecord.levelTableCounts {
+		counts[level] = count
+	}
+	return counts
+}
+
+func (lm *Manager) GetStats() Stats {
+	lm.lock.RLock()
+	defer lm.lock.RUnlock()
+	statsCopy := lm.masterRecord.stats.copy()
+	return *statsCopy
+}
+
+// Only used in testing
+func (lm *Manager) reset() {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	lm.started = false
+	lm.clusterVersions = map[string]int{}
+	lm.masterRecord = nil
+}
+
+func (lm *Manager) GetLevelEntry(level int) *levelEntry {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	return lm.getLevelEntry(level)
+}
+
+// Used in testing only
+func (lm *Manager) getMasterRecord() *MasterRecord {
+	lm.lock.Lock()
+	defer lm.lock.Unlock()
+	// Serialize/Deserialize so not to expose internal MasterRecord directly
+	buff := lm.masterRecord.Serialize(nil)
+	mr := &MasterRecord{}
+	mr.Deserialize(buff, 0)
+	return mr
+}

--- a/lsm/level_manager_test.go
+++ b/lsm/level_manager_test.go
@@ -1202,7 +1202,7 @@ func regTableInLevel(t *testing.T, lm *Manager, level int, keyStart int, keyEnd 
 }
 
 func verifyTablesInLevel(t *testing.T, lm *Manager, level int, expectedTablePairs []int) {
-	levEntry := lm.getLevelEntry(level)
+	levEntry := lm.GetLevelEntry(level)
 	require.Equal(t, len(expectedTablePairs), 2*len(levEntry.tableEntries))
 	pos := 0
 	for i := 0; i < len(expectedTablePairs); i += 2 {

--- a/lsm/level_manager_test.go
+++ b/lsm/level_manager_test.go
@@ -1,0 +1,1219 @@
+package lsm
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/asl/conf"
+	encoding2 "github.com/spirit-labs/tektite/asl/encoding"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/objstore/dev"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestAddAndGet_L0(t *testing.T) {
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	l0Pairs := []int{3, 5, 6, 7, 8, 12, //contiguous
+		14, 17, 20, 21, 23, 30, //gaps between
+		32, 40, 32, 40, 32, 40, //exactly overlapping
+		42, 50, 45, 47, //one fully inside other
+		51, 54, 52, 56, 54, 60}
+	addedTableIDs := addTables(t, levelManager, 0, l0Pairs...) //each overlapping next one
+
+	verifyTablesInLevel(t, levelManager, 0, l0Pairs)
+
+	// Before data shouldn't find anything
+	overlapTableIDs := getInRange(t, levelManager, 0, 1)
+	validateTabIds(t, nil, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 0, 3)
+	validateTabIds(t, nil, overlapTableIDs)
+
+	// After data shouldn't find anything
+	overlapTableIDs = getInRange(t, levelManager, 91, 93)
+	validateTabIds(t, nil, overlapTableIDs)
+
+	// Get entire contiguous block with exact range
+	overlapTableIDs = getInRange(t, levelManager, 3, 13)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[2]},
+		NonOverlappingTables{addedTableIDs[1]},
+		NonOverlappingTables{addedTableIDs[0]},
+	}, overlapTableIDs)
+
+	// Get entire contiguous block with smaller range
+	overlapTableIDs = getInRange(t, levelManager, 4, 10)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[2]},
+		NonOverlappingTables{addedTableIDs[1]},
+		NonOverlappingTables{addedTableIDs[0]},
+	}, overlapTableIDs)
+
+	// Get entire contiguous block with larger range
+	overlapTableIDs = getInRange(t, levelManager, 2, 14)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[2]},
+		NonOverlappingTables{addedTableIDs[1]},
+		NonOverlappingTables{addedTableIDs[0]},
+	}, overlapTableIDs)
+
+	// Get exactly one from contiguous block
+	overlapTableIDs = getInRange(t, levelManager, 6, 8)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[1]},
+	}, overlapTableIDs)
+
+	// Don't return anything from gap
+	overlapTableIDs = getInRange(t, levelManager, 18, 20)
+	validateTabIds(t, nil, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 18, 19)
+	validateTabIds(t, nil, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 22, 23)
+	validateTabIds(t, nil, overlapTableIDs)
+
+	// Select entire block with gaps
+	overlapTableIDs = getInRange(t, levelManager, 14, 31)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[5]},
+		NonOverlappingTables{addedTableIDs[4]},
+		NonOverlappingTables{addedTableIDs[3]},
+	}, overlapTableIDs)
+
+	// Select subset with gaps
+	overlapTableIDs = getInRange(t, levelManager, 18, 22)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[4]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 18, 31)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[5]},
+		NonOverlappingTables{addedTableIDs[4]},
+	}, overlapTableIDs)
+
+	// Exactly overlapping
+	overlapTableIDs = getInRange(t, levelManager, 32, 41)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[8]},
+		NonOverlappingTables{addedTableIDs[7]},
+		NonOverlappingTables{addedTableIDs[6]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 31, 41)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[8]},
+		NonOverlappingTables{addedTableIDs[7]},
+		NonOverlappingTables{addedTableIDs[6]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 35, 35)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[8]},
+		NonOverlappingTables{addedTableIDs[7]},
+		NonOverlappingTables{addedTableIDs[6]},
+	}, overlapTableIDs)
+
+	// Fully inside
+	overlapTableIDs = getInRange(t, levelManager, 42, 48)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[10]},
+		NonOverlappingTables{addedTableIDs[9]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 41, 49)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[10]},
+		NonOverlappingTables{addedTableIDs[9]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 45, 46)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[10]},
+		NonOverlappingTables{addedTableIDs[9]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 41, 43)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[9]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 48, 49)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[9]},
+	}, overlapTableIDs)
+
+	// Select entire block overlapping next
+	overlapTableIDs = getInRange(t, levelManager, 51, 61)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[13]},
+		NonOverlappingTables{addedTableIDs[12]},
+		NonOverlappingTables{addedTableIDs[11]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 53, 58)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[13]},
+		NonOverlappingTables{addedTableIDs[12]},
+		NonOverlappingTables{addedTableIDs[11]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 51, 53)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[12]},
+		NonOverlappingTables{addedTableIDs[11]},
+	}, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 55, 56)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[13]},
+		NonOverlappingTables{addedTableIDs[12]},
+	}, overlapTableIDs)
+
+	afterTest(t, levelManager)
+}
+
+func TestAddAndGet_L1(t *testing.T) {
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	l1Pairs := []int{3, 5, 6, 8, 9, 11, 14, 15, 20, 30, 35, 50}
+
+	addedTableIDs := addTables(t, levelManager, 1, l1Pairs...)
+	verifyTablesInLevel(t, levelManager, 1, l1Pairs)
+
+	// Before data shouldn't find anything
+	overlapTableIDs := getInRange(t, levelManager, 0, 1)
+	validateTabIds(t, nil, overlapTableIDs)
+	overlapTableIDs = getInRange(t, levelManager, 0, 3)
+	validateTabIds(t, nil, overlapTableIDs)
+
+	// After data shouldn't find anything
+	overlapTableIDs = getInRange(t, levelManager, 51, 56)
+	validateTabIds(t, nil, overlapTableIDs)
+
+	// Get entire block with exact range
+	overlapTableIDs = getInRange(t, levelManager, 3, 51)
+	validateTabIds(t, OverlappingTables{addedTableIDs}, overlapTableIDs)
+
+	// Get subset block with exact range
+	overlapTableIDs = getInRange(t, levelManager, 6, 16)
+	validateTabIds(t, OverlappingTables{addedTableIDs[1:4]}, overlapTableIDs)
+
+	// Get entire block with larger range
+	overlapTableIDs = getInRange(t, levelManager, 0, 1000)
+	validateTabIds(t, OverlappingTables{addedTableIDs}, overlapTableIDs)
+
+	// Get single table
+	overlapTableIDs = getInRange(t, levelManager, 9, 11)
+	validateTabIds(t, OverlappingTables{{addedTableIDs[2]}}, overlapTableIDs)
+
+	afterTest(t, levelManager)
+}
+
+func TestAddAndGet_MultipleLevels(t *testing.T) {
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	l0Pairs := []int{51, 54, 52, 56, 54, 60}
+	addedTableIDs0 := addTables(t, levelManager, 0, l0Pairs...)
+	verifyTablesInLevel(t, levelManager, 0, l0Pairs)
+
+	l1Pairs := []int{48, 49, 52, 54, 55, 58, 59, 63}
+	addedTableIDs1 := addTables(t, levelManager, 1, l1Pairs...)
+	verifyTablesInLevel(t, levelManager, 1, l1Pairs)
+
+	l2Pairs := []int{22, 31, 38, 48, 50, 52, 53, 65, 68, 70}
+	addedTableIDs2 := addTables(t, levelManager, 2, l2Pairs...)
+	verifyTablesInLevel(t, levelManager, 2, l2Pairs)
+
+	// Get everything
+	overlapTableIDs := getInRange(t, levelManager, 20, 70)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs0[2]},
+		NonOverlappingTables{addedTableIDs0[1]},
+		NonOverlappingTables{addedTableIDs0[0]},
+		addedTableIDs1,
+		addedTableIDs2,
+	}, overlapTableIDs)
+
+	// Get selection
+	overlapTableIDs = getInRange(t, levelManager, 55, 58)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs0[2]},
+		NonOverlappingTables{addedTableIDs0[1]},
+		addedTableIDs1[2:3],
+		addedTableIDs2[3:4],
+	}, overlapTableIDs)
+
+	afterTest(t, levelManager)
+}
+
+func TestAddAndRemove_L0(t *testing.T) {
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	l0Pairs := []int{2, 4, 5, 7, 14, 17, 20, 21, 23, 30}
+	addedTableIDs := addTables(t, levelManager, 0, l0Pairs...)
+	verifyTablesInLevel(t, levelManager, 0, l0Pairs)
+
+	overlapTableIDs := getInRange(t, levelManager, 2, 31)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[4]},
+		NonOverlappingTables{addedTableIDs[3]},
+		NonOverlappingTables{addedTableIDs[2]},
+		NonOverlappingTables{addedTableIDs[1]},
+		NonOverlappingTables{addedTableIDs[0]},
+	}, overlapTableIDs)
+
+	deregEntry0 := RegistrationEntry{
+		Level:    0,
+		TableID:  overlapTableIDs[4][0].ID,
+		KeyStart: createKey(2),
+		KeyEnd:   createKey(4),
+	}
+	deregBatch := RegistrationBatch{
+		DeRegistrations: []RegistrationEntry{deregEntry0},
+	}
+	err := levelManager.ApplyChangesNoCheck(deregBatch)
+	require.NoError(t, err)
+
+	overlapTableIDs2 := getInRange(t, levelManager, 2, 31)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[4]},
+		NonOverlappingTables{addedTableIDs[3]},
+		NonOverlappingTables{addedTableIDs[2]},
+		NonOverlappingTables{addedTableIDs[1]},
+	}, overlapTableIDs2)
+	remaining := []int{5, 7, 14, 17, 20, 21, 23, 30}
+	verifyTablesInLevel(t, levelManager, 0, remaining)
+
+	deregEntry2 := RegistrationEntry{
+		Level:    0,
+		TableID:  overlapTableIDs[2][0].ID,
+		KeyStart: createKey(14),
+		KeyEnd:   createKey(17),
+	}
+
+	deregEntry4 := RegistrationEntry{
+		Level:    0,
+		TableID:  overlapTableIDs[0][0].ID,
+		KeyStart: createKey(23),
+		KeyEnd:   createKey(30),
+	}
+
+	deregBatch2 := RegistrationBatch{
+		DeRegistrations: []RegistrationEntry{deregEntry2, deregEntry4},
+	}
+	err = levelManager.ApplyChangesNoCheck(deregBatch2)
+	require.NoError(t, err)
+
+	overlapTableIDs3 := getInRange(t, levelManager, 2, 31)
+	validateTabIds(t, OverlappingTables{
+		NonOverlappingTables{addedTableIDs[3]},
+		NonOverlappingTables{addedTableIDs[1]},
+	}, overlapTableIDs3)
+
+	remaining = []int{5, 7, 20, 21}
+	verifyTablesInLevel(t, levelManager, 0, remaining)
+
+	deregEntry1 := RegistrationEntry{
+		Level:    0,
+		TableID:  overlapTableIDs[3][0].ID,
+		KeyStart: createKey(5),
+		KeyEnd:   createKey(7),
+	}
+
+	deregEntry3 := RegistrationEntry{
+		Level:    0,
+		TableID:  overlapTableIDs[1][0].ID,
+		KeyStart: createKey(20),
+		KeyEnd:   createKey(21),
+	}
+
+	deregBatch3 := RegistrationBatch{
+		DeRegistrations: []RegistrationEntry{deregEntry1, deregEntry3},
+	}
+	err = levelManager.ApplyChangesNoCheck(deregBatch3)
+	require.NoError(t, err)
+
+	verifyTablesInLevel(t, levelManager, 0, nil)
+
+	afterTest(t, levelManager)
+}
+
+func TestAddRemove_L0(t *testing.T) {
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	mr := levelManager.getMasterRecord()
+	require.Equal(t, common.MetadataFormatV1, mr.format)
+	require.Equal(t, uint64(0), mr.version)
+	require.Equal(t, 0, len(mr.levelEntries))
+
+	// Add some table entries in level 0
+
+	tableIDs1 := addTables(t, levelManager, 0,
+		12, 17, 3, 9, 1, 2, 10, 15, 4, 20, 7, 30)
+
+	mr = levelManager.getMasterRecord()
+	require.Equal(t, common.MetadataFormatV1, mr.format)
+	require.Equal(t, uint64(1), mr.version)
+	require.Equal(t, 1, len(mr.levelEntries))
+
+	levEntry := mr.levelEntries[0]
+	require.NotNil(t, levEntry)
+	require.Equal(t, 6, len(levEntry.tableEntries))
+	require.Equal(t, createKey(1), levEntry.rangeStart)
+	require.Equal(t, createKey(30), levEntry.rangeEnd)
+
+	// Add some more - now there should be 10
+
+	tableIDs2 := addTables(t, levelManager, 0,
+		11, 13, 3, 9, 0, 35, 7, 12)
+
+	mr = levelManager.getMasterRecord()
+	require.Equal(t, common.MetadataFormatV1, mr.format)
+	require.Equal(t, uint64(2), mr.version)
+	require.Equal(t, 1, len(mr.levelEntries))
+
+	levEntry = mr.levelEntries[0]
+	require.NotNil(t, levEntry)
+	require.Equal(t, 10, len(levEntry.tableEntries))
+	require.Equal(t, createKey(0), levEntry.rangeStart)
+	require.Equal(t, createKey(35), levEntry.rangeEnd)
+
+	// Add some more
+
+	tableIDs3 := addTables(t, levelManager, 0,
+		15, 19, 45, 47, 12, 13, 88, 89, 45, 40)
+
+	mr = levelManager.getMasterRecord()
+	require.Equal(t, common.MetadataFormatV1, mr.format)
+	require.Equal(t, uint64(3), mr.version)
+
+	levEntry = mr.levelEntries[0]
+	require.NotNil(t, levEntry)
+	require.Equal(t, 15, len(levEntry.tableEntries))
+	require.Equal(t, createKey(0), levEntry.rangeStart)
+	require.Equal(t, createKey(89), levEntry.rangeEnd)
+
+	// Now delete some
+	removeTables(t, levelManager, 0, tableIDs3, 15, 19, 45, 47, 12, 13, 88, 89, 45, 40)
+
+	mr = levelManager.getMasterRecord()
+	require.Equal(t, common.MetadataFormatV1, mr.format)
+	require.Equal(t, uint64(4), mr.version)
+
+	levEntry = mr.levelEntries[0]
+	require.NotNil(t, levEntry)
+	require.Equal(t, 10, len(levEntry.tableEntries))
+	require.Equal(t, createKey(0), levEntry.rangeStart)
+	require.Equal(t, createKey(35), levEntry.rangeEnd)
+
+	removeTables(t, levelManager, 0, tableIDs2, 11, 13, 3, 9, 0, 35, 7, 12)
+
+	mr = levelManager.getMasterRecord()
+	require.Equal(t, common.MetadataFormatV1, mr.format)
+	require.Equal(t, uint64(5), mr.version)
+
+	levEntry = mr.levelEntries[0]
+	require.NotNil(t, levEntry)
+	require.Equal(t, 6, len(levEntry.tableEntries))
+	require.Equal(t, createKey(1), levEntry.rangeStart)
+	require.Equal(t, createKey(30), levEntry.rangeEnd)
+
+	removeTables(t, levelManager, 0, tableIDs1, 12, 17, 3, 9, 1, 2, 10, 15, 4, 20, 7, 30)
+
+	// Should be all gone
+	mr = levelManager.getMasterRecord()
+	require.Equal(t, common.MetadataFormatV1, mr.format)
+	require.Equal(t, uint64(6), mr.version)
+	require.Equal(t, 0, len(mr.levelEntries[0].tableEntries))
+
+	afterTest(t, levelManager)
+}
+
+func TestAddAndRemoveSameBatch(t *testing.T) {
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	tableIDs := addTables(t, levelManager, 1, 3, 5, 6, 7, 8, 12)
+
+	newTableID1, err := uuid.New().MarshalBinary()
+	require.NoError(t, err)
+	newTableID2, err := uuid.New().MarshalBinary()
+	require.NoError(t, err)
+
+	regBatch := RegistrationBatch{
+		Registrations: []RegistrationEntry{{
+			Level:    1,
+			TableID:  newTableID1,
+			KeyStart: createKey(15),
+			KeyEnd:   createKey(19),
+		}, {
+			Level:    1,
+			TableID:  newTableID2,
+			KeyStart: createKey(36),
+			KeyEnd:   createKey(39),
+		}},
+		DeRegistrations: []RegistrationEntry{{
+			Level:    1,
+			TableID:  tableIDs[1].ID,
+			KeyStart: createKey(6),
+			KeyEnd:   createKey(7),
+		}},
+	}
+	err = levelManager.ApplyChangesNoCheck(regBatch)
+	require.NoError(t, err)
+
+	oTabIDs, err := levelManager.QueryTablesInRange(createKey(3), createKey(1000))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(oTabIDs))
+	noTabIDs := oTabIDs[0]
+	require.Equal(t, 4, len(noTabIDs))
+
+	require.Equal(t, tableIDs[0], noTabIDs[0])
+	require.Equal(t, tableIDs[2], noTabIDs[1])
+	require.Equal(t, sst.SSTableID(newTableID1), noTabIDs[2].ID)
+	require.Equal(t, sst.SSTableID(newTableID2), noTabIDs[3].ID)
+
+	afterTest(t, levelManager)
+}
+
+func TestNilRangeStartAndEnd(t *testing.T) {
+	// Range start of nil means start at the beginning
+	testNilRangeStartAndEnd(t, nil, createKey(1000))
+	// Range end of nil means right to the end
+	testNilRangeStartAndEnd(t, createKey(0), nil)
+	// Full range
+	testNilRangeStartAndEnd(t, nil, nil)
+}
+
+func testNilRangeStartAndEnd(t *testing.T, rangeStart []byte, rangeEnd []byte) {
+	t.Helper()
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	addTables(t, levelManager, 1, 3, 5, 6, 7, 8, 12)
+
+	oTabIDs, err := levelManager.QueryTablesInRange(rangeStart, rangeEnd)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(oTabIDs))
+	noTabIDs := oTabIDs[0]
+	require.Equal(t, 3, len(noTabIDs))
+}
+
+func TestAddRemoveL1_OrderedKeys(t *testing.T) {
+	testAddRemoveNonOverlapping(t, true, 1, 0, 1)
+	testAddRemoveNonOverlapping(t, true, 1, 1, 1)
+	testAddRemoveNonOverlapping(t, true, 1, 0, 3)
+	testAddRemoveNonOverlapping(t, true, 3, 0, 1)
+}
+
+func TestAddRemoveL1_RandomKeys(t *testing.T) {
+	testAddRemoveNonOverlapping(t, false, 1, 0, 1)
+	testAddRemoveNonOverlapping(t, false, 1, 1, 1)
+	testAddRemoveNonOverlapping(t, false, 1, 0, 3)
+	testAddRemoveNonOverlapping(t, false, 3, 0, 1)
+}
+
+func testAddRemoveNonOverlapping(t *testing.T, ordered bool, level int, rangeGap int, batchSize int) {
+	t.Helper()
+	numEntries := 1000
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	entries := prepareEntries(numEntries, 2, rangeGap)
+	if !ordered {
+		entries = shuffleEntries(entries)
+	}
+
+	var regBatch *RegistrationBatch
+	entryNum := 0
+	batchNum := 0
+	for entryNum < len(entries) {
+		if regBatch == nil {
+			regBatch = &RegistrationBatch{}
+		}
+		ent := entries[entryNum]
+		tableID, err := uuid.New().MarshalBinary()
+		require.NoError(t, err)
+		regBatch.Registrations = append(regBatch.Registrations, RegistrationEntry{
+			Level:    level,
+			TableID:  tableID,
+			KeyStart: ent.keyStart,
+			KeyEnd:   ent.keyEnd,
+		})
+		if len(regBatch.Registrations) == batchSize || entryNum == len(entries)-1 {
+			err = levelManager.ApplyChangesNoCheck(*regBatch)
+			require.NoError(t, err)
+			// Get the table ids to make sure they were added ok
+			for i := 0; i < len(regBatch.Registrations); i++ {
+				oIDs, err := levelManager.QueryTablesInRange(regBatch.Registrations[i].KeyStart,
+					common.IncBigEndianBytes(regBatch.Registrations[i].KeyEnd))
+				require.NoError(t, err)
+				require.Equal(t, 1, len(oIDs))
+				nIDs := oIDs[0]
+				require.Equal(t, 1, len(nIDs))
+				require.Equal(t, regBatch.Registrations[i].TableID, nIDs[0].ID)
+				// We store the sstableid on the entry so we can use it later in the deregistration
+				entries[entryNum+1-len(regBatch.Registrations)+i].tableID = nIDs[0].ID
+			}
+			checkState(t, levelManager, batchNum)
+			batchNum++
+			regBatch = nil
+		}
+		entryNum++
+	}
+	regBatch = nil
+
+	// Now shuffle the entries and remove in batches
+	// verify removed entries can't be getted
+	if !ordered {
+		entries = shuffleEntries(entries)
+	}
+	entryNum = 0
+	for entryNum < len(entries) {
+		if regBatch == nil {
+			regBatch = &RegistrationBatch{}
+		}
+		ent := entries[entryNum]
+
+		regBatch.DeRegistrations = append(regBatch.DeRegistrations, RegistrationEntry{
+			Level:    level,
+			TableID:  ent.tableID,
+			KeyStart: ent.keyStart,
+			KeyEnd:   ent.keyEnd,
+		})
+		if len(regBatch.DeRegistrations) == batchSize || entryNum == len(entries)-1 {
+			err := levelManager.ApplyChangesNoCheck(*regBatch)
+			require.NoError(t, err)
+			// Get the table ids to make sure they were removed ok
+			for i := 0; i < len(regBatch.DeRegistrations); i++ {
+				oIDs, err := levelManager.QueryTablesInRange(regBatch.DeRegistrations[i].KeyStart,
+					common.IncBigEndianBytes(regBatch.DeRegistrations[i].KeyEnd))
+				require.NoError(t, err)
+				require.Equal(t, 0, len(oIDs))
+			}
+			checkState(t, levelManager, batchNum)
+			batchNum++
+			regBatch = nil
+		}
+		entryNum++
+	}
+}
+
+func shuffleEntries(entries []entry) []entry {
+	rand.Shuffle(len(entries), func(i, j int) { entries[i], entries[j] = entries[j], entries[i] })
+	return entries
+}
+
+func checkState(t *testing.T, levelManager *Manager, batchNum int) {
+	t.Helper()
+	err := levelManager.Validate(false)
+	require.NoError(t, err)
+	mr := levelManager.getMasterRecord()
+	require.NotNil(t, mr)
+	require.Equal(t, batchNum+1, int(mr.version))
+}
+
+func prepareEntries(numEntries int, rangeSize int, rangeGap int) []entry {
+	entries := make([]entry, 0, numEntries)
+	start := 0
+	for i := 0; i < numEntries; i++ {
+		ks := createKey(start)
+		ke := createKey(start + rangeSize - 1)
+		start += rangeSize + rangeGap
+		entries = append(entries, entry{
+			keyStart: ks,
+			keyEnd:   ke,
+		})
+	}
+	return entries
+}
+
+type entry struct {
+	keyStart []byte
+	keyEnd   []byte
+	tableID  sst.SSTableID
+}
+
+func afterTest(t *testing.T, levelManager *Manager) {
+	t.Helper()
+	err := levelManager.Validate(false)
+	require.NoError(t, err)
+}
+
+func validateTabIds(t *testing.T, expectedTabIDs OverlappingTables, actualTabIDs OverlappingTables) {
+	t.Helper()
+	require.Equal(t, expectedTabIDs, actualTabIDs)
+}
+
+func getInRange(t *testing.T, levelManager *Manager, ks int, ke int) OverlappingTables {
+	t.Helper()
+	keyStart := createKey(ks)
+	keyEnd := createKey(ke)
+	overlapTabIDs, err := levelManager.QueryTablesInRange(keyStart, keyEnd)
+	require.NoError(t, err)
+	return overlapTabIDs
+}
+
+func setupLevelManager(t *testing.T) (*Manager, func(t *testing.T)) {
+	t.Helper()
+	return setupLevelManagerWithConfigSetter(t, false, true, func(cfg *conf.Config) {})
+}
+
+func setupLevelManagerWithConfigSetter(t *testing.T, enableCompaction bool, validate bool,
+	configSetter func(cfg *conf.Config)) (*Manager, func(t *testing.T)) {
+	t.Helper()
+	cfg := conf.Config{}
+	cfg.ApplyDefaults()
+	configSetter(&cfg)
+	cloudStore := &dev.InMemStore{}
+	lm := NewManager(&cfg, cloudStore, enableCompaction, validate)
+	mr := NewMasterRecord(common.MetadataFormatV1)
+	err := lm.Start(mr)
+	require.NoError(t, err)
+	return lm, func(t *testing.T) {
+		err := lm.Stop()
+		require.NoError(t, err)
+		err = cloudStore.Stop()
+		require.NoError(t, err)
+	}
+}
+
+func createKey(i int) []byte {
+	// First 24 bytes is the [partition_hash, slab_id] - we just add a constant prefix
+	prefix := make([]byte, 0, 24)
+	prefix = append(prefix, []byte("xxxxxxxxxxxxxxxx")...)  // partition hash
+	prefix = encoding2.AppendUint64ToBufferBE(prefix, 1234) // slab id
+	prefix = append(prefix, []byte(fmt.Sprintf("key-%010d", i))...)
+	return encoding2.EncodeVersion(prefix, 0)
+}
+
+func removeTables(t *testing.T, levelManager *Manager, level int, tabIDs []QueryTableInfo, pairs ...int) {
+	t.Helper()
+	var regEntries []RegistrationEntry
+	j := 0
+	for i := 0; i < len(pairs); i++ {
+		ks := pairs[i]
+		i++
+		ke := pairs[i]
+		firstKey := createKey(ks)
+		lastKey := createKey(ke)
+		tabID := tabIDs[j]
+		j++
+		regEntry := RegistrationEntry{
+			Level:    level,
+			TableID:  tabID.ID,
+			KeyStart: firstKey,
+			KeyEnd:   lastKey,
+		}
+		regEntries = append(regEntries, regEntry)
+	}
+	regBatch := RegistrationBatch{
+		DeRegistrations: regEntries,
+	}
+	err := levelManager.ApplyChangesNoCheck(regBatch)
+	require.NoError(t, err)
+}
+
+func addTables(t *testing.T, levelManager *Manager, level int, pairs ...int) []QueryTableInfo {
+	t.Helper()
+	addRegEntries, addTableIDs := createRegistrationEntries(t, level, pairs...)
+	regBatch := RegistrationBatch{
+		Registrations: addRegEntries,
+	}
+	err := levelManager.ApplyChangesNoCheck(regBatch)
+	require.NoError(t, err)
+	return addTableIDs
+}
+
+func createRegistrationEntries(t *testing.T, level int, pairs ...int) ([]RegistrationEntry, []QueryTableInfo) {
+	t.Helper()
+	var regEntries []RegistrationEntry
+	var tableIDs []QueryTableInfo
+	for i := 0; i < len(pairs); i++ {
+		ks := pairs[i]
+		i++
+		ke := pairs[i]
+		firstKey := createKey(ks)
+		lastKey := createKey(ke)
+		tabID, err := uuid.New().MarshalBinary()
+		require.NoError(t, err)
+		regEntry := RegistrationEntry{
+			Level:    level,
+			TableID:  tabID,
+			KeyStart: firstKey,
+			KeyEnd:   lastKey,
+		}
+		regEntries = append(regEntries, regEntry)
+		tableIDs = append(tableIDs, QueryTableInfo{ID: tabID})
+	}
+	return regEntries, tableIDs
+}
+
+func TestRegisterAndGetSlabRetentions(t *testing.T) {
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	allRetentions := map[int]time.Duration{}
+	for i := 0; i < 10; i++ {
+		retention := time.Duration(i) * time.Minute
+		err := levelManager.RegisterSlabRetention(i, retention)
+		require.NoError(t, err)
+		allRetentions[i] = retention
+	}
+
+	for slabID, retention := range allRetentions {
+		ret, err := levelManager.GetSlabRetention(slabID)
+		require.NoError(t, err)
+		require.Equal(t, retention, ret)
+	}
+
+	err := levelManager.UnregisterSlabRetention(1)
+	require.NoError(t, err)
+	ret, err := levelManager.GetSlabRetention(1)
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(0), ret)
+}
+
+func TestVersionOnApplyChanges(t *testing.T) {
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	clusterName := "test_cluster"
+
+	tabID, err := uuid.New().MarshalBinary()
+	require.NoError(t, err)
+	regBatch := RegistrationBatch{
+		ClusterName:    clusterName,
+		ClusterVersion: 100,
+		Registrations: []RegistrationEntry{{
+			Level:    0,
+			TableID:  tabID,
+			KeyStart: createKey(0),
+			KeyEnd:   createKey(10),
+		}},
+	}
+	err = callRegisterL0Tables(levelManager, regBatch)
+	require.NoError(t, err)
+
+	// higher version
+	tabID, err = uuid.New().MarshalBinary()
+	require.NoError(t, err)
+	regBatch = RegistrationBatch{
+		ClusterName:    clusterName,
+		ClusterVersion: 101,
+		Registrations: []RegistrationEntry{{
+			Level:    0,
+			TableID:  tabID,
+			KeyStart: createKey(0),
+			KeyEnd:   createKey(10),
+		}},
+	}
+	err = callRegisterL0Tables(levelManager, regBatch)
+	require.NoError(t, err)
+
+	// Now with older version
+	tabID, err = uuid.New().MarshalBinary()
+	require.NoError(t, err)
+	regBatch = RegistrationBatch{
+		ClusterName:    clusterName,
+		ClusterVersion: 99,
+		Registrations: []RegistrationEntry{{
+			Level:    0,
+			TableID:  tabID,
+			KeyStart: createKey(0),
+			KeyEnd:   createKey(10),
+		}},
+	}
+	err = callRegisterL0Tables(levelManager, regBatch)
+	require.Error(t, err)
+	require.True(t, common.IsTektiteErrorWithCode(err, common.Unavailable))
+
+	afterTest(t, levelManager)
+}
+
+func callRegisterL0Tables(lm *Manager, regBatch RegistrationBatch) error {
+	ch := make(chan error, 1)
+	lm.RegisterL0Tables(regBatch, func(err error) {
+		ch <- err
+	})
+	return <-ch
+}
+
+func TestStats(t *testing.T) {
+	lm, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	l0NumTables := 5
+	l0TotTableSize := 0
+	l0TotEntrySize := 0
+	var registrations []RegistrationEntry
+	for i := 0; i < l0NumTables; i++ {
+		numEntries := rand.Intn(10000)
+		tableSize := rand.Intn(10000000)
+		reg := RegistrationEntry{
+			Level:      0,
+			TableID:    sst.SSTableID(uuid.New().String()),
+			MinVersion: 100,
+			MaxVersion: 200,
+			KeyStart:   []byte(fmt.Sprintf("key-%05d", i)),
+			KeyEnd:     []byte(fmt.Sprintf("key-%05d", i+1)),
+			NumEntries: uint64(numEntries),
+			TableSize:  uint64(tableSize),
+		}
+		l0TotEntrySize += numEntries
+		l0TotTableSize += tableSize
+		registrations = append(registrations, reg)
+	}
+
+	regBatch0 := RegistrationBatch{
+		Registrations: registrations,
+	}
+	err := lm.ApplyChangesNoCheck(regBatch0)
+	require.NoError(t, err)
+
+	stats := lm.GetStats()
+	require.Equal(t, l0NumTables, stats.TablesIn)
+	require.Equal(t, l0TotTableSize, stats.BytesIn)
+	require.Equal(t, l0TotEntrySize, stats.EntriesIn)
+
+	require.Equal(t, l0NumTables, stats.TotTables)
+	require.Equal(t, l0TotTableSize, stats.TotBytes)
+	require.Equal(t, l0TotEntrySize, stats.TotEntries)
+
+	require.Equal(t, 1, len(stats.LevelStats))
+	levStats0 := stats.LevelStats[0]
+	require.Equal(t, l0NumTables, levStats0.Tables)
+	require.Equal(t, l0TotTableSize, levStats0.Bytes)
+	require.Equal(t, l0TotEntrySize, levStats0.Entries)
+
+	l1NumTables := 10
+	l1TotTableSize := 0
+	l1TotEntrySize := 0
+	registrations = nil
+	for i := 0; i < l1NumTables; i++ {
+		numEntries := rand.Intn(10000)
+		tableSize := rand.Intn(10000000)
+		reg := RegistrationEntry{
+			Level:      1,
+			TableID:    sst.SSTableID(uuid.New().String()),
+			MinVersion: 100,
+			MaxVersion: 200,
+			KeyStart:   []byte(fmt.Sprintf("key-%05d", i)),
+			KeyEnd:     []byte(fmt.Sprintf("key-%05d", i+1)),
+			NumEntries: uint64(numEntries),
+			TableSize:  uint64(tableSize),
+		}
+		l1TotEntrySize += numEntries
+		l1TotTableSize += tableSize
+		registrations = append(registrations, reg)
+	}
+
+	regBatch1 := RegistrationBatch{
+		Registrations: registrations,
+	}
+	err = lm.ApplyChangesNoCheck(regBatch1)
+	require.NoError(t, err)
+
+	stats = lm.GetStats()
+	require.Equal(t, l0NumTables, stats.TablesIn)
+	require.Equal(t, l0TotTableSize, stats.BytesIn)
+	require.Equal(t, l0TotEntrySize, stats.EntriesIn)
+
+	require.Equal(t, l0NumTables+l1NumTables, stats.TotTables)
+	require.Equal(t, l0TotTableSize+l1TotTableSize, stats.TotBytes)
+	require.Equal(t, l0TotEntrySize+l1TotEntrySize, stats.TotEntries)
+
+	require.Equal(t, 2, len(stats.LevelStats))
+	levStats0 = stats.LevelStats[0]
+	require.Equal(t, l0NumTables, levStats0.Tables)
+	require.Equal(t, l0TotTableSize, levStats0.Bytes)
+	require.Equal(t, l0TotEntrySize, levStats0.Entries)
+
+	levStats1 := stats.LevelStats[1]
+	require.Equal(t, l1NumTables, levStats1.Tables)
+	require.Equal(t, l1TotTableSize, levStats1.Bytes)
+	require.Equal(t, l1TotEntrySize, levStats1.Entries)
+
+	l2NumTables := 50
+	l2TotTableSize := 0
+	l2TotEntrySize := 0
+	registrations = nil
+	for i := 0; i < l2NumTables; i++ {
+		numEntries := rand.Intn(10000)
+		tableSize := rand.Intn(10000000)
+		reg := RegistrationEntry{
+			Level:      2,
+			TableID:    sst.SSTableID(uuid.New().String()),
+			MinVersion: 100,
+			MaxVersion: 200,
+			KeyStart:   []byte(fmt.Sprintf("key-%05d", i)),
+			KeyEnd:     []byte(fmt.Sprintf("key-%05d", i+1)),
+			NumEntries: uint64(numEntries),
+			TableSize:  uint64(tableSize),
+		}
+		l2TotEntrySize += numEntries
+		l2TotTableSize += tableSize
+		registrations = append(registrations, reg)
+	}
+
+	regBatch2 := RegistrationBatch{
+		Registrations: registrations,
+	}
+	err = lm.ApplyChangesNoCheck(regBatch2)
+	require.NoError(t, err)
+
+	stats = lm.GetStats()
+	require.Equal(t, l0NumTables, stats.TablesIn)
+	require.Equal(t, l0TotTableSize, stats.BytesIn)
+	require.Equal(t, l0TotEntrySize, stats.EntriesIn)
+
+	require.Equal(t, l0NumTables+l1NumTables+l2NumTables, stats.TotTables)
+	require.Equal(t, l0TotTableSize+l1TotTableSize+l2TotTableSize, stats.TotBytes)
+	require.Equal(t, l0TotEntrySize+l1TotEntrySize+l2TotEntrySize, stats.TotEntries)
+
+	require.Equal(t, 3, len(stats.LevelStats))
+	levStats0 = stats.LevelStats[0]
+	require.Equal(t, l0NumTables, levStats0.Tables)
+	require.Equal(t, l0TotTableSize, levStats0.Bytes)
+	require.Equal(t, l0TotEntrySize, levStats0.Entries)
+
+	levStats1 = stats.LevelStats[1]
+	require.Equal(t, l1NumTables, levStats1.Tables)
+	require.Equal(t, l1TotTableSize, levStats1.Bytes)
+	require.Equal(t, l1TotEntrySize, levStats1.Entries)
+
+	levStats2 := stats.LevelStats[2]
+	require.Equal(t, l2NumTables, levStats2.Tables)
+	require.Equal(t, l2TotTableSize, levStats2.Bytes)
+	require.Equal(t, l2TotEntrySize, levStats2.Entries)
+
+	deregBatch0 := regBatch0.Registrations[0]
+	deregBatch1 := regBatch1.Registrations[0]
+	deregBatch2 := regBatch2.Registrations[0]
+
+	deregBatch := RegistrationBatch{
+		DeRegistrations: []RegistrationEntry{
+			deregBatch0,
+			deregBatch1,
+			deregBatch2,
+		},
+	}
+	err = lm.ApplyChangesNoCheck(deregBatch)
+	require.NoError(t, err)
+
+	stats = lm.GetStats()
+	require.Equal(t, l0NumTables, stats.TablesIn)
+	require.Equal(t, l0TotTableSize, stats.BytesIn)
+	require.Equal(t, l0TotEntrySize, stats.EntriesIn)
+
+	require.Equal(t, l0NumTables+l1NumTables+l2NumTables-3, stats.TotTables)
+	require.Equal(t, l0TotTableSize+l1TotTableSize+l2TotTableSize-int(deregBatch0.TableSize)-int(deregBatch1.TableSize)-int(deregBatch2.TableSize), stats.TotBytes)
+	require.Equal(t, l0TotEntrySize+l1TotEntrySize+l2TotEntrySize-int(deregBatch0.NumEntries)-int(deregBatch1.NumEntries)-int(deregBatch2.NumEntries), stats.TotEntries)
+
+	require.Equal(t, 3, len(stats.LevelStats))
+	levStats0 = stats.LevelStats[0]
+	require.Equal(t, l0NumTables-1, levStats0.Tables)
+	require.Equal(t, l0TotTableSize-int(deregBatch0.TableSize), levStats0.Bytes)
+	require.Equal(t, l0TotEntrySize-int(deregBatch0.NumEntries), levStats0.Entries)
+
+	levStats1 = stats.LevelStats[1]
+	require.Equal(t, l1NumTables-1, levStats1.Tables)
+	require.Equal(t, l1TotTableSize-int(deregBatch1.TableSize), levStats1.Bytes)
+	require.Equal(t, l1TotEntrySize-int(deregBatch1.NumEntries), levStats1.Entries)
+
+	levStats2 = stats.LevelStats[2]
+	require.Equal(t, l2NumTables-1, levStats2.Tables)
+	require.Equal(t, l2TotTableSize-int(deregBatch2.TableSize), levStats2.Bytes)
+	require.Equal(t, l2TotEntrySize-int(deregBatch2.NumEntries), levStats2.Entries)
+}
+
+func TestRegisterDeadVersionRanges(t *testing.T) {
+	levelManager, tearDown := setupLevelManager(t)
+	defer tearDown(t)
+
+	// Add some entries in different levels
+	regEntry01 := regTableInLevel(t, levelManager, 0, 0, 9, 310, 319, 0)
+	regEntry02 := regTableInLevel(t, levelManager, 0, 10, 19, 320, 329, 1)
+	regEntry03 := regTableInLevel(t, levelManager, 0, 20, 29, 330, 339, 2)
+
+	regEntry11 := regTableInLevel(t, levelManager, 1, 0, 9, 210, 219, 0)
+	regEntry12 := regTableInLevel(t, levelManager, 1, 10, 19, 220, 229, 0)
+	regEntry13 := regTableInLevel(t, levelManager, 1, 20, 29, 230, 239, 0)
+
+	regEntry21 := regTableInLevel(t, levelManager, 2, 0, 9, 110, 119, 0)
+	regEntry22 := regTableInLevel(t, levelManager, 2, 10, 19, 120, 129, 0)
+	regEntry23 := regTableInLevel(t, levelManager, 2, 20, 29, 130, 139, 0)
+
+	tables := getInRange(t, levelManager, 0, 30)
+	require.Equal(t, 5, len(tables))
+	// Make sure no dead version ranges
+	for _, infos := range tables {
+		for _, table := range infos {
+			require.Nil(t, table.DeadVersions)
+		}
+	}
+
+	// Ranges that overlap one entry
+	rng1 := VersionRange{
+		VersionStart: 220,
+		VersionEnd:   225,
+	}
+	expected := []NonOverlappingTables{
+		{
+			{ID: regEntry03.TableID},
+		},
+		{
+			{ID: regEntry02.TableID},
+		},
+		{
+			{ID: regEntry01.TableID},
+		},
+		{
+			{ID: regEntry11.TableID},
+			{ID: regEntry12.TableID, DeadVersions: []VersionRange{rng1}},
+			{ID: regEntry13.TableID},
+		},
+		{
+			{ID: regEntry21.TableID},
+			{ID: regEntry22.TableID},
+			{ID: regEntry23.TableID},
+		},
+	}
+	validateDeadVersions(t, levelManager, rng1, expected)
+
+	rng2 := VersionRange{
+		VersionStart: 223,
+		VersionEnd:   227,
+	}
+	expected = []NonOverlappingTables{
+		{
+			{ID: regEntry03.TableID},
+		},
+		{
+			{ID: regEntry02.TableID},
+		},
+		{
+			{ID: regEntry01.TableID},
+		},
+		{
+			{ID: regEntry11.TableID},
+			{ID: regEntry12.TableID, DeadVersions: []VersionRange{rng1, rng2}},
+			{ID: regEntry13.TableID},
+		},
+		{
+			{ID: regEntry21.TableID},
+			{ID: regEntry22.TableID},
+			{ID: regEntry23.TableID},
+		},
+	}
+	validateDeadVersions(t, levelManager, rng2, expected)
+
+	rng3 := VersionRange{
+		VersionStart: 224,
+		VersionEnd:   229,
+	}
+	expected = []NonOverlappingTables{
+		{
+			{ID: regEntry03.TableID},
+		},
+		{
+			{ID: regEntry02.TableID},
+		},
+		{
+			{ID: regEntry01.TableID},
+		},
+		{
+			{ID: regEntry11.TableID},
+			{ID: regEntry12.TableID, DeadVersions: []VersionRange{rng1, rng2, rng3}},
+			{ID: regEntry13.TableID},
+		},
+		{
+			{ID: regEntry21.TableID},
+			{ID: regEntry22.TableID},
+			{ID: regEntry23.TableID},
+		},
+	}
+	validateDeadVersions(t, levelManager, rng3, expected)
+
+	rng4 := VersionRange{
+		VersionStart: 125,
+		VersionEnd:   325,
+	}
+	expected = []NonOverlappingTables{
+		{
+			{ID: regEntry03.TableID},
+		},
+		{
+			{ID: regEntry02.TableID, DeadVersions: []VersionRange{rng4}},
+		},
+		{
+			{ID: regEntry01.TableID, DeadVersions: []VersionRange{rng4}},
+		},
+		{
+			{ID: regEntry11.TableID, DeadVersions: []VersionRange{rng4}},
+			{ID: regEntry12.TableID, DeadVersions: []VersionRange{rng1, rng2, rng3, rng4}},
+			{ID: regEntry13.TableID, DeadVersions: []VersionRange{rng4}},
+		},
+		{
+			{ID: regEntry21.TableID},
+			{ID: regEntry22.TableID, DeadVersions: []VersionRange{rng4}},
+			{ID: regEntry23.TableID, DeadVersions: []VersionRange{rng4}},
+		},
+	}
+	validateDeadVersions(t, levelManager, rng4, expected)
+
+	// No matches
+
+	rng5 := VersionRange{
+		VersionStart: 0,
+		VersionEnd:   109,
+	}
+	validateDeadVersions(t, levelManager, rng5, expected)
+
+	rng6 := VersionRange{
+		VersionStart: 340,
+		VersionEnd:   350,
+	}
+	validateDeadVersions(t, levelManager, rng6, expected)
+
+	afterTest(t, levelManager)
+}
+
+func validateDeadVersions(t *testing.T, lm *Manager, rng VersionRange, expected []NonOverlappingTables) {
+	err := lm.RegisterDeadVersionRange(rng, "test_cluster", 0)
+	require.NoError(t, err)
+	tables := getInRange(t, lm, 0, 30)
+	require.Equal(t, OverlappingTables(expected), tables)
+}
+
+func regTableInLevel(t *testing.T, lm *Manager, level int, keyStart int, keyEnd int, minVersion int, maxVersion int, processorID int) *RegistrationEntry {
+	tabID, err := uuid.New().MarshalBinary()
+	require.NoError(t, err)
+	regEntry := RegistrationEntry{
+		Level:      level,
+		TableID:    tabID,
+		KeyStart:   createKey(keyStart),
+		KeyEnd:     createKey(keyEnd),
+		MinVersion: uint64(minVersion),
+		MaxVersion: uint64(maxVersion),
+	}
+	regBatch := RegistrationBatch{Registrations: []RegistrationEntry{regEntry}, ProcessorID: processorID}
+	err = lm.ApplyChangesNoCheck(regBatch)
+	require.NoError(t, err)
+	return &regEntry
+}
+
+func verifyTablesInLevel(t *testing.T, lm *Manager, level int, expectedTablePairs []int) {
+	levEntry := lm.getLevelEntry(level)
+	require.Equal(t, len(expectedTablePairs), 2*len(levEntry.tableEntries))
+	pos := 0
+	for i := 0; i < len(expectedTablePairs); i += 2 {
+		start := expectedTablePairs[i]
+		end := expectedTablePairs[i+1]
+		expectedStart := createKey(start)
+		expectedEnd := createKey(end)
+		lte := levEntry.tableEntries[pos]
+		te := lte.Get(levEntry)
+		require.Equal(t, expectedStart, te.RangeStart)
+		require.Equal(t, expectedEnd, te.RangeEnd)
+		pos++
+	}
+}

--- a/lsm/level_manager_test.go
+++ b/lsm/level_manager_test.go
@@ -1211,7 +1211,7 @@ func verifyTablesInLevel(t *testing.T, lm *Manager, level int, expectedTablePair
 		expectedStart := createKey(start)
 		expectedEnd := createKey(end)
 		lte := levEntry.tableEntries[pos]
-		te := lte.Get(levEntry)
+		te := getTableEntry(lm, lte, levEntry)
 		require.Equal(t, expectedStart, te.RangeStart)
 		require.Equal(t, expectedEnd, te.RangeEnd)
 		pos++

--- a/lsm/structs.go
+++ b/lsm/structs.go
@@ -1,0 +1,639 @@
+//lint:file-ignore U1000 Ignore all unused code
+package lsm
+
+import (
+	"encoding/binary"
+	"github.com/spirit-labs/tektite/asl/encoding"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/sst"
+)
+
+type QueryTableInfo struct {
+	ID           sst.SSTableID
+	DeadVersions []VersionRange
+}
+
+type NonOverlappingTables []QueryTableInfo
+
+type OverlappingTables []NonOverlappingTables
+
+func (ot OverlappingTables) Serialize(bytes []byte) []byte {
+	bytes = encoding.AppendUint32ToBufferLE(bytes, uint32(len(ot)))
+	for _, tableInfos := range ot {
+		bytes = encoding.AppendUint32ToBufferLE(bytes, uint32(len(tableInfos)))
+		for _, tableInfo := range tableInfos {
+			bytes = encoding.AppendUint32ToBufferLE(bytes, uint32(len(tableInfo.ID)))
+			bytes = append(bytes, tableInfo.ID...)
+			bytes = encoding.AppendUint32ToBufferLE(bytes, uint32(len(tableInfo.DeadVersions)))
+			for _, dv := range tableInfo.DeadVersions {
+				bytes = dv.Serialize(bytes)
+			}
+		}
+	}
+	return bytes
+}
+
+func DeserializeOverlappingTables(bytes []byte, offset int) OverlappingTables {
+	nn, offset := encoding.ReadUint32FromBufferLE(bytes, offset)
+	otids := make([]NonOverlappingTables, nn)
+	for i := 0; i < int(nn); i++ {
+		var no uint32
+		no, offset = encoding.ReadUint32FromBufferLE(bytes, offset)
+		tableInfos := make([]QueryTableInfo, no)
+		otids[i] = tableInfos
+		for j := 0; j < int(no); j++ {
+			var l uint32
+			l, offset = encoding.ReadUint32FromBufferLE(bytes, offset)
+			tabID := bytes[offset : offset+int(l)]
+			offset += int(l)
+			tableInfos[j].ID = tabID
+			l, offset = encoding.ReadUint32FromBufferLE(bytes, offset)
+			deadVersions := make([]VersionRange, l)
+			for i := 0; i < int(l); i++ {
+				offset = deadVersions[i].Deserialize(bytes, offset)
+			}
+			tableInfos[j].DeadVersions = deadVersions
+		}
+	}
+	return otids
+}
+
+type RegistrationEntry struct {
+	Level            int
+	TableID          sst.SSTableID
+	MinVersion       uint64
+	MaxVersion       uint64
+	KeyStart, KeyEnd []byte
+	DeleteRatio      float64
+	AddedTime        uint64
+	NumEntries       uint64
+	TableSize        uint64
+	NumPrefixDeletes uint32
+}
+
+func (re *RegistrationEntry) serialize(buff []byte) []byte {
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(re.Level))
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(re.TableID)))
+	buff = append(buff, re.TableID...)
+	buff = encoding.AppendUint64ToBufferLE(buff, re.MinVersion)
+	buff = encoding.AppendUint64ToBufferLE(buff, re.MaxVersion)
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(re.KeyStart)))
+	buff = append(buff, re.KeyStart...)
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(re.KeyEnd)))
+	buff = append(buff, re.KeyEnd...)
+	buff = encoding.AppendFloat64ToBufferLE(buff, re.DeleteRatio)
+	buff = encoding.AppendUint64ToBufferLE(buff, re.AddedTime)
+	buff = encoding.AppendUint64ToBufferLE(buff, re.NumEntries)
+	buff = encoding.AppendUint64ToBufferLE(buff, re.TableSize)
+	buff = encoding.AppendUint32ToBufferLE(buff, re.NumPrefixDeletes)
+	return buff
+}
+
+func (re *RegistrationEntry) deserialize(buff []byte, offset int) int {
+	var lev uint32
+	lev, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	re.Level = int(lev)
+	var l uint32
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	re.TableID = buff[offset : offset+int(l)]
+	offset += int(l)
+	re.MinVersion, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	re.MaxVersion, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	re.KeyStart = buff[offset : offset+int(l)]
+	offset += int(l)
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	re.KeyEnd = buff[offset : offset+int(l)]
+	offset += int(l)
+	re.DeleteRatio, offset = encoding.ReadFloat64FromBufferLE(buff, offset)
+	re.AddedTime, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	re.NumEntries, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	re.TableSize, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	re.NumPrefixDeletes, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	return offset
+}
+
+type RegistrationBatch struct {
+	ClusterName     string
+	ClusterVersion  int
+	Compaction      bool
+	JobID           string
+	ProcessorID     int
+	Registrations   []RegistrationEntry
+	DeRegistrations []RegistrationEntry
+}
+
+func (rb *RegistrationBatch) Serialize(buff []byte) []byte {
+	buff = encoding.AppendStringToBufferLE(buff, rb.ClusterName)
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(rb.ClusterVersion))
+	buff = encoding.AppendBoolToBuffer(buff, rb.Compaction)
+	buff = encoding.AppendStringToBufferLE(buff, rb.JobID)
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(rb.ProcessorID))
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(rb.Registrations)))
+	for _, reg := range rb.Registrations {
+		buff = reg.serialize(buff)
+	}
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(rb.DeRegistrations)))
+	for _, dereg := range rb.DeRegistrations {
+		buff = dereg.serialize(buff)
+	}
+	return buff
+}
+
+func (rb *RegistrationBatch) Deserialize(buff []byte, offset int) int {
+	var s string
+	s, offset = encoding.ReadStringFromBufferLE(buff, offset)
+	rb.ClusterName = s
+	var ver uint64
+	ver, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	rb.ClusterVersion = int(ver)
+	rb.Compaction, offset = encoding.ReadBoolFromBuffer(buff, offset)
+	rb.JobID, offset = encoding.ReadStringFromBufferLE(buff, offset)
+	var pid uint64
+	pid, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	rb.ProcessorID = int(pid)
+	var l uint32
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	rb.Registrations = make([]RegistrationEntry, l)
+	for i := 0; i < int(l); i++ {
+		offset = rb.Registrations[i].deserialize(buff, offset)
+	}
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	rb.DeRegistrations = make([]RegistrationEntry, l)
+	for i := 0; i < int(l); i++ {
+		offset = rb.DeRegistrations[i].deserialize(buff, offset)
+	}
+	return offset
+}
+
+type TableEntry struct {
+	SSTableID         sst.SSTableID
+	RangeStart        []byte
+	RangeEnd          []byte
+	MinVersion        uint64
+	MaxVersion        uint64
+	DeleteRatio       float64
+	AddedTime         uint64 // The time the table was first added to the database - used to calculate retention
+	NumEntries        uint64
+	Size              uint64
+	NumPrefixDeletes  uint32
+	DeadVersionRanges []VersionRange
+}
+
+func (te *TableEntry) copy() *TableEntry {
+	cp := *te
+	cp.DeadVersionRanges = make([]VersionRange, len(te.DeadVersionRanges))
+	copy(cp.DeadVersionRanges, te.DeadVersionRanges)
+	return &cp
+}
+
+func (te *TableEntry) serialize(buff []byte) []byte {
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(te.SSTableID)))
+	buff = append(buff, te.SSTableID...)
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(te.RangeStart)))
+	buff = append(buff, te.RangeStart...)
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(te.RangeEnd)))
+	buff = append(buff, te.RangeEnd...)
+	buff = encoding.AppendUint64ToBufferLE(buff, te.MinVersion)
+	buff = encoding.AppendUint64ToBufferLE(buff, te.MaxVersion)
+	buff = encoding.AppendFloat64ToBufferLE(buff, te.DeleteRatio)
+	buff = encoding.AppendUint64ToBufferLE(buff, te.AddedTime)
+	buff = encoding.AppendUint64ToBufferLE(buff, te.NumEntries)
+	buff = encoding.AppendUint64ToBufferLE(buff, te.Size)
+	buff = encoding.AppendUint32ToBufferLE(buff, te.NumPrefixDeletes)
+	// We encode DeadVersionRanges as varint to save space as most TableEntry instances won't have any DeadVersionRanges
+	ldvps := len(te.DeadVersionRanges)
+	buff = binary.AppendUvarint(buff, uint64(ldvps))
+	for i := 0; i < ldvps; i++ {
+		buff = te.DeadVersionRanges[i].Serialize(buff)
+	}
+	return buff
+}
+
+func (te *TableEntry) deserialize(buff []byte, offset int) int {
+	var l uint32
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	te.SSTableID = buff[offset : offset+int(l)]
+	offset += int(l)
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	te.RangeStart = buff[offset : offset+int(l)]
+	offset += int(l)
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	te.RangeEnd = buff[offset : offset+int(l)]
+	offset += int(l)
+	te.MinVersion, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	te.MaxVersion, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	te.DeleteRatio, offset = encoding.ReadFloat64FromBufferLE(buff, offset)
+	te.AddedTime, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	te.NumEntries, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	te.Size, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	te.NumPrefixDeletes, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	ldvps, bytesRead := binary.Uvarint(buff[offset:])
+	offset += bytesRead
+	if ldvps > 0 {
+		te.DeadVersionRanges = make([]VersionRange, ldvps)
+		for i := 0; i < int(ldvps); i++ {
+			offset = te.DeadVersionRanges[i].Deserialize(buff, offset)
+		}
+	}
+	return offset
+}
+
+type Stats struct {
+	TotBytes       int
+	TotEntries     int
+	TotTables      int
+	BytesIn        int
+	EntriesIn      int
+	TablesIn       int
+	TotCompactions int
+	LevelStats     map[int]*LevelStats
+}
+
+func (l *Stats) Serialize(buff []byte) []byte {
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.TotBytes))
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.TotEntries))
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.TotTables))
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.BytesIn))
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.EntriesIn))
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.TablesIn))
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.TotCompactions))
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(l.LevelStats)))
+	for level, levStats := range l.LevelStats {
+		buff = encoding.AppendUint32ToBufferLE(buff, uint32(level))
+		buff = levStats.serialize(buff)
+	}
+	return buff
+}
+
+func (l *Stats) Deserialize(buff []byte, offset int) int {
+	var u uint64
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.TotBytes = int(u)
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.TotEntries = int(u)
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.TotTables = int(u)
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.BytesIn = int(u)
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.EntriesIn = int(u)
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.TablesIn = int(u)
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.TotCompactions = int(u)
+	var nl uint32
+	nl, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	numLevels := int(nl)
+	levStatsMap := make(map[int]*LevelStats, numLevels)
+	for i := 0; i < numLevels; i++ {
+		var l uint32
+		l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+		levStats := &LevelStats{}
+		offset = levStats.deserialize(buff, offset)
+		levStatsMap[int(l)] = levStats
+	}
+	l.LevelStats = levStatsMap
+	return offset
+}
+
+func (l *Stats) copy() *Stats {
+	statsCopy := &Stats{}
+	statsCopy.TotBytes = l.TotBytes
+	statsCopy.TotEntries = l.TotEntries
+	statsCopy.TotTables = l.TotTables
+	statsCopy.BytesIn = l.BytesIn
+	statsCopy.EntriesIn = l.EntriesIn
+	statsCopy.TablesIn = l.TablesIn
+	statsCopy.TotCompactions = l.TotCompactions
+	statsCopy.LevelStats = make(map[int]*LevelStats, len(l.LevelStats))
+	for level, levStats := range l.LevelStats {
+		statsCopy.LevelStats[level] = &LevelStats{
+			Bytes:   levStats.Bytes,
+			Entries: levStats.Entries,
+			Tables:  levStats.Tables,
+		}
+	}
+	return statsCopy
+}
+
+type LevelStats struct {
+	Bytes   int
+	Entries int
+	Tables  int
+}
+
+func (l *LevelStats) serialize(buff []byte) []byte {
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.Bytes))
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.Entries))
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.Tables))
+	return buff
+}
+
+func (l *LevelStats) deserialize(buff []byte, offset int) int {
+	var u uint64
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.Bytes = int(u)
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.Entries = int(u)
+	u, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	l.Tables = int(u)
+	return offset
+}
+
+type MasterRecord struct {
+	format             common.MetadataFormat
+	version            uint64
+	levelEntries       []*levelEntry
+	levelTableCounts   map[int]int
+	slabRetentions     map[uint64]uint64 // this is a map as we can get duplicate registrations
+	lastFlushedVersion int64
+	stats              *Stats
+}
+
+func NewMasterRecord(format common.MetadataFormat) *MasterRecord {
+	return &MasterRecord{
+		format:             format,
+		version:            0,
+		slabRetentions:     map[uint64]uint64{},
+		stats:              &Stats{LevelStats: map[int]*LevelStats{}},
+		levelTableCounts:   map[int]int{},
+		lastFlushedVersion: -1,
+	}
+}
+
+func (mr *MasterRecord) Serialize(buff []byte) []byte {
+	buff = append(buff, byte(mr.format))
+	buff = encoding.AppendUint64ToBufferLE(buff, mr.version)
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(mr.levelEntries)))
+	for _, entry := range mr.levelEntries {
+		buff = entry.Serialize(buff)
+	}
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(mr.levelTableCounts)))
+	for level, cnt := range mr.levelTableCounts {
+		buff = encoding.AppendUint32ToBufferLE(buff, uint32(level))
+		buff = encoding.AppendUint64ToBufferLE(buff, uint64(cnt))
+	}
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(mr.slabRetentions)))
+	for slabID, retention := range mr.slabRetentions {
+		buff = encoding.AppendUint64ToBufferLE(buff, slabID)
+		buff = encoding.AppendUint64ToBufferLE(buff, retention)
+	}
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(mr.lastFlushedVersion))
+	return mr.stats.Serialize(buff)
+}
+
+func (mr *MasterRecord) Deserialize(buff []byte, offset int) int {
+	mr.format = common.MetadataFormat(buff[offset])
+	offset++
+	mr.version, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	var nl uint32
+	nl, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	mr.levelEntries = make([]*levelEntry, nl)
+	for level := 0; level < int(nl); level++ {
+		mr.levelEntries[level] = &levelEntry{}
+		offset = mr.levelEntries[level].Deserialize(buff, offset)
+	}
+	var ncnts uint32
+	ncnts, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	mr.levelTableCounts = make(map[int]int, ncnts)
+	for i := 0; i < int(ncnts); i++ {
+		var lev uint32
+		lev, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+		var cnt uint64
+		cnt, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+		mr.levelTableCounts[int(lev)] = int(cnt)
+	}
+	var np uint32
+	np, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	mr.slabRetentions = make(map[uint64]uint64, np)
+	for i := 0; i < int(np); i++ {
+		var slabID uint64
+		slabID, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+		var retention uint64
+		retention, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+		mr.slabRetentions[slabID] = retention
+	}
+	var lfv uint64
+	lfv, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	mr.lastFlushedVersion = int64(lfv)
+	mr.stats = &Stats{}
+	return mr.stats.Deserialize(buff, offset)
+}
+
+type levelEntry struct {
+	maxVersion       uint64 // Note this is the max version ever stored in the level, not necessarily the current max version in the level
+	rangeStart       []byte
+	rangeEnd         []byte
+	tableEntries     []levelTableEntry
+	tableEntriesBuff []byte
+	addedTablesBuff  []byte
+}
+
+func (le *levelEntry) SetAt(index int, te *TableEntry) {
+	pos := len(le.addedTablesBuff)
+	le.addedTablesBuff = te.serialize(le.addedTablesBuff)
+	length := uint32(len(le.addedTablesBuff) - pos)
+	lte := levelTableEntry{
+		pos:    pos + len(le.tableEntriesBuff),
+		length: length,
+	}
+	le.tableEntries[index] = lte
+}
+
+func (le *levelEntry) InsertAt(index int, te *TableEntry) {
+	pos := len(le.addedTablesBuff)
+	le.addedTablesBuff = te.serialize(le.addedTablesBuff)
+	length := uint32(len(le.addedTablesBuff) - pos)
+	// When adding new entries we set pos to be pos in the addedTablesBuff + length of the existing tableEntriesBuff
+	// this allows us to distinguish between newly inserted/set entries and ones that are backed by the existing buffer
+	// without having to store an extra field in levelTableEntry which would take more memory
+	lte := levelTableEntry{
+		pos:    pos + len(le.tableEntriesBuff),
+		length: length,
+	}
+	le.tableEntries = insertInSlice(le.tableEntries, index, lte)
+}
+
+func (le *levelEntry) RemoveAt(index int) {
+	le.tableEntries = append(le.tableEntries[:index], le.tableEntries[index+1:]...)
+}
+
+var eightZeroBytes = []byte{0, 0, 0, 0, 0, 0, 0, 0}
+
+func (le *levelEntry) Serialize(buff []byte) []byte {
+	buff = encoding.AppendUint64ToBufferLE(buff, le.maxVersion)
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(le.rangeStart)))
+	buff = append(buff, le.rangeStart...)
+	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(le.rangeEnd)))
+	buff = append(buff, le.rangeEnd...)
+	positionsPos := len(buff)
+	buff = append(buff, eightZeroBytes...)
+	blockStart := -1
+	blockEnd := 0
+	newEntries := make([]levelTableEntry, len(le.tableEntries))
+	newPosStart := len(buff)
+	buff = encoding.AppendUint64ToBufferLE(buff, uint64(len(le.tableEntries)))
+	for i, lte := range le.tableEntries {
+		if lte.pos >= len(le.tableEntriesBuff) {
+			// Added entry
+			// Append any block
+			if blockStart != -1 {
+				buff = append(buff, le.tableEntriesBuff[blockStart:blockEnd]...)
+			}
+			// Then append the added entry
+			addedTablePos := lte.pos - len(le.tableEntriesBuff)
+			newPosStart = len(buff)
+			block := le.addedTablesBuff[addedTablePos : addedTablePos+int(lte.length)]
+			buff = append(buff, block...)
+			blockStart = -1
+		} else {
+			if blockStart != -1 && lte.pos > blockEnd {
+				// discontinuity - entry was removed here - append previous block
+				buff = append(buff, le.tableEntriesBuff[blockStart:blockEnd]...)
+				newPosStart = len(buff)
+				blockStart = lte.pos
+				blockEnd = lte.pos + int(lte.length)
+			} else {
+				if blockStart == -1 {
+					blockStart = lte.pos
+					newPosStart = len(buff)
+				} else {
+					newPosStart += int(newEntries[i-1].length)
+				}
+				blockEnd = lte.pos + int(lte.length)
+			}
+		}
+		newEntries[i] = levelTableEntry{
+			pos:    newPosStart,
+			length: lte.length,
+		}
+	}
+	if blockStart != -1 {
+		// Append any final block
+		buff = append(buff, le.tableEntriesBuff[blockStart:blockEnd]...)
+	}
+	// Append the positions
+	// TODO if most positions haven't changed no need to compute them again...
+	binary.LittleEndian.PutUint64(buff[positionsPos:], uint64(len(buff)))
+	for _, ne := range newEntries {
+		buff = encoding.AppendUint64ToBufferLE(buff, uint64(ne.pos))
+	}
+	le.addedTablesBuff = nil // reset
+	le.tableEntriesBuff = buff
+	le.tableEntries = newEntries
+	return buff
+}
+
+func (le *levelEntry) Deserialize(buff []byte, offset int) int {
+	le.maxVersion, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	var l uint32
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	if l > 0 {
+		le.rangeStart = buff[offset : offset+int(l)]
+		offset += int(l)
+	}
+	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
+	if l > 0 {
+		le.rangeEnd = buff[offset : offset+int(l)]
+		offset += int(l)
+	}
+	var positionPos uint64
+	positionPos, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	var numEntries uint64
+	numEntries, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	le.tableEntries = make([]levelTableEntry, numEntries)
+	le.tableEntriesBuff = buff
+	entriesSize := int(positionPos) - offset
+	// Skip over the encoded entries to the positions
+	offset = int(positionPos)
+	ne := int(numEntries)
+	var prevPos uint64
+	for i := 0; i < ne; i++ {
+		var pos uint64
+		pos, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+		le.tableEntries[i].pos = int(pos)
+		if i > 0 {
+			le.tableEntries[i-1].length = uint32(pos - prevPos)
+		}
+		prevPos = pos
+	}
+	if numEntries == 1 {
+		le.tableEntries[0].length = uint32(entriesSize)
+	} else if numEntries > 1 {
+		lastButOne := le.tableEntries[numEntries-2]
+		le.tableEntries[numEntries-1].length = uint32(int(positionPos) - lastButOne.pos - int(lastButOne.length))
+	}
+	le.addedTablesBuff = nil
+	return offset
+}
+
+func insertInSlice[T any](s []T, index int, value T) []T {
+	if index < 0 || index > len(s) {
+		panic("index out of bounds")
+	}
+	ls := len(s)
+	cs := cap(s)
+	if ls == cs {
+		var newCap int
+		if cs == 0 {
+			// start at 8 so we don't reallocate too much at the beginning
+			newCap = 8
+		} else {
+			newCap = cs * 2
+		}
+		newSlice := make([]T, ls+1, newCap)
+		copy(newSlice, s[:index])
+		copy(newSlice[index+1:], s[index:])
+		s = newSlice
+	} else {
+		s = s[:ls+1]
+		copy(s[index+1:], s[index:])
+	}
+	s[index] = value
+	return s
+}
+
+/*
+levelTableEntry - holds the position and length of the table-entry in the underlying buffer.
+Note, that we do not deserialize all table entries when the master record is deserialized, instead we keep them
+as a byte slice. This is more memory efficient than deserializing them all. When the database is large, it's important
+we keep the in-memory size small. Also, during a typical operation only a small number of table entries are
+updated/added/removed, this means the majority do not need to get serialized - we can use the original buffer.
+*/
+type levelTableEntry struct {
+	pos    int
+	length uint32
+}
+
+func (lte *levelTableEntry) Get(levEntry *levelEntry) *TableEntry {
+	var buff []byte
+	var offset int
+	if lte.pos >= len(levEntry.tableEntriesBuff) {
+		buff = levEntry.addedTablesBuff
+		// The pos is relative to the tableEntriesBuff
+		offset = lte.pos - len(levEntry.tableEntriesBuff)
+	} else {
+		buff = levEntry.tableEntriesBuff
+		offset = lte.pos
+	}
+	te := &TableEntry{}
+	te.deserialize(buff, offset)
+	return te
+}
+
+type VersionRange struct {
+	VersionStart uint64
+	VersionEnd   uint64
+}
+
+func (v *VersionRange) Serialize(buff []byte) []byte {
+	buff = encoding.AppendUint64ToBufferLE(buff, v.VersionStart)
+	return encoding.AppendUint64ToBufferLE(buff, v.VersionEnd)
+}
+
+func (v *VersionRange) Deserialize(buff []byte, offset int) int {
+	v.VersionStart, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	v.VersionEnd, offset = encoding.ReadUint64FromBufferLE(buff, offset)
+	return offset
+}

--- a/lsm/structs_test.go
+++ b/lsm/structs_test.go
@@ -1,0 +1,361 @@
+package lsm
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestSerializeDeserializeOverlappingTableIDs(t *testing.T) {
+	var overlapping OverlappingTables
+	for i := 0; i < 10; i++ {
+		var notOverlapping []QueryTableInfo
+		for j := 0; j < 10; j++ {
+			u, err := uuid.NewUUID()
+			require.NoError(t, err)
+			bytes, err := u.MarshalBinary()
+			require.NoError(t, err)
+			var dvs []VersionRange
+			dvs = append(dvs, VersionRange{
+				VersionStart: 111,
+				VersionEnd:   222,
+			})
+			dvs = append(dvs, VersionRange{
+				VersionStart: 333,
+				VersionEnd:   555,
+			})
+			dvs = append(dvs, VersionRange{
+				VersionStart: 777,
+				VersionEnd:   888,
+			})
+			notOverlapping = append(notOverlapping, QueryTableInfo{
+				ID:           bytes,
+				DeadVersions: dvs,
+			})
+		}
+		overlapping = append(overlapping, notOverlapping)
+	}
+
+	var buff []byte
+	buff = append(buff, 1, 2, 3)
+	require.NotNil(t, overlapping)
+	buff = overlapping.Serialize(buff)
+	overlappingAfter := DeserializeOverlappingTables(buff, 3)
+	require.Equal(t, overlapping, overlappingAfter)
+}
+
+func TestSerializeDeserializeRegistrationEntry(t *testing.T) {
+	regEntry := &RegistrationEntry{
+		Level:       23,
+		TableID:     sst.SSTableID("sometableid"),
+		KeyStart:    []byte("keystart"),
+		KeyEnd:      []byte("keyend"),
+		MinVersion:  2536353,
+		MaxVersion:  2353653,
+		DeleteRatio: 0.25,
+		AddedTime:   12345,
+	}
+	var buff []byte
+	buff = append(buff, 1, 2, 3)
+	buff = regEntry.serialize(buff)
+
+	regEntryAfter := &RegistrationEntry{}
+	regEntryAfter.deserialize(buff, 3)
+
+	require.Equal(t, regEntry, regEntryAfter)
+}
+
+func TestSerializeDeserializeRegistrationBatch(t *testing.T) {
+	regBatch := &RegistrationBatch{
+		ClusterName:    "test_cluster",
+		ClusterVersion: 23,
+		Compaction:     true,
+		JobID:          "job-12345",
+		ProcessorID:    534343,
+		Registrations: []RegistrationEntry{{
+			Level:      23,
+			TableID:    sst.SSTableID("sometableid1"),
+			MaxVersion: 100001,
+			KeyStart:   []byte("keystart1"),
+			KeyEnd:     []byte("keyend2"),
+		}, {
+			Level:      12,
+			TableID:    sst.SSTableID("sometableid2"),
+			MaxVersion: 200002,
+			KeyStart:   []byte("keystart1"),
+			KeyEnd:     []byte("keyend2"),
+		}},
+		DeRegistrations: []RegistrationEntry{{
+			Level:    23,
+			TableID:  sst.SSTableID("sometableid11"),
+			KeyStart: []byte("keystart11"),
+			KeyEnd:   []byte("keyend12"),
+		}, {
+			Level:    27,
+			TableID:  sst.SSTableID("sometableid12"),
+			KeyStart: []byte("keystart21"),
+			KeyEnd:   []byte("keyend22"),
+		}},
+	}
+	var buff []byte
+	buff = append(buff, 1, 2, 3)
+	buff = regBatch.Serialize(buff)
+
+	regBatchAfter := &RegistrationBatch{}
+	regBatchAfter.Deserialize(buff, 3)
+
+	require.Equal(t, regBatch, regBatchAfter)
+}
+
+func TestSerializeDeserializeTableEntry(t *testing.T) {
+	te := &TableEntry{
+		SSTableID:        []byte("sstableid1"),
+		RangeStart:       []byte("rangestart1"),
+		RangeEnd:         []byte("rangeend1"),
+		MinVersion:       7653595,
+		MaxVersion:       7654321,
+		DeleteRatio:      1234.23,
+		AddedTime:        uint64(time.Now().UnixMilli()),
+		NumEntries:       47464,
+		Size:             696686,
+		NumPrefixDeletes: 36363,
+	}
+	var buff []byte
+	buff = append(buff, 1, 2, 3)
+	buff = te.serialize(buff)
+
+	teAfter := &TableEntry{}
+	teAfter.deserialize(buff, 3)
+
+	require.Equal(t, te, teAfter)
+}
+
+func TestSerializeDeserializeTableEntryWithDeadVersionRanges(t *testing.T) {
+	te := &TableEntry{
+		SSTableID:  []byte("sstableid1"),
+		RangeStart: []byte("rangestart1"),
+		RangeEnd:   []byte("rangeend1"),
+		MinVersion: 7653595,
+		MaxVersion: 7654321,
+		NumEntries: 47464,
+		Size:       696686,
+		DeadVersionRanges: []VersionRange{
+			{VersionStart: 111, VersionEnd: 222},
+			{VersionStart: 333, VersionEnd: 777},
+		},
+	}
+	var buff []byte
+	buff = append(buff, 1, 2, 3)
+	buff = te.serialize(buff)
+
+	teAfter := &TableEntry{}
+	teAfter.deserialize(buff, 3)
+
+	require.Equal(t, te, teAfter)
+}
+
+func TestSerializeDeserializeLevelEntry(t *testing.T) {
+	le1 := levelEntry{}
+	numTableEntries := 10
+	var expectedEntries []*TableEntry
+	for i := 0; i < numTableEntries; i++ {
+		te := createTabEntry(i)
+		expectedEntries = append(expectedEntries, te)
+		le1.InsertAt(i, te)
+	}
+
+	// Verify table entries before serialize
+	verifyTableEntries(t, expectedEntries, &le1)
+
+	buff := le1.Serialize(nil)
+
+	// Verify after serialize (levelEntry internal state changes after serialization)
+	verifyTableEntries(t, expectedEntries, &le1)
+
+	// Deserialize
+	le2 := levelEntry{}
+	le2.Deserialize(buff, 0)
+
+	// Verify same after deserialization
+	require.Equal(t, le1.rangeStart, le2.rangeStart)
+	require.Equal(t, le1.rangeEnd, le2.rangeEnd)
+	require.Equal(t, le1.maxVersion, le2.maxVersion)
+	verifyTableEntries(t, expectedEntries, &le2)
+
+	// Now insert some more
+	te10 := createTabEntry(10)
+	le2.InsertAt(3, te10)
+	expectedEntries = insertInSlice(expectedEntries, 3, te10)
+
+	te11 := createTabEntry(11)
+	le2.InsertAt(7, te11)
+	expectedEntries = insertInSlice(expectedEntries, 7, te11)
+
+	verifyTableEntries(t, expectedEntries, &le2)
+
+	// Now delete a couple
+	le2.RemoveAt(5)
+	expectedEntries = append(expectedEntries[:5], expectedEntries[6:]...)
+
+	// Remove the last one
+	le2.RemoveAt(10)
+	expectedEntries = expectedEntries[:10]
+
+	verifyTableEntries(t, expectedEntries, &le2)
+
+	// Serialize again
+	buff = le2.Serialize(nil)
+	// Verify after serialize
+	verifyTableEntries(t, expectedEntries, &le2)
+
+	// Deserialize
+	le3 := levelEntry{}
+	le3.Deserialize(buff, 0)
+
+	// Verify same after deserialization
+	require.Equal(t, le1.rangeStart, le3.rangeStart)
+	require.Equal(t, le1.rangeEnd, le3.rangeEnd)
+	require.Equal(t, le1.maxVersion, le3.maxVersion)
+	verifyTableEntries(t, expectedEntries, &le3)
+
+	// Serialize/deserialize again with no changes
+	buff = le3.Serialize(nil)
+	// Verify after serialize
+	verifyTableEntries(t, expectedEntries, &le2)
+
+	le4 := levelEntry{}
+	le4.Deserialize(buff, 0)
+
+	// Verify same after deserialization
+	require.Equal(t, le1.rangeStart, le4.rangeStart)
+	require.Equal(t, le1.rangeEnd, le4.rangeEnd)
+	require.Equal(t, le1.maxVersion, le4.maxVersion)
+	verifyTableEntries(t, expectedEntries, &le4)
+}
+
+// TestSerializeDeserializeLevelEntryRandomUpdates does a bunch of random inserts and deletes and serializes/deserializes
+// making sure state is correctly preserved
+func TestSerializeDeserializeLevelEntryRandomUpdates(t *testing.T) {
+	le := levelEntry{}
+	numTableEntries := 10
+	var expectedEntries []*TableEntry
+	for i := 0; i < numTableEntries; i++ {
+		te := createTabEntry(i)
+		expectedEntries = append(expectedEntries, te)
+		le.InsertAt(i, te)
+	}
+
+	seq := numTableEntries
+	iters := 100
+	updates := 4
+	for i := 0; i < iters; i++ {
+		for j := 0; j < updates; j++ {
+			r := rand.Intn(3)
+			if len(expectedEntries) == 0 || r == 0 {
+				// insert
+				te := createTabEntry(seq)
+				seq++
+				index := rand.Intn(len(expectedEntries) + 1)
+				le.InsertAt(index, te)
+				expectedEntries = insertInSlice(expectedEntries, index, te)
+			} else if r == 1 {
+				// Set
+				te := createTabEntry(seq)
+				seq++
+				index := rand.Intn(len(expectedEntries))
+				le.SetAt(index, te)
+				expectedEntries[index] = te
+			} else {
+				// Remove
+				index := rand.Intn(len(expectedEntries))
+				le.RemoveAt(index)
+				expectedEntries = append(expectedEntries[:index], expectedEntries[index+1:]...)
+			}
+		}
+		buff := le.Serialize(nil)
+		verifyTableEntries(t, expectedEntries, &le)
+
+		le2 := levelEntry{}
+		le2.Deserialize(buff, 0)
+		require.Equal(t, le.rangeStart, le2.rangeStart)
+		require.Equal(t, le.rangeEnd, le2.rangeEnd)
+		require.Equal(t, le.maxVersion, le2.maxVersion)
+		verifyTableEntries(t, expectedEntries, &le2)
+
+		le = le2
+	}
+}
+
+func createTabEntry(i int) *TableEntry {
+	return &TableEntry{
+		SSTableID:  []byte(fmt.Sprintf("sstableid%d", i)),
+		RangeStart: []byte(fmt.Sprintf("rangestart%d", i)),
+		RangeEnd:   []byte(fmt.Sprintf("rangeend%d", i)),
+		MinVersion: uint64(7653595 + i),
+		MaxVersion: uint64(7654321 + i),
+		NumEntries: uint64(47464 + i),
+		Size:       uint64(696686 + i),
+		AddedTime:  uint64(time.Now().UnixMilli()),
+		DeadVersionRanges: []VersionRange{
+			{VersionStart: uint64(111 + i), VersionEnd: uint64(222 + i)},
+			{VersionStart: uint64(333 + i), VersionEnd: uint64(777 + i)},
+		},
+	}
+}
+
+func verifyTableEntries(t *testing.T, tableEntries []*TableEntry, levEntry *levelEntry) {
+	for i, te := range tableEntries {
+		lte := levEntry.tableEntries[i]
+		te2 := lte.Get(levEntry)
+		require.Equal(t, te, te2)
+	}
+}
+
+func TestSerializeDeserializeMasterRecord(t *testing.T) {
+	// Note we test the level entries elsewhere
+	mr := &MasterRecord{
+		format:  21,
+		version: 12345,
+		levelTableCounts: map[int]int{
+			0: 2, 1: 2,
+		},
+		slabRetentions: map[uint64]uint64{
+			10: 1000,
+			11: 2000,
+			12: 3000,
+		},
+		lastFlushedVersion: 1234,
+		stats: &Stats{
+			TotBytes:       23232,
+			TotEntries:     2132,
+			TotTables:      43,
+			BytesIn:        67657,
+			EntriesIn:      453,
+			TablesIn:       23,
+			TotCompactions: 45,
+			LevelStats: map[int]*LevelStats{
+				0: {
+					Bytes:   4565,
+					Entries: 454,
+					Tables:  67,
+				},
+				1: {
+					Bytes:   5756,
+					Entries: 343,
+					Tables:  66,
+				},
+			},
+		},
+	}
+	buff := mr.Serialize(nil)
+
+	mrAfter := &MasterRecord{}
+	mrAfter.Deserialize(buff, 0)
+	mrAfter.levelEntries = nil
+
+	require.Equal(t, mr, mrAfter)
+}

--- a/lsm/table_entries_bench_test.go
+++ b/lsm/table_entries_bench_test.go
@@ -1,0 +1,30 @@
+package lsm
+
+import (
+	log "github.com/spirit-labs/tektite/logger"
+	"testing"
+)
+
+func BenchmarkSerializeManyTableEntries(b *testing.B) {
+
+	numEntries := 1000000
+
+	levEntry := levelEntry{}
+	for i := 0; i < numEntries; i++ {
+		levEntry.InsertAt(i, createTabEntry(i))
+	}
+
+	b.ResetTimer()
+
+	buff := make([]byte, 0, 16*1024*1024)
+
+	for i := 0; i < b.N; i++ {
+		buff = levEntry.Serialize(buff)
+		if i == 0 {
+			log.Infof("buff len %d", len(buff))
+		}
+		var le2 levelEntry
+		le2.Deserialize(buff, 0)
+		buff = buff[:0]
+	}
+}

--- a/lsm/validate.go
+++ b/lsm/validate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spirit-labs/tektite/sst"
 )
 
-// Validate checks the LSM is sound - no overlapping keys in L > 0 etc
+// Validate checks the LSM is sound - no overlapping keys in L > 0, keys in each table are sorted, etc.
 func (lm *Manager) Validate(validateTables bool) error {
 	lse := lm.masterRecord.levelEntries
 	if len(lse) == 0 {

--- a/lsm/validate.go
+++ b/lsm/validate.go
@@ -1,0 +1,124 @@
+package lsm
+
+import (
+	"bytes"
+	"github.com/spirit-labs/tektite/asl/errwrap"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/sst"
+)
+
+// Validate checks the LSM is sound - no overlapping keys in L > 0 etc
+func (lm *Manager) Validate(validateTables bool) error {
+	lse := lm.masterRecord.levelEntries
+	if len(lse) == 0 {
+		return nil
+	}
+	for level, levEntry := range lse {
+		if err := lm.validateLevelEntry(level, levEntry, validateTables); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (lm *Manager) validateLevelEntry(level int, levEntry *levelEntry, validateTables bool) error {
+	var smallestKey, largestKey []byte
+	var prevRangeEnd []byte
+	for _, lte := range levEntry.tableEntries {
+		te := lte.Get(levEntry)
+		if smallestKey == nil || bytes.Compare(te.RangeStart, smallestKey) < 0 {
+			smallestKey = te.RangeStart
+		}
+		if largestKey == nil || bytes.Compare(te.RangeEnd, largestKey) > 0 {
+			largestKey = te.RangeEnd
+		}
+		// L0 segment has overlap
+		if level > 0 {
+			if prevRangeEnd != nil && bytes.Compare(te.RangeEnd, prevRangeEnd) < 0 {
+				return errwrap.Errorf("level %d has overlapping table entries", level)
+			}
+			prevRangeEnd = te.RangeEnd
+		}
+		if validateTables {
+			if err := lm.validateTable(te); err != nil {
+				return err
+			}
+		}
+	}
+	if !bytes.Equal(smallestKey, levEntry.rangeStart) {
+		return errwrap.Errorf("levEntry.rangeStart does not match table entries")
+	}
+	if !bytes.Equal(largestKey, levEntry.rangeEnd) {
+		return errwrap.Errorf("levEntry.rangeEnd does not match table entries")
+	}
+	return nil
+}
+
+func (lm *Manager) validateTable(te *TableEntry) error {
+	buff, err := objstore.GetWithTimeout(lm.objStore, lm.conf.BucketName, string(te.SSTableID), objstore.DefaultCallTimeout)
+	if err != nil {
+		return err
+	}
+	if buff == nil {
+		return errwrap.Errorf("cannot find sstable %v", te.SSTableID)
+	}
+	table := &sst.SSTable{}
+	table.Deserialize(buff, 0)
+	iter, err := table.NewIterator(nil, nil)
+	if err != nil {
+		return err
+	}
+	first := true
+	var prevKey []byte
+	for {
+		v, curr, err := iter.Next()
+		if err != nil {
+			return err
+		}
+		if !v {
+			break
+		}
+		if first {
+			if !bytes.Equal(te.RangeStart, curr.Key) {
+				return errwrap.Errorf("table %v (%s) range start %s does not match first entry key %s",
+					te.SSTableID, string(te.SSTableID), string(te.RangeStart), string(curr.Key))
+			}
+			first = false
+		}
+		if prevKey != nil {
+			if bytes.Compare(prevKey, curr.Key) >= 0 {
+				dumpTable(te.SSTableID, table)
+				return errwrap.Errorf("table %v (%s) keys out of order or duplicates %s %s", te.SSTableID, string(te.SSTableID),
+					string(prevKey), string(curr.Key))
+			}
+		}
+		prevKey = curr.Key
+	}
+	if prevKey == nil {
+		return errwrap.Errorf("table %v has no entries", te.SSTableID)
+	}
+	if !bytes.Equal(te.RangeEnd, prevKey) {
+		return errwrap.Errorf("table %v range end does not match last entry key", te.SSTableID)
+	}
+	return nil
+}
+
+func dumpTable(tableID []byte, sst *sst.SSTable) {
+	iter, err := sst.NewIterator(nil, nil)
+	if err != nil {
+		panic(err)
+	}
+	log.Debugf("========== dumping table %v (%s)", tableID, string(tableID))
+	for {
+		valid, curr, err := iter.Next()
+		if err != nil {
+			panic(err)
+		}
+		if !valid {
+			break
+		}
+		log.Debugf("key: %v (%s) val: %v (%s)", curr.Key, string(curr.Key), curr.Value, string(curr.Value))
+	}
+	log.Debugf("========== end dumping table %v (%s)", tableID, string(tableID))
+}


### PR DESCRIPTION
This PR extracts and simplifies the level manager into a new lsm.Manager struct.

It includes a more efficient way of representing table entries in memory, whereby the table entries aren't serialized/deserialized when the master record is, but kept in their []byte form. This allows quicker serialization/deserialization and a lower memory footprint. Both of these are important if we're going to be store metadata in S3 on each update.