### PR TITLE
Implement ClusteredData for ownership and updates of large data. 

### DIFF
--- a/cluster/clustered_data.go
+++ b/cluster/clustered_data.go
@@ -1,0 +1,199 @@
+package cluster
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spirit-labs/tektite/common"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/objstore"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+/*
+ClusteredData - provides a mechanism whereby potentially large state can be loaded by a member of the cluster, updated
+and then new state stored without fear of another member overwriting the state.
+
+This is used in Tektite for persisting the controller metadata.
+
+A member of the cluster takes ownership of the state by calling `LoadState` which atomically increments an 'epoch' value
+in a `StateUpdator` instance and returns the current state, if any.
+
+The owner makes changes to the state then calls `StoreState` to persist it. This stores the state as on object in the
+object store external to the `StateUpdator`. Ideally we would store the state in the `StateUpdator` but the current S3
+implementation of conditional PUTs requires us to create a new object on each update. If the object is large this
+results in a lot of objects and a lot of storage under load.
+
+Before the call to `StoreState` returns a no-op update on `StatePersistor` occurs to read the latest epoch. If this does
+not match the epoch the state was stored with thew call returns an error.
+
+The key that we store the state under includes the epoch in it, e.g. `my-data-key-prefix-0000000234`. When data is
+loaded, the key with the highest epoch prefix is loaded.
+*/
+type ClusteredData struct {
+	lock           sync.Mutex
+	dataBucketName string
+	dataKeyPrefix  string
+	stateMachine   *StateUpdator
+	objStoreClient objstore.Client
+	epoch          uint64
+	opts           ClusteredDataOpts
+	readyState     clusteredDataState
+	stopping       atomic.Bool
+}
+
+type clusteredDataState int
+
+const (
+	clusteredDataStateReady = iota
+	clusteredDataStateLoaded
+	clusteredDataStateStopped
+)
+
+func NewClusteredData(stateMachineBucketName string, stateMachineKeyPrefix string, dataBucketName string,
+	dataKeyPrefix string, objStoreClient objstore.Client, opts ClusteredDataOpts) *ClusteredData {
+	return &ClusteredData{
+		objStoreClient: objStoreClient,
+		dataBucketName: dataBucketName,
+		dataKeyPrefix:  dataKeyPrefix,
+		stateMachine: NewStateUpdator(stateMachineBucketName, stateMachineKeyPrefix, objStoreClient,
+			StateUpdatorOpts{}),
+		opts:       opts,
+		readyState: clusteredDataStateReady,
+	}
+}
+
+type ClusteredDataOpts struct {
+	AvailabilityRetryInterval time.Duration
+	ObjStoreCallTimeout       time.Duration
+}
+
+func (mo *ClusteredDataOpts) setDefaults() {
+	if mo.AvailabilityRetryInterval == 0 {
+		mo.AvailabilityRetryInterval = DefaultAvailabilityRetryInterval
+	}
+}
+
+func (m *ClusteredData) LoadData() ([]byte, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.readyState == clusteredDataStateStopped {
+		return nil, errors.New("stopped")
+	}
+	// Atomically increment the epoch
+	buff, err := m.stateMachine.Update(func(state []byte) ([]byte, error) {
+		epoch := buffToEpoch(state)
+		newState := make([]byte, 8)
+		binary.BigEndian.PutUint64(newState, epoch+1)
+		return newState, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	m.epoch = buffToEpoch(buff)
+	prevEpoch := m.epoch - 1
+	// Now we try and load the key with the highest epoch - the key might be lower than prevEpoch as no data might
+	// have been stored in previous epoch
+	var data []byte
+	for {
+		dataKey := m.createDataKey(prevEpoch)
+		data, err = m.getWithRetry(dataKey)
+		if err != nil {
+			return nil, err
+		}
+		if len(data) == 0 {
+			// no key found - try with next lower epoch
+			if prevEpoch == 0 {
+				// No data to load
+				break
+			}
+			prevEpoch--
+		} else {
+			break
+		}
+	}
+	m.readyState = clusteredDataStateLoaded
+	return data, nil
+}
+
+func (m *ClusteredData) StoreData(data []byte) (bool, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.readyState != clusteredDataStateLoaded {
+		return false, errors.New("not loaded")
+	}
+	dataKey := m.createDataKey(m.epoch)
+	if err := m.putWithRetry(dataKey, data); err != nil {
+		return false, err
+	}
+	// Then we get latest epoch using a no-op update
+	buff, err := m.stateMachine.Update(func(buff []byte) ([]byte, error) {
+		return buff, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	currEpoch := buffToEpoch(buff)
+	if currEpoch != m.epoch {
+		// Epoch has changed - fail the store
+		log.Debug("controller failed to store metadata as epoch has changed")
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *ClusteredData) Stop() {
+	// Allow any retry loops to exit
+	m.stopping.Store(true)
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.readyState = clusteredDataStateStopped
+}
+
+func (m *ClusteredData) getWithRetry(dataKey string) ([]byte, error) {
+	for {
+		if m.stopping.Load() {
+			return nil, errors.New("clustered data is stopping")
+		}
+		data, err := objstore.GetWithTimeout(m.objStoreClient, m.dataBucketName, dataKey, m.opts.ObjStoreCallTimeout)
+		if err == nil {
+			return data, nil
+		}
+		if !common.IsUnavailableError(err) {
+			return nil, err
+		}
+		// retry
+		time.Sleep(m.opts.AvailabilityRetryInterval)
+	}
+}
+
+func (m *ClusteredData) putWithRetry(dataKey string, data []byte) error {
+	for {
+		if m.stopping.Load() {
+			return errors.New("clustered data is stopping")
+		}
+		err := objstore.PutWithTimeout(m.objStoreClient, m.dataBucketName, dataKey, data, m.opts.ObjStoreCallTimeout)
+		if err == nil {
+			return err
+		}
+		if !common.IsUnavailableError(err) {
+			return err
+		}
+		// retry
+		time.Sleep(m.opts.AvailabilityRetryInterval)
+	}
+}
+
+func (m *ClusteredData) createDataKey(epoch uint64) string {
+	return fmt.Sprintf("%s-%010d", m.dataKeyPrefix, epoch)
+}
+
+func buffToEpoch(buff []byte) uint64 {
+	var epoch uint64
+	if len(buff) > 0 {
+		epoch = binary.BigEndian.Uint64(buff)
+	}
+	return epoch
+}

--- a/cluster/clustered_data_test.go
+++ b/cluster/clustered_data_test.go
@@ -15,7 +15,7 @@ func TestClusteredData(t *testing.T) {
 	cd1 := NewClusteredData("statebucket", "stateprefix",
 		"databucket", "dataprefix", objStore, ClusteredDataOpts{})
 
-	data, err := cd1.LoadData()
+	data, err := cd1.AcquireData()
 	require.NoError(t, err)
 	require.Nil(t, data)
 
@@ -28,7 +28,7 @@ func TestClusteredData(t *testing.T) {
 	cd2 := NewClusteredData("statebucket", "stateprefix",
 		"databucket", "dataprefix", objStore, ClusteredDataOpts{})
 
-	data, err = cd2.LoadData()
+	data, err = cd2.AcquireData()
 	require.NoError(t, err)
 	require.NotNil(t, data)
 	require.Equal(t, sData, string(data))
@@ -39,7 +39,7 @@ func TestClusteredData(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	data, err = cd2.LoadData()
+	data, err = cd2.AcquireData()
 	require.NoError(t, err)
 	require.NotNil(t, data)
 	require.Equal(t, sData, string(data))
@@ -56,7 +56,7 @@ func TestClusteredData(t *testing.T) {
 	cd3 := NewClusteredData("statebucket", "stateprefix",
 		"databucket", "dataprefix", objStore, ClusteredDataOpts{})
 
-	data, err = cd3.LoadData()
+	data, err = cd3.AcquireData()
 	require.NoError(t, err)
 	require.NotNil(t, data)
 	require.Equal(t, sData, string(data))
@@ -74,16 +74,16 @@ func TestClusteredDataReadyState(t *testing.T) {
 	require.Equal(t, "not loaded", err.Error())
 	require.False(t, ok)
 
-	_, err = cd.LoadData()
+	_, err = cd.AcquireData()
 	require.NoError(t, err)
 
 	// Can load more than once
-	_, err = cd.LoadData()
+	_, err = cd.AcquireData()
 	require.NoError(t, err)
 
 	cd.Stop()
 
-	_, err = cd.LoadData()
+	_, err = cd.AcquireData()
 	require.Error(t, err)
 	require.Equal(t, "stopped", err.Error())
 
@@ -122,7 +122,7 @@ func TestClusteredDataConcurrency(t *testing.T) {
 	// Check final state
 	cd := NewClusteredData("statebucket", "stateprefix",
 		"databucket", "dataprefix", objStore, ClusteredDataOpts{})
-	data, err := cd.LoadData()
+	data, err := cd.AcquireData()
 	require.NoError(t, err)
 
 	m := deserializeMap(data)
@@ -148,7 +148,7 @@ func (r *runner) run() error {
 		for {
 			cd := NewClusteredData("statebucket", "stateprefix",
 				"databucket", "dataprefix", r.objStore, ClusteredDataOpts{})
-			data, err := cd.LoadData()
+			data, err := cd.AcquireData()
 			if err != nil {
 				return err
 			}

--- a/cluster/clustered_data_test.go
+++ b/cluster/clustered_data_test.go
@@ -1,0 +1,205 @@
+package cluster
+
+import (
+	"encoding/binary"
+	"github.com/pkg/errors"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/objstore/dev"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestClusteredData(t *testing.T) {
+	objStore := dev.NewInMemStore(0)
+
+	cd1 := NewClusteredData("statebucket", "stateprefix",
+		"databucket", "dataprefix", objStore, ClusteredDataOpts{})
+
+	data, err := cd1.LoadData()
+	require.NoError(t, err)
+	require.Nil(t, data)
+
+	sData := "hello"
+
+	ok, err := cd1.StoreData([]byte(sData))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	cd2 := NewClusteredData("statebucket", "stateprefix",
+		"databucket", "dataprefix", objStore, ClusteredDataOpts{})
+
+	data, err = cd2.LoadData()
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Equal(t, sData, string(data))
+
+	sData += "clustered"
+
+	ok, err = cd2.StoreData([]byte(sData))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	data, err = cd2.LoadData()
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Equal(t, sData, string(data))
+
+	// Now try and store on previous clustered data
+
+	sData2 := "armadillos"
+
+	ok, err = cd1.StoreData([]byte(sData2))
+	require.NoError(t, err)
+	// must fail as cd2 has advanced the epoch
+	require.False(t, ok)
+
+	cd3 := NewClusteredData("statebucket", "stateprefix",
+		"databucket", "dataprefix", objStore, ClusteredDataOpts{})
+
+	data, err = cd3.LoadData()
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Equal(t, sData, string(data))
+}
+
+func TestClusteredDataReadyState(t *testing.T) {
+	objStore := dev.NewInMemStore(0)
+
+	cd := NewClusteredData("statebucket", "stateprefix",
+		"databucket", "dataprefix", objStore, ClusteredDataOpts{})
+
+	// not loaded
+	ok, err := cd.StoreData([]byte("foo"))
+	require.Error(t, err)
+	require.Equal(t, "not loaded", err.Error())
+	require.False(t, ok)
+
+	_, err = cd.LoadData()
+	require.NoError(t, err)
+
+	// Can load more than once
+	_, err = cd.LoadData()
+	require.NoError(t, err)
+
+	cd.Stop()
+
+	_, err = cd.LoadData()
+	require.Error(t, err)
+	require.Equal(t, "stopped", err.Error())
+
+	ok, err = cd.StoreData([]byte("foo"))
+	require.Error(t, err)
+	require.Equal(t, "not loaded", err.Error())
+	require.False(t, ok)
+}
+
+// TestClusteredDataConcurrency - this test concurrently invokes LoadState and StoreState on multiple ClusteredState
+// instances and validates that no state is lost
+func TestClusteredDataConcurrency(t *testing.T) {
+	objStore := dev.NewInMemStore(0)
+	concurrency := 10
+	updatesPerRunner := 100
+
+	var runners []runner
+	for i := 0; i < concurrency; i++ {
+		runners = append(runners, runner{
+			objStore:    objStore,
+			runnerIndex: i,
+			numUpdates:  updatesPerRunner,
+			completeCh:  make(chan error, 1),
+		})
+	}
+	for _, runner := range runners {
+		r := runner
+		go func() {
+			r.Run()
+		}()
+	}
+	for _, runner := range runners {
+		err := <-runner.completeCh
+		require.NoError(t, err)
+	}
+	// Check final state
+	cd := NewClusteredData("statebucket", "stateprefix",
+		"databucket", "dataprefix", objStore, ClusteredDataOpts{})
+	data, err := cd.LoadData()
+	require.NoError(t, err)
+
+	m := deserializeMap(data)
+	require.Equal(t, concurrency, len(m))
+	for i := 0; i < concurrency; i++ {
+		require.Equal(t, m[i], updatesPerRunner)
+	}
+}
+
+type runner struct {
+	objStore    objstore.Client
+	runnerIndex int
+	numUpdates  int
+	completeCh  chan error
+}
+
+func (r *runner) Run() {
+	r.completeCh <- r.run()
+}
+
+func (r *runner) run() error {
+	for i := 0; i < r.numUpdates; i++ {
+		for {
+			cd := NewClusteredData("statebucket", "stateprefix",
+				"databucket", "dataprefix", r.objStore, ClusteredDataOpts{})
+			data, err := cd.LoadData()
+			if err != nil {
+				return err
+			}
+			if data == nil {
+				data = make([]byte, 8) // zero length map
+			}
+			// deserialize map
+			m := deserializeMap(data)
+			prev := m[r.runnerIndex]
+			if i > 0 {
+				if prev < i {
+					// lost data
+					return errors.Errorf("runner %d expected at least previous data %d found %d", r.runnerIndex, i, prev)
+				}
+			}
+			// update map
+			m[r.runnerIndex] = i + 1
+			// serialize map
+			buff := serializeMap(m)
+			ok, err := cd.StoreData(buff)
+			if err != nil {
+				return err
+			}
+			if ok {
+				break
+			}
+			// failed to store, epoch change. retry
+		}
+	}
+	return nil
+}
+
+func deserializeMap(data []byte) map[int]int {
+	numEntries := int(binary.BigEndian.Uint64(data))
+	offset := 8
+	m := make(map[int]int, numEntries)
+	for i := 0; i < numEntries; i++ {
+		k := int(binary.BigEndian.Uint64(data[offset:]))
+		offset += 8
+		v := int(binary.BigEndian.Uint64(data[offset:]))
+		offset += 8
+		m[k] = v
+	}
+	return m
+}
+
+func serializeMap(m map[int]int) []byte {
+	buff := binary.BigEndian.AppendUint64(nil, uint64(len(m)))
+	for k, v := range m {
+		buff = binary.BigEndian.AppendUint64(buff, uint64(k))
+		buff = binary.BigEndian.AppendUint64(buff, uint64(v))
+	}
+	return buff
+}

--- a/cluster/membership.go
+++ b/cluster/membership.go
@@ -15,7 +15,7 @@ type Membership struct {
 	updateTimer          *time.Timer
 	lock                 sync.Mutex
 	started              bool
-	stateMachine         *StateUpdator
+	stateUpdator         *StateUpdator
 	address              string
 	leader               bool
 	becomeLeaderCallback func()
@@ -25,7 +25,7 @@ func NewMembership(bucket string, keyPrefix string, address string, objStoreClie
 	evictionInterval time.Duration, becomeLeaderCallback func()) *Membership {
 	return &Membership{
 		address:              address,
-		stateMachine:         NewStateUpdator(bucket, keyPrefix, objStoreClient, StateUpdatorOpts{}),
+		stateUpdator:         NewStateUpdator(bucket, keyPrefix, objStoreClient, StateUpdatorOpts{}),
 		updateInterval:       updateInterval,
 		evictionInterval:     evictionInterval,
 		becomeLeaderCallback: becomeLeaderCallback,
@@ -38,7 +38,7 @@ func (m *Membership) Start() {
 	if m.started {
 		return
 	}
-	m.stateMachine.Start()
+	m.stateUpdator.Start()
 	m.scheduleTimer()
 	m.started = true
 }
@@ -51,7 +51,7 @@ func (m *Membership) Stop() {
 	}
 	m.started = false
 	m.updateTimer.Stop()
-	m.stateMachine.Stop()
+	m.stateUpdator.Stop()
 }
 
 func (m *Membership) scheduleTimer() {
@@ -71,7 +71,7 @@ func (m *Membership) updateOnTimer() {
 }
 
 func (m *Membership) update() error {
-	buff, err := m.stateMachine.Update(m.updateState)
+	buff, err := m.stateUpdator.Update(m.updateState)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func (m *Membership) GetState() (MembershipState, error) {
 	if !m.started {
 		return MembershipState{}, errors.New("not started")
 	}
-	buff, err := m.stateMachine.GetState()
+	buff, err := m.stateUpdator.GetState()
 	if err != nil {
 		return MembershipState{}, err
 	}

--- a/cluster/membership.go
+++ b/cluster/membership.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"encoding/json"
 	"github.com/pkg/errors"
 	log "github.com/spirit-labs/tektite/logger"
 	"github.com/spirit-labs/tektite/objstore"
@@ -14,7 +15,7 @@ type Membership struct {
 	updateTimer          *time.Timer
 	lock                 sync.Mutex
 	started              bool
-	stateMachine         *StateMachine[MembershipState]
+	stateMachine         *StateUpdator
 	address              string
 	leader               bool
 	becomeLeaderCallback func()
@@ -24,7 +25,7 @@ func NewMembership(bucket string, keyPrefix string, address string, objStoreClie
 	evictionInterval time.Duration, becomeLeaderCallback func()) *Membership {
 	return &Membership{
 		address:              address,
-		stateMachine:         NewStateMachine[MembershipState](bucket, keyPrefix, objStoreClient, StateMachineOpts{}),
+		stateMachine:         NewStateUpdator(bucket, keyPrefix, objStoreClient, StateUpdatorOpts{}),
 		updateInterval:       updateInterval,
 		evictionInterval:     evictionInterval,
 		becomeLeaderCallback: becomeLeaderCallback,
@@ -70,7 +71,12 @@ func (m *Membership) updateOnTimer() {
 }
 
 func (m *Membership) update() error {
-	newState, err := m.stateMachine.Update(m.updateState)
+	buff, err := m.stateMachine.Update(m.updateState)
+	if err != nil {
+		return err
+	}
+	var newState MembershipState
+	err = json.Unmarshal(buff, &newState)
 	if err != nil {
 		return err
 	}
@@ -83,7 +89,14 @@ func (m *Membership) update() error {
 	return nil
 }
 
-func (m *Membership) updateState(memberShipState MembershipState) (MembershipState, error) {
+func (m *Membership) updateState(buff []byte) ([]byte, error) {
+	var memberShipState MembershipState
+	if buff != nil {
+		err := json.Unmarshal(buff, &memberShipState)
+		if err != nil {
+			return nil, err
+		}
+	}
 	now := time.Now().UnixMilli()
 	found := false
 	var newMembers []MembershipEntry
@@ -113,14 +126,14 @@ func (m *Membership) updateState(memberShipState MembershipState) (MembershipSta
 	memberShipState.Members = newMembers
 	if changed {
 		// NewmMember joined or member(s) where evicted, so we change the epoch
-		memberShipState.Epoch++
+		memberShipState.ClusterVersion++
 	}
-	return memberShipState, nil
+	return json.Marshal(&memberShipState)
 }
 
 type MembershipState struct {
-	Epoch   int               // Epoch changes every time member joins or leaves the group
-	Members []MembershipEntry // The members of the group, we define the first member to be the leader
+	ClusterVersion int               // ClusterVersion changes every time member joins or leaves the group
+	Members        []MembershipEntry // The members of the group, we define the first member to be the leader
 }
 
 type MembershipEntry struct {
@@ -134,5 +147,17 @@ func (m *Membership) GetState() (MembershipState, error) {
 	if !m.started {
 		return MembershipState{}, errors.New("not started")
 	}
-	return m.stateMachine.GetState()
+	buff, err := m.stateMachine.GetState()
+	if err != nil {
+		return MembershipState{}, err
+	}
+	if buff == nil {
+		return MembershipState{}, nil
+	}
+	memberShipState := MembershipState{}
+	err = json.Unmarshal(buff, &memberShipState)
+	if err != nil {
+		return MembershipState{}, err
+	}
+	return memberShipState, nil
 }

--- a/cluster/membership_test.go
+++ b/cluster/membership_test.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"fmt"
-	log "github.com/spirit-labs/tektite/logger"
 	"github.com/spirit-labs/tektite/objstore/dev"
 	"github.com/stretchr/testify/require"
 	"math/rand"
@@ -36,14 +35,13 @@ func TestJoinSequential(t *testing.T) {
 		waitForMembers(t, memberships...)
 		state, err := membership.GetState()
 		require.NoError(t, err)
-		require.Equal(t, i+1, state.Epoch)
+		require.Equal(t, i+1, state.ClusterVersion)
 	}
 	require.Equal(t, 1, int(becomeLeaderCalledCount.Load()))
 	for _, membership := range memberships {
 		state, err := membership.GetState()
 		require.NoError(t, err)
-		log.Infof("epoch is %d", state.Epoch)
-		require.Equal(t, numMembers, state.Epoch)
+		require.Equal(t, numMembers, state.ClusterVersion)
 		require.Equal(t, numMembers, len(state.Members))
 		// should be in order of joining
 		for i, membership2 := range memberships {
@@ -76,8 +74,7 @@ func TestJoinParallel(t *testing.T) {
 	for _, membership := range memberships {
 		state, err := membership.GetState()
 		require.NoError(t, err)
-		log.Infof("epoch is %d", state.Epoch)
-		require.Equal(t, numMembers, state.Epoch)
+		require.Equal(t, numMembers, state.ClusterVersion)
 	}
 }
 
@@ -111,7 +108,7 @@ func TestNonLeadersEvicted(t *testing.T) {
 		for _, membership := range memberships {
 			state, err := membership.GetState()
 			require.NoError(t, err)
-			require.Equal(t, numMembers+i+1, state.Epoch)
+			require.Equal(t, numMembers+i+1, state.ClusterVersion)
 		}
 	}
 	finalState, err := memberships[0].GetState()
@@ -160,7 +157,7 @@ func TestLeaderEvicted(t *testing.T) {
 		for _, membership := range memberships {
 			state, err := membership.GetState()
 			require.NoError(t, err)
-			require.Equal(t, numMembers+i+1, state.Epoch)
+			require.Equal(t, numMembers+i+1, state.ClusterVersion)
 		}
 	}
 	for i := 0; i < numMembers; i++ {

--- a/cluster/state_updator.go
+++ b/cluster/state_updator.go
@@ -16,11 +16,11 @@ import (
 )
 
 /*
-StateUpdator persists its state using object storage. Clients concurrently update the state through their own instances
+StateUpdator persists its state in object storage. Clients concurrently update the state through their own instances
 of this struct by supplying a function that takes the previous state and returns the new state. The struct provides
-serializability to updates even though clients are distributed. It can be used as the foundation for various distributed
-concurrency primitives, such as finite state machines, group membership, distributed locks, distributed sequences, and
-more.
+serializability to updates even though clients are distributed. Updates occur as if they happened one after another.
+It can be used as the foundation for various distributed concurrency primitives, such as finite state machines, group
+membership, distributed locks, distributed sequences, and more.
 
 StateUpdator uses conditional writes via the PutIfNotExists method of the object store. This method atomically stores an
 object only if no existing object with the same key is present.
@@ -62,9 +62,9 @@ type StateUpdator struct {
 	stateKeyPrefix string
 	keyBucket      string
 	objStoreClient objstore.Client
-	memberID string
-	opts     StateUpdatorOpts
-	started  bool
+	memberID       string
+	opts           StateUpdatorOpts
+	started        bool
 	stopping       atomic.Bool
 	updateTimer    *time.Timer
 	lastUpdateTime int64

--- a/lsm/compaction.go
+++ b/lsm/compaction.go
@@ -77,7 +77,7 @@ func (lm *Manager) maybeScheduleCompaction() error {
 }
 
 func (lm *Manager) getAllL0Tables() ([][]*TableEntry, error) {
-	entry := lm.getLevelEntry(0)
+	entry := lm.levelEntry(0)
 	tableEntries := make([]*TableEntry, len(entry.tableEntries))
 	for i, lte := range entry.tableEntries {
 		tableEntries[i] = lte.Get(entry)
@@ -88,7 +88,7 @@ func (lm *Manager) getAllL0Tables() ([][]*TableEntry, error) {
 func (lm *Manager) scheduleCompaction(level int, tableSlices [][]*TableEntry, completionFunc func(error)) (int, bool, error) {
 	// If we are compacting into the last level, then we delete tombstones
 	var jobs []CompactionJob
-	destLevelEntries := lm.getLevelEntry(level + 1)
+	destLevelEntries := lm.levelEntry(level + 1)
 	destLevelExists := len(destLevelEntries.tableEntries) > 0
 	hasLocked := false
 	now := uint64(time.Now().UTC().UnixMilli())
@@ -409,7 +409,7 @@ func (lm *Manager) chooseTablesToCompact(level int, maxTables int) ([][]*TableEn
 		// We compact the whole level -this is done as a single job, as there can be overlap between L0 tables
 		return lm.getAllL0Tables()
 	}
-	levEntry := lm.getLevelEntry(level)
+	levEntry := lm.levelEntry(level)
 	tables, err := chooseTablesToCompactFromLevel(levEntry, maxTables)
 	if err != nil {
 		return nil, err
@@ -645,7 +645,7 @@ func (lm *Manager) checkForDeadEntries(rng VersionRange) bool {
 func (lm *Manager) forceCompaction(level int, maxTables int) error {
 	lm.lock.Lock()
 	defer lm.lock.Unlock()
-	entries := lm.getLevelEntry(level)
+	entries := lm.levelEntry(level)
 	if len(entries.tableEntries) == 0 {
 		return nil
 	}

--- a/lsm/compaction_test.go
+++ b/lsm/compaction_test.go
@@ -902,7 +902,7 @@ func getJob(lm *Manager) (*CompactionJob, error) {
 }
 
 func checkLevelEntries(t *testing.T, lm *Manager, level int, entries ...TableEntry) {
-	levEntry := lm.GetLevelEntry(level)
+	levEntry := lm.getLevelEntry(level)
 	require.Equal(t, len(entries), len(levEntry.tableEntries))
 	for i, expectedTe := range entries {
 		te := getTableEntry(lm, levEntry.tableEntries[i], levEntry)

--- a/lsm/compaction_worker_test.go
+++ b/lsm/compaction_worker_test.go
@@ -570,7 +570,7 @@ func TestCompactionExpiredPrefix(t *testing.T) {
 
 	endRange := common.IncBigEndianBytes(prefix1)
 	for i := 0; i < lm.getLastLevel(); i++ {
-		levEntry := lm.GetLevelEntry(i)
+		levEntry := lm.getLevelEntry(i)
 		tableEntries := levEntry.tableEntries
 		for _, lte := range tableEntries {
 			te := getTableEntry(lm, lte, levEntry)
@@ -647,7 +647,7 @@ func TestCompactionDeadVersions(t *testing.T) {
 
 	// Should be no dead versions
 	for i := 0; i <= lm.getLastLevel(); i++ {
-		levEntry := lm.GetLevelEntry(i)
+		levEntry := lm.getLevelEntry(i)
 		tableEntries := levEntry.tableEntries
 		for _, lte := range tableEntries {
 			te := getTableEntry(lm, lte, levEntry)
@@ -758,7 +758,7 @@ func TestCompactionPrefixDeletions(t *testing.T) {
 		// There should be no prefix1 in any levels
 		endRange := common.IncBigEndianBytes(prefixes[1])
 		for i := 0; i < lm.getLastLevel(); i++ {
-			levEntry := lm.GetLevelEntry(i)
+			levEntry := lm.getLevelEntry(i)
 			tableEntries := levEntry.tableEntries
 			for _, lte := range tableEntries {
 				te := getTableEntry(lm, lte, levEntry)

--- a/lsm/level_manager_test.go
+++ b/lsm/level_manager_test.go
@@ -666,7 +666,7 @@ func setupLevelManagerWithConfigSetter(t *testing.T, enableCompaction bool, vali
 	cloudStore := &dev.InMemStore{}
 	lm := NewManager(&cfg, cloudStore, enableCompaction, validate)
 	mr := NewMasterRecord(common.MetadataFormatV1)
-	err := lm.Start(mr)
+	err := lm.Start(mr.Serialize(nil))
 	require.NoError(t, err)
 	return lm, func(t *testing.T) {
 		err := lm.Stop()
@@ -1202,7 +1202,7 @@ func regTableInLevel(t *testing.T, lm *Manager, level int, keyStart int, keyEnd 
 }
 
 func verifyTablesInLevel(t *testing.T, lm *Manager, level int, expectedTablePairs []int) {
-	levEntry := lm.GetLevelEntry(level)
+	levEntry := lm.getLevelEntry(level)
 	require.Equal(t, len(expectedTablePairs), 2*len(levEntry.tableEntries))
 	pos := 0
 	for i := 0; i < len(expectedTablePairs); i += 2 {

--- a/lsm/structs.go
+++ b/lsm/structs.go
@@ -250,6 +250,12 @@ type Stats struct {
 	LevelStats     map[int]*LevelStats
 }
 
+func (l *Stats) SerializedSize() int {
+	size := 7 * 8 + 4
+	size += len(l.LevelStats) * (4 + 3 * 8)
+	return size
+}
+
 func (l *Stats) Serialize(buff []byte) []byte {
 	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.TotBytes))
 	buff = encoding.AppendUint64ToBufferLE(buff, uint64(l.TotEntries))
@@ -362,6 +368,25 @@ func NewMasterRecord(format common.MetadataFormat) *MasterRecord {
 	}
 }
 
+func (mr *MasterRecord) SerializedSize() int {
+	size :=
+		1 + // format
+		8 + // version
+		4 + // num levels
+		4 + // num level table counts
+		len(mr.levelTableCounts) * (4 + 8) + // level table counts
+		4 + // num slab retentions
+		len(mr.slabRetentions) * (8 + 8) + // slab retentions
+		8 // last flushed version
+	for _, levEntry := range mr.levelEntries {
+		size += levEntry.serializedSize()
+	}
+	if mr.stats != nil {
+		size += mr.stats.SerializedSize()
+	}
+	return size
+}
+
 func (mr *MasterRecord) Serialize(buff []byte) []byte {
 	buff = append(buff, byte(mr.format))
 	buff = encoding.AppendUint64ToBufferLE(buff, mr.version)
@@ -428,9 +453,11 @@ type levelEntry struct {
 	tableEntries     []levelTableEntry
 	tableEntriesBuff []byte
 	addedTablesBuff  []byte
+	totEntrySizes int
 }
 
 func (le *levelEntry) SetAt(index int, te *TableEntry) {
+	prevLength := le.tableEntries[index].length
 	pos := len(le.addedTablesBuff)
 	le.addedTablesBuff = te.serialize(le.addedTablesBuff)
 	length := uint32(len(le.addedTablesBuff) - pos)
@@ -439,6 +466,7 @@ func (le *levelEntry) SetAt(index int, te *TableEntry) {
 		length: length,
 	}
 	le.tableEntries[index] = lte
+	le.totEntrySizes += int(length - prevLength)
 }
 
 func (le *levelEntry) InsertAt(index int, te *TableEntry) {
@@ -453,13 +481,28 @@ func (le *levelEntry) InsertAt(index int, te *TableEntry) {
 		length: length,
 	}
 	le.tableEntries = insertInSlice(le.tableEntries, index, lte)
+	le.totEntrySizes += int(length)
 }
 
 func (le *levelEntry) RemoveAt(index int) {
+	prevLength := le.tableEntries[index].length
 	le.tableEntries = append(le.tableEntries[:index], le.tableEntries[index+1:]...)
+	le.totEntrySizes -= int(prevLength)
 }
 
 var eightZeroBytes = []byte{0, 0, 0, 0, 0, 0, 0, 0}
+
+func (le *levelEntry) serializedSize() int {
+	return 	8 + //  max version
+			4 + // len(rangeStart)
+			len(le.rangeStart) +
+			4 + // len(rangeEnd)
+			len(le.rangeEnd) +
+			8 + // positionPos
+			8 + // num table entries
+			le.totEntrySizes +
+			len(le.tableEntries) * 8 // positions
+}
 
 func (le *levelEntry) Serialize(buff []byte) []byte {
 	buff = encoding.AppendUint64ToBufferLE(buff, le.maxVersion)
@@ -526,6 +569,7 @@ func (le *levelEntry) Serialize(buff []byte) []byte {
 }
 
 func (le *levelEntry) Deserialize(buff []byte, offset int) int {
+	totEntriesSize := 0
 	le.maxVersion, offset = encoding.ReadUint64FromBufferLE(buff, offset)
 	var l uint32
 	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
@@ -554,17 +598,23 @@ func (le *levelEntry) Deserialize(buff []byte, offset int) int {
 		pos, offset = encoding.ReadUint64FromBufferLE(buff, offset)
 		le.tableEntries[i].pos = int(pos)
 		if i > 0 {
-			le.tableEntries[i-1].length = uint32(pos - prevPos)
+			l := pos - prevPos
+			totEntriesSize += int(l)
+			le.tableEntries[i-1].length = uint32(l)
 		}
 		prevPos = pos
 	}
 	if numEntries == 1 {
+		totEntriesSize += entriesSize
 		le.tableEntries[0].length = uint32(entriesSize)
 	} else if numEntries > 1 {
 		lastButOne := le.tableEntries[numEntries-2]
-		le.tableEntries[numEntries-1].length = uint32(int(positionPos) - lastButOne.pos - int(lastButOne.length))
+		l := int(positionPos) - lastButOne.pos - int(lastButOne.length)
+		totEntriesSize += l
+		le.tableEntries[numEntries-1].length = uint32(l)
 	}
 	le.addedTablesBuff = nil
+	le.totEntrySizes = totEntriesSize
 	return offset
 }
 

--- a/lsm/structs.go
+++ b/lsm/structs.go
@@ -251,8 +251,8 @@ type Stats struct {
 }
 
 func (l *Stats) SerializedSize() int {
-	size := 7 * 8 + 4
-	size += len(l.LevelStats) * (4 + 3 * 8)
+	size := 7*8 + 4
+	size += len(l.LevelStats) * (4 + 3*8)
 	return size
 }
 
@@ -371,13 +371,13 @@ func NewMasterRecord(format common.MetadataFormat) *MasterRecord {
 func (mr *MasterRecord) SerializedSize() int {
 	size :=
 		1 + // format
-		8 + // version
-		4 + // num levels
-		4 + // num level table counts
-		len(mr.levelTableCounts) * (4 + 8) + // level table counts
-		4 + // num slab retentions
-		len(mr.slabRetentions) * (8 + 8) + // slab retentions
-		8 // last flushed version
+			8 + // version
+			4 + // num levels
+			4 + // num level table counts
+			len(mr.levelTableCounts)*(4+8) + // level table counts
+			4 + // num slab retentions
+			len(mr.slabRetentions)*(8+8) + // slab retentions
+			8 // last flushed version
 	for _, levEntry := range mr.levelEntries {
 		size += levEntry.serializedSize()
 	}
@@ -453,7 +453,7 @@ type levelEntry struct {
 	tableEntries     []levelTableEntry
 	tableEntriesBuff []byte
 	addedTablesBuff  []byte
-	totEntrySizes int
+	totEntrySizes    int
 }
 
 func (le *levelEntry) SetAt(index int, te *TableEntry) {
@@ -493,15 +493,15 @@ func (le *levelEntry) RemoveAt(index int) {
 var eightZeroBytes = []byte{0, 0, 0, 0, 0, 0, 0, 0}
 
 func (le *levelEntry) serializedSize() int {
-	return 	8 + //  max version
-			4 + // len(rangeStart)
-			len(le.rangeStart) +
-			4 + // len(rangeEnd)
-			len(le.rangeEnd) +
-			8 + // positionPos
-			8 + // num table entries
-			le.totEntrySizes +
-			len(le.tableEntries) * 8 // positions
+	return 8 + //  max version
+		4 + // len(rangeStart)
+		len(le.rangeStart) +
+		4 + // len(rangeEnd)
+		len(le.rangeEnd) +
+		8 + // positionPos
+		8 + // num table entries
+		le.totEntrySizes +
+		len(le.tableEntries)*8 // positions
 }
 
 func (le *levelEntry) Serialize(buff []byte) []byte {
@@ -510,6 +510,9 @@ func (le *levelEntry) Serialize(buff []byte) []byte {
 	buff = append(buff, le.rangeStart...)
 	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(le.rangeEnd)))
 	buff = append(buff, le.rangeEnd...)
+	// The positions go at the end of the serialized state, and this is the position in the buffer of the start of the
+	// positions. We fill it in first with zeros (as we don't know the value until we have serialized all the entries),
+	// then we fill it in at the end.
 	positionsPos := len(buff)
 	buff = append(buff, eightZeroBytes...)
 	blockStart := -1

--- a/lsm/table_entries_bench_test.go
+++ b/lsm/table_entries_bench_test.go
@@ -7,7 +7,7 @@ import (
 
 func BenchmarkSerializeManyTableEntries(b *testing.B) {
 
-	numEntries := 1000000
+	numEntries := 62500
 
 	levEntry := levelEntry{}
 	for i := 0; i < numEntries; i++ {
@@ -16,7 +16,7 @@ func BenchmarkSerializeManyTableEntries(b *testing.B) {
 
 	b.ResetTimer()
 
-	buff := make([]byte, 0, 16*1024*1024)
+	buff := make([]byte, 0, 10*1024*1024)
 
 	for i := 0; i < b.N; i++ {
 		buff = levEntry.Serialize(buff)


### PR DESCRIPTION
This PR includes a few things.
* Implements a new struct called ClusteredData which allows a member of the cluster to take safely take ownership of a potentially large piece of data, update it and store it without fear of concurrent updates from another member overwriting changes. It will be used by the controller to store metadata for Tektite, e.g. the LSM metadata.
* Also renames StateMachine to StateUpdator to avoid confusion.
* Some small changes to level manager method names
* Provide a buffer size calculation for master record so we efficiently allocated a buffer of the correct size when serializing.