### PR TITLE
MINOR: Add a FetchLatest method to StateUpdator and touch up docs a bit

### DIFF
--- a/cluster/state_updator_test.go
+++ b/cluster/state_updator_test.go
@@ -107,7 +107,6 @@ func TestStateUpdatorJoinMember(t *testing.T) {
 	// Should catch up and get correct sequence
 	require.Equal(t, expectedSeq, member.NextSequence())
 	expectedSeq++
-
 }
 
 func TestStateUpdatorLatestState(t *testing.T) {
@@ -277,11 +276,9 @@ func applyLoadAndVerifyStateUpdator(t *testing.T, runTime time.Duration, numMemb
 		require.NoError(t, err)
 	}
 
-	// Do a final no-op update on each member to make sure it loads final state
+	// Do a final fetch on each member to make sure it loads final state
 	for _, member := range members {
-		_, err := member.Update(updateWithBytesFunc(func(state stateMachineState) (stateMachineState, error) {
-			return state, nil
-		}))
+		_, err := member.FetchLatestState()
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
This patch:

- touches up the docs in Clustered Data to, imo, make the mechanism clearer.
- adds a log prefix and ensures its used consistently in clustered_data
- adds a FetchLatest method to StateUpdator. I thought it's better to abstract that away, as for example - Clustered Data shouldn't really care about the implementation detail of doing a "no-op update" to ensure it fetches the latest state