### PR TITLE
Shard manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/minio v0.33.0
 	github.com/tetratelabs/wazero v1.7.1
 	github.com/tidwall/gjson v1.14.4
-	github.com/timandy/routine v1.1.1
+	github.com/timandy/routine v1.1.4
 	github.com/xdg-go/pbkdf2 v1.0.0
 	github.com/xdg-go/scram v1.1.2
 	github.com/yosuke-furukawa/json5 v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -968,6 +968,8 @@ github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375 h1:QB54BJwA6x8
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375/go.mod h1:xRroudyp5iVtxKqZCrA6n2TLFRBf8bmnjr1UD4x+z7g=
 github.com/timandy/routine v1.1.1 h1:6/Z7qLFZj3GrzuRksBFzIG8YGUh8CLhjnnMePBQTrEI=
 github.com/timandy/routine v1.1.1/go.mod h1:OZHPOKSvqL/ZvqXFkNZyit0xIVelERptYXdAHH00adQ=
+github.com/timandy/routine v1.1.4 h1:L9eAli/ROJcW6LhmwZcusYQcdAqxAXGOQhEXLQSNWOA=
+github.com/timandy/routine v1.1.4/go.mod h1:siBcl8iIsGmhLCajRGRcy7Y7FVcicNXkr97JODdt9fc=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=

--- a/lsm/client.go
+++ b/lsm/client.go
@@ -7,13 +7,11 @@ import (
 type Client interface {
 	QueryTablesInRange(keyStart []byte, keyEnd []byte) (OverlappingTables, error)
 
-	RegisterL0Tables(registrationBatch RegistrationBatch) error
-
-	ApplyChanges(registrationBatch RegistrationBatch) error
+	ApplyChanges(registrationBatch RegistrationBatch) (bool, error)
 
 	PollForJob() (*CompactionJob, error)
 
-	RegisterDeadVersionRange(versionRange VersionRange, clusterName string, clusterVersion int) error
+	RegisterDeadVersionRange(versionRange VersionRange) error
 
 	StoreLastFlushedVersion(version int64) error
 

--- a/lsm/compaction_worker.go
+++ b/lsm/compaction_worker.go
@@ -150,7 +150,7 @@ func (c *compactionWorker) loop() {
 					Registrations:   registrations,
 					DeRegistrations: deRegistrations,
 				}
-				err = c.client.ApplyChanges(regBatch)
+				_, err := c.client.ApplyChanges(regBatch)
 				if err == nil {
 					// success
 					break

--- a/lsm/in_mem.go
+++ b/lsm/in_mem.go
@@ -18,20 +18,12 @@ func (c *InMemClient) QueryTablesInRange(keyStart []byte, keyEnd []byte) (Overla
 	return c.LevelManager.QueryTablesInRange(keyStart, keyEnd)
 }
 
-func (c *InMemClient) RegisterL0Tables(registrationBatch RegistrationBatch) error {
-	ch := make(chan error, 1)
-	c.LevelManager.RegisterL0Tables(registrationBatch, func(err error) {
-		ch <- err
-	})
-	return <-ch
+func (c *InMemClient) ApplyChanges(registrationBatch RegistrationBatch) (bool, error) {
+	return c.LevelManager.ApplyChanges(registrationBatch, false)
 }
 
-func (c *InMemClient) ApplyChanges(registrationBatch RegistrationBatch) error {
-	return c.LevelManager.ApplyChanges(registrationBatch)
-}
-
-func (c *InMemClient) RegisterDeadVersionRange(versionRange VersionRange, clusterName string, clusterVersion int) error {
-	return c.LevelManager.RegisterDeadVersionRange(versionRange, clusterName, clusterVersion)
+func (c *InMemClient) RegisterDeadVersionRange(versionRange VersionRange) error {
+	return c.LevelManager.RegisterDeadVersionRange(versionRange)
 }
 
 func (c *InMemClient) PollForJob() (*CompactionJob, error) {

--- a/lsm/structs.go
+++ b/lsm/structs.go
@@ -114,21 +114,15 @@ func (re *RegistrationEntry) deserialize(buff []byte, offset int) int {
 }
 
 type RegistrationBatch struct {
-	ClusterName     string
-	ClusterVersion  int
 	Compaction      bool
 	JobID           string
-	ProcessorID     int
 	Registrations   []RegistrationEntry
 	DeRegistrations []RegistrationEntry
 }
 
 func (rb *RegistrationBatch) Serialize(buff []byte) []byte {
-	buff = encoding.AppendStringToBufferLE(buff, rb.ClusterName)
-	buff = encoding.AppendUint64ToBufferLE(buff, uint64(rb.ClusterVersion))
 	buff = encoding.AppendBoolToBuffer(buff, rb.Compaction)
 	buff = encoding.AppendStringToBufferLE(buff, rb.JobID)
-	buff = encoding.AppendUint64ToBufferLE(buff, uint64(rb.ProcessorID))
 	buff = encoding.AppendUint32ToBufferLE(buff, uint32(len(rb.Registrations)))
 	for _, reg := range rb.Registrations {
 		buff = reg.serialize(buff)
@@ -141,17 +135,8 @@ func (rb *RegistrationBatch) Serialize(buff []byte) []byte {
 }
 
 func (rb *RegistrationBatch) Deserialize(buff []byte, offset int) int {
-	var s string
-	s, offset = encoding.ReadStringFromBufferLE(buff, offset)
-	rb.ClusterName = s
-	var ver uint64
-	ver, offset = encoding.ReadUint64FromBufferLE(buff, offset)
-	rb.ClusterVersion = int(ver)
 	rb.Compaction, offset = encoding.ReadBoolFromBuffer(buff, offset)
 	rb.JobID, offset = encoding.ReadStringFromBufferLE(buff, offset)
-	var pid uint64
-	pid, offset = encoding.ReadUint64FromBufferLE(buff, offset)
-	rb.ProcessorID = int(pid)
 	var l uint32
 	l, offset = encoding.ReadUint32FromBufferLE(buff, offset)
 	rb.Registrations = make([]RegistrationEntry, l)

--- a/lsm/structs_test.go
+++ b/lsm/structs_test.go
@@ -71,11 +71,8 @@ func TestSerializeDeserializeRegistrationEntry(t *testing.T) {
 
 func TestSerializeDeserializeRegistrationBatch(t *testing.T) {
 	regBatch := &RegistrationBatch{
-		ClusterName:    "test_cluster",
-		ClusterVersion: 23,
-		Compaction:     true,
-		JobID:          "job-12345",
-		ProcessorID:    534343,
+		Compaction:  true,
+		JobID:       "job-12345",
 		Registrations: []RegistrationEntry{{
 			Level:      23,
 			TableID:    sst.SSTableID("sometableid1"),

--- a/lsm/validate.go
+++ b/lsm/validate.go
@@ -9,20 +9,20 @@ import (
 )
 
 // Validate checks the LSM is sound - no overlapping keys in L > 0, keys in each table are sorted, etc.
-func (lm *Manager) Validate(validateTables bool) error {
-	lse := lm.masterRecord.levelEntries
+func (m *Manager) Validate(validateTables bool) error {
+	lse := m.masterRecord.levelEntries
 	if len(lse) == 0 {
 		return nil
 	}
 	for level, levEntry := range lse {
-		if err := lm.validateLevelEntry(level, levEntry, validateTables); err != nil {
+		if err := m.validateLevelEntry(level, levEntry, validateTables); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (lm *Manager) validateLevelEntry(level int, levEntry *levelEntry, validateTables bool) error {
+func (m *Manager) validateLevelEntry(level int, levEntry *levelEntry, validateTables bool) error {
 	var smallestKey, largestKey []byte
 	var prevRangeEnd []byte
 	for _, lte := range levEntry.tableEntries {
@@ -41,7 +41,7 @@ func (lm *Manager) validateLevelEntry(level int, levEntry *levelEntry, validateT
 			prevRangeEnd = te.RangeEnd
 		}
 		if validateTables {
-			if err := lm.validateTable(te); err != nil {
+			if err := m.validateTable(te); err != nil {
 				return err
 			}
 		}
@@ -55,8 +55,8 @@ func (lm *Manager) validateLevelEntry(level int, levEntry *levelEntry, validateT
 	return nil
 }
 
-func (lm *Manager) validateTable(te *TableEntry) error {
-	buff, err := objstore.GetWithTimeout(lm.objStore, lm.conf.BucketName, string(te.SSTableID), objstore.DefaultCallTimeout)
+func (m *Manager) validateTable(te *TableEntry) error {
+	buff, err := objstore.GetWithTimeout(m.objStore, m.opts.SSTableBucketName, string(te.SSTableID), objstore.DefaultCallTimeout)
 	if err != nil {
 		return err
 	}

--- a/shard/client.go
+++ b/shard/client.go
@@ -1,0 +1,103 @@
+package shard
+
+import (
+	"encoding/binary"
+	"github.com/pkg/errors"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/transport"
+)
+
+type Client interface {
+	ApplyLsmChanges(regBatch lsm.RegistrationBatch) error
+
+	QueryTablesInRange(keyStart []byte, keyEnd []byte) (lsm.OverlappingTables, error)
+
+	Close() error
+}
+
+// client - note this is not goroutine safe!
+// on error, the caller must close the connection
+type client struct {
+	m           *Manager
+	shardID     int
+	clusterVersion int
+	address     string
+	conn        transport.Connection
+	connFactory transport.ConnectionFactory
+	closed      bool
+}
+
+var _ Client = &client{}
+
+func (c *client) getConnection() (transport.Connection, error) {
+	if c.closed {
+		return nil, errors.New("client has been closed")
+	}
+	if c.conn != nil {
+		return c.conn, nil
+	}
+	if c.address == "" {
+		address, ok := c.m.AddressForShard(c.shardID)
+		if !ok {
+			// No address for this shard - this can happen if no members in cluster
+			return nil, common.NewTektiteErrorf(common.Unavailable, "no address for shard %d", c.shardID)
+		}
+		c.address = address
+	}
+	conn, err := c.connFactory(c.address)
+	if err != nil {
+		return nil, err
+	}
+	c.conn = conn
+	return conn, nil
+}
+
+func (c *client) Close() error {
+	c.address = ""
+	c.closed = true
+	if c.conn != nil {
+		return c.conn.Close()
+	}
+	return nil
+}
+
+func (c *client) ApplyLsmChanges(regBatch lsm.RegistrationBatch) error {
+	conn, err := c.getConnection()
+	if err != nil {
+		return err
+	}
+	req := ApplyChangesRequest{
+		ShardID:  c.shardID,
+		ClusterVersion: c.clusterVersion,
+		RegBatch: regBatch,
+	}
+	request := req.Serialize(createRequestBuffer())
+	_, err = conn.SendRPC(transport.HandlerIDShardApplyChanges, request)
+	return err
+}
+
+func (c *client) QueryTablesInRange(keyStart []byte, keyEnd []byte) (lsm.OverlappingTables, error) {
+	conn, err := c.getConnection()
+	if err != nil {
+		return nil, err
+	}
+	req := QueryTablesInRangeRequest{
+		ShardID:  c.shardID,
+		ClusterVersion: c.clusterVersion,
+		KeyStart: keyStart,
+		KeyEnd:   keyEnd,
+	}
+	request := req.Serialize(createRequestBuffer())
+	respBuff, err := conn.SendRPC(transport.HandlerIDShardQueryTablesInRange, request)
+	if err != nil {
+		return nil, err
+	}
+	return lsm.DeserializeOverlappingTables(respBuff, 0), nil
+}
+
+func createRequestBuffer() []byte {
+	buff := make([]byte, 0, 128)                  // Initial size guess
+	buff = binary.BigEndian.AppendUint16(buff, 1) // rpc version - currently 1
+	return buff
+}

--- a/shard/manager.go
+++ b/shard/manager.go
@@ -1,0 +1,249 @@
+package shard
+
+import (
+	"encoding/binary"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spirit-labs/tektite/cluster"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/transport"
+	"sync"
+)
+
+/*
+Manager manages instances of LSM shards on an agent. It responds to changes in the membership of the cluster and as
+members are added or removed it calculates whether it needs to start or stop shard instances on this node.
+*/
+type Manager struct {
+	lock                   sync.RWMutex
+	started                bool
+	numShards              int
+	stateUpdatorBucketName string
+	stateUpdatorKeyPrefix  string
+	dataBucketName         string
+	dataKeyPrefix          string
+	objStoreClient         objstore.Client
+	connectionFactory      transport.ConnectionFactory
+	transportServer        transport.Server
+	lsmOpts                lsm.ManagerOpts
+	shards                 map[int]*LsmShard
+	currentMembership      cluster.MembershipState
+}
+
+func NewManager(numShards int, stateUpdatorBucketName string, stateUpdatorKeyPrefix string, dataBucketName string,
+	dataKeyPrefix string, objStoreClient objstore.Client, connectionFactory transport.ConnectionFactory,
+	transportServer transport.Server, lsmOpts lsm.ManagerOpts) *Manager {
+	return &Manager{
+		numShards:              numShards,
+		stateUpdatorBucketName: stateUpdatorBucketName,
+		stateUpdatorKeyPrefix:  stateUpdatorKeyPrefix,
+		dataBucketName:         dataBucketName,
+		dataKeyPrefix:          dataKeyPrefix,
+		objStoreClient:         objStoreClient,
+		connectionFactory:      connectionFactory,
+		transportServer:        transportServer,
+		lsmOpts:                lsmOpts,
+		shards:                 map[int]*LsmShard{},
+	}
+}
+
+func (sm *Manager) Start() error {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+	if sm.started {
+		return nil
+	}
+	// Register the handlers
+	sm.transportServer.RegisterHandler(transport.HandlerIDShardApplyChanges, sm.handleApplyChanges)
+	sm.transportServer.RegisterHandler(transport.HandlerIDShardQueryTablesInRange, sm.handleQueryTablesInRange)
+	sm.started = true
+	return nil
+}
+
+func (sm *Manager) Stop() error {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+	if !sm.started {
+		return nil
+	}
+	for _, shard := range sm.shards {
+		if err := shard.Stop(); err != nil {
+			return err
+		}
+	}
+	sm.shards = map[int]*LsmShard{}
+	sm.currentMembership = cluster.MembershipState{}
+	sm.started = false
+	return nil
+}
+
+// MembershipChanged is called when membership of the cluster changes. The manager will now create or stop LSM shards
+// as appropriate
+func (sm *Manager) MembershipChanged(newState cluster.MembershipState) error {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+	if !sm.started {
+		return errors.New("manager not started")
+	}
+	sm.currentMembership = newState
+	address := sm.transportServer.Address()
+	newShards := make(map[int]*LsmShard, len(sm.shards))
+	for shardID := 0; shardID < sm.numShards; shardID++ {
+		shardAddress, ok := sm.addressForShard(shardID)
+		if ok && (shardAddress == address) {
+			// The controller lives on this node
+			shard, ok := sm.shards[shardID]
+			if ok {
+				// If we already have it, then keep it
+				newShards[shardID] = shard
+			} else {
+				// Create and start a controller
+				// Note, each shard needs a unique prefix for updator and data keys
+				updatorPrefix := fmt.Sprintf("%s-%06d", sm.stateUpdatorKeyPrefix, shardID)
+				dataKeyPrefix := fmt.Sprintf("%s-%06d", sm.dataKeyPrefix, shardID)
+				shard = NewLsmShard(sm.stateUpdatorBucketName, updatorPrefix, sm.dataBucketName,
+					dataKeyPrefix, sm.objStoreClient, sm.lsmOpts)
+				if err := shard.Start(); err != nil {
+					return err
+				}
+				newShards[shardID] = shard
+			}
+		} else {
+			shard, ok := sm.shards[shardID]
+			if ok {
+				// The shard was on this node but has moved, so we need to close the one here
+				if err := shard.Stop(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	sm.shards = newShards
+	return nil
+}
+
+func (sm *Manager) AddressForShard(shardID int) (string, bool) {
+	sm.lock.RLock()
+	defer sm.lock.RUnlock()
+	return sm.addressForShard(shardID)
+}
+
+func (sm *Manager) Client(shardID int) (Client, error) {
+	if sm.currentMembership.ClusterVersion == 0 {
+		return nil, common.NewTektiteErrorf(common.Unavailable, "manager has not received cluster membership")
+	}
+	return &client{
+		m:              sm,
+		shardID:        shardID,
+		clusterVersion: sm.currentMembership.ClusterVersion,
+		connFactory:    sm.connectionFactory,
+	}, nil
+}
+
+func (sm *Manager) GetShard(shardID int) (*LsmShard, bool) {
+	sm.lock.RLock()
+	defer sm.lock.RUnlock()
+	return sm.getShard(shardID)
+}
+
+func (sm *Manager) getShard(shardID int) (*LsmShard, bool) {
+	controller, ok := sm.shards[shardID]
+	return controller, ok
+}
+
+func (sm *Manager) addressForShard(shardID int) (string, bool) {
+	lms := len(sm.currentMembership.Members)
+	if lms == 0 {
+		return "", false
+	}
+	index := shardID % len(sm.currentMembership.Members)
+	return sm.currentMembership.Members[index].Address, true
+}
+
+func (sm *Manager) handleApplyChanges(request []byte, responseBuff []byte, responseWriter transport.ResponseWriter) error {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+	if err := checkRPCVersion(request); err != nil {
+		return responseWriter(nil, err)
+	}
+	var req ApplyChangesRequest
+	req.Deserialize(request, 2)
+	if err := sm.checkClusterVersion(req.ClusterVersion); err != nil {
+		return responseWriter(nil, err)
+	}
+	shard, err := sm.getShardWithError(req.ShardID)
+	if err != nil {
+		return responseWriter(nil, err)
+	}
+	return shard.ApplyLsmChanges(req.RegBatch, func(err error) error {
+		if err != nil {
+			return responseWriter(nil, err)
+		}
+		// Send back zero byte to represent nil OK response
+		responseBuff = append(responseBuff, 0)
+		return responseWriter(responseBuff, nil)
+	})
+}
+
+func (sm *Manager) handleQueryTablesInRange(request []byte, responseBuff []byte, responseWriter transport.ResponseWriter) error {
+	sm.lock.RLock()
+	defer sm.lock.RUnlock()
+	if err := checkRPCVersion(request); err != nil {
+		return responseWriter(nil, err)
+	}
+	var req QueryTablesInRangeRequest
+	req.Deserialize(request, 2)
+	if err := sm.checkClusterVersion(req.ClusterVersion); err != nil {
+		return responseWriter(nil, err)
+	}
+	shard, err := sm.getShardWithError(req.ShardID)
+	if err != nil {
+		return responseWriter(nil, err)
+	}
+	res, err := shard.QueryTablesInRange(req.KeyStart, req.KeyEnd)
+	if err != nil {
+		return responseWriter(nil, err)
+	}
+	responseBuff = res.Serialize(responseBuff)
+	return responseWriter(responseBuff, nil)
+}
+
+func (sm *Manager) getShardWithError(shardID int) (*LsmShard, error) {
+	shard, ok := sm.getShard(shardID)
+	if !ok {
+		// Shard not found - most likely membership changed. We send back an error and the client will retry
+		return nil, common.NewTektiteErrorf(common.Unavailable, "shard %d not found", shardID)
+	}
+	return shard, nil
+}
+
+func checkRPCVersion(request []byte) error {
+	rpcVersion := binary.BigEndian.Uint16(request)
+	if rpcVersion != 1 {
+		// Currently just 1
+		return errors.New("invalid rpc version")
+	}
+	return nil
+}
+
+func (sm *Manager) checkClusterVersion(clusterVersion int) error {
+	if clusterVersion != sm.currentMembership.ClusterVersion {
+		// This will occur when a cluster change occurs and a client created from an older cluster version tries
+		// to perform an operation. We return an unavailable error which will cause the caller to close the connection
+		// and create a new one, with the correct version
+		return common.NewTektiteErrorf(common.Unavailable, "shard manager - cluster version mismatch")
+	}
+	return nil
+}
+
+func (sm *Manager) getShards() map[int]*LsmShard {
+	sm.lock.RLock()
+	defer sm.lock.RUnlock()
+	shards := make(map[int]*LsmShard, len(sm.shards))
+	for shardID, shard := range sm.shards {
+		shards[shardID] = shard
+	}
+	return shards
+}

--- a/shard/manager_test.go
+++ b/shard/manager_test.go
@@ -1,0 +1,255 @@
+package shard
+
+import (
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/cluster"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/objstore/dev"
+	"github.com/spirit-labs/tektite/transport"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestManagerAddRemoveShard(t *testing.T) {
+	numShards := 10
+	numMembers := 3
+	managers, tearDown := setupManagers(t, numMembers, numShards)
+	defer tearDown(t)
+
+	newMembers := updateMembership(t, 1, managers, 0, 1, 2)
+	checkMapping(t, managers, numShards, newMembers)
+
+	// Now remove a member
+	newMembers = updateMembership(t, 2, managers, 1, 2)
+	checkMapping(t, managers, numShards, newMembers)
+
+	// Now reduce to zero
+	newMembers = updateMembership(t, 3, managers)
+	checkMapping(t, managers, numShards, newMembers)
+}
+
+// TestManagerShardRandomAddRemove - exercises the shard mapping logic by creating random combinations of members
+// and verify the mapping of shard to manager is correct
+func TestManagerShardRandomAddRemove(t *testing.T) {
+	numShards := 10
+	numMembers := 5
+	managers, tearDown := setupManagers(t, numMembers, numShards)
+	defer tearDown(t)
+	for i := 0; i < 100; i++ {
+
+		var memberIndexes []int
+		for j := 0; j < numMembers; j++ {
+			// toss a coin to see if member is added
+			if rand.Intn(2) == 0 {
+				memberIndexes = append(memberIndexes, j)
+			}
+		}
+		// shuffle them
+		rand.Shuffle(len(memberIndexes), func(i, j int) { memberIndexes[i], memberIndexes[j] = memberIndexes[j], memberIndexes[i] })
+		newMembers := updateMembership(t, i, managers, memberIndexes...)
+		checkMapping(t, managers, numShards, newMembers)
+	}
+}
+
+func updateMembership(t *testing.T, clusterVersion int, managers []*Manager, memberIndexes ...int) []cluster.MembershipEntry {
+	now := time.Now().UnixMilli()
+	var members []cluster.MembershipEntry
+	for _, memberIndex := range memberIndexes {
+		members = append(members, cluster.MembershipEntry{
+			Address:    managers[memberIndex].transportServer.Address(),
+			UpdateTime: now,
+		})
+	}
+	newState := cluster.MembershipState{
+		ClusterVersion: clusterVersion,
+		Members:        members,
+	}
+	for _, mgr := range managers {
+		err := mgr.MembershipChanged(newState)
+		require.NoError(t, err)
+	}
+	return members
+}
+
+func checkMapping(t *testing.T, managers []*Manager, numShards int, members []cluster.MembershipEntry) {
+	mapping := expectedShardMemberMapping(numShards, members)
+	for shardID, address := range mapping {
+		for _, mgr := range managers {
+			if address == mgr.transportServer.Address() {
+				// shard must be on this member
+				s, ok := mgr.GetShard(shardID)
+				require.True(t, ok)
+				require.NotNil(t, s)
+			} else {
+				// must not be here
+				s, ok := mgr.GetShard(shardID)
+				require.False(t, ok)
+				require.Nil(t, s)
+			}
+		}
+	}
+}
+
+func expectedShardMemberMapping(numShards int, members []cluster.MembershipEntry) map[int]string {
+	mapping := map[int]string{}
+	if len(members) > 0 {
+		for shard := 0; shard < numShards; shard++ {
+			i := shard % len(members)
+			mapping[shard] = members[i].Address
+		}
+	}
+	return mapping
+}
+
+func TestClientNoMembersOnCreation(t *testing.T) {
+	numShards := 10
+	numMembers := 3
+	managers, tearDown := setupManagers(t, numMembers, numShards)
+	defer tearDown(t)
+
+	// There are no members in the cluster at this point
+
+	_, err := managers[0].Client(7)
+	require.Error(t, err)
+	// caller should get an unavailable error so it can retry
+	require.True(t, common.IsTektiteErrorWithCode(err, common.Unavailable))
+	require.Equal(t, "manager has not received cluster membership", err.Error())
+}
+
+func TestClientWrongClusterVersion(t *testing.T) {
+	numShards := 10
+	numMembers := 3
+	managers, tearDown := setupManagers(t, numMembers, numShards)
+	defer tearDown(t)
+	updateMembership(t, 1, managers, 0, 1, 2)
+
+	keyStart := []byte("key000001")
+	keyEnd := []byte("key000010")
+	tableID := []byte(uuid.New().String())
+	batch := createBatch(1, tableID, keyStart, keyEnd)
+
+	cl, err := managers[0].Client(7)
+	require.NoError(t, err)
+
+	// Now update membership again so cluster version increases
+	updateMembership(t, 2, managers, 0, 1)
+
+	err = cl.ApplyLsmChanges(batch)
+	require.Error(t, err)
+	require.True(t, common.IsTektiteErrorWithCode(err, common.Unavailable))
+	require.Equal(t, "shard manager - cluster version mismatch", err.Error())
+
+	_, err = cl.QueryTablesInRange(nil, nil)
+	require.Error(t, err)
+	require.True(t, common.IsTektiteErrorWithCode(err, common.Unavailable))
+	require.Equal(t, "shard manager - cluster version mismatch", err.Error())
+}
+
+func TestManagerUseClosedClient(t *testing.T) {
+	numShards := 10
+	numMembers := 3
+	managers, tearDown := setupManagers(t, numMembers, numShards)
+	defer tearDown(t)
+
+	updateMembership(t, 1, managers, 0, 1, 2)
+
+	cl, err := managers[0].Client(7)
+	require.NoError(t, err)
+	// close client before using it
+	err = cl.Close()
+	require.NoError(t, err)
+
+	keyStart := []byte("key000001")
+	keyEnd := []byte("key000010")
+	tableID := []byte(uuid.New().String())
+	batch := createBatch(1, tableID, keyStart, keyEnd)
+
+	err = cl.ApplyLsmChanges(batch)
+	require.Error(t, err)
+	// Should not be an unavailable error - caller should not be re-using closed connection so would be a programming error
+	require.False(t, common.IsUnavailableError(err))
+
+	// create new client
+	cl, err = managers[0].Client(7)
+	require.NoError(t, err)
+	// use it
+	err = cl.ApplyLsmChanges(batch)
+	require.NoError(t, err)
+
+	// close it
+	err = cl.Close()
+	require.NoError(t, err)
+
+	// try and use it again
+	err = cl.ApplyLsmChanges(batch)
+	require.Error(t, err)
+	require.False(t, common.IsUnavailableError(err))
+}
+
+func TestManagerApplyChanges(t *testing.T) {
+	numShards := 10
+	numMembers := 3
+	managers, tearDown := setupManagers(t, numMembers, numShards)
+	defer tearDown(t)
+
+	updateMembership(t, 1, managers, 0, 1, 2)
+
+	cl, err := managers[0].Client(7)
+	require.NoError(t, err)
+	defer func() {
+		err := cl.Close()
+		require.NoError(t, err)
+	}()
+
+	keyStart := []byte("key000001")
+	keyEnd := []byte("key000010")
+	tableID := []byte(uuid.New().String())
+	batch := createBatch(1, tableID, keyStart, keyEnd)
+
+	err = cl.ApplyLsmChanges(batch)
+	require.NoError(t, err)
+
+	res, err := cl.QueryTablesInRange(keyStart, keyEnd)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(res[0]))
+	resTableID := res[0][0].ID
+	require.Equal(t, tableID, []byte(resTableID))
+
+	// And with nil keyStart and end
+	res, err = cl.QueryTablesInRange(nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(res[0]))
+	resTableID = res[0][0].ID
+	require.Equal(t, tableID, []byte(resTableID))
+}
+
+func setupManagers(t *testing.T, numMembers int, numShards int) ([]*Manager, func(t *testing.T)) {
+	localTransports := transport.NewLocalTransports()
+	var addresses []string
+	var managers []*Manager
+	for i := 0; i < numMembers; i++ {
+		address := uuid.New().String()
+		addresses = append(addresses, address)
+		transportServer, err := localTransports.NewLocalServer(address)
+		require.NoError(t, err)
+		objStore := dev.NewInMemStore(0)
+		mgr := NewManager(numShards, stateUpdatorBucketName, stateUpdatorKeyprefix, dataBucketName, dataKeyprefix,
+			objStore, localTransports.CreateConnection, transportServer, lsm.ManagerOpts{})
+		err = mgr.Start()
+		require.NoError(t, err)
+		managers = append(managers, mgr)
+	}
+	return managers, func(t *testing.T) {
+		for _, manager := range managers {
+			err := manager.Stop()
+			require.NoError(t, err)
+		}
+	}
+}

--- a/shard/rpcs.go
+++ b/shard/rpcs.go
@@ -1,0 +1,64 @@
+package shard
+
+import (
+	"encoding/binary"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/lsm"
+)
+
+type ApplyChangesRequest struct {
+	ShardID  int
+	ClusterVersion int
+	RegBatch lsm.RegistrationBatch
+}
+
+func (a *ApplyChangesRequest) Serialize(buff []byte) []byte {
+	buff = binary.BigEndian.AppendUint64(buff, uint64(a.ShardID))
+	buff = binary.BigEndian.AppendUint64(buff, uint64(a.ClusterVersion))
+	return a.RegBatch.Serialize(buff)
+}
+
+func (a *ApplyChangesRequest) Deserialize(buff []byte, offset int) int {
+	a.ShardID = int(binary.BigEndian.Uint64(buff[offset:]))
+	offset += 8
+	a.ClusterVersion = int(binary.BigEndian.Uint64(buff[offset:]))
+	offset += 8
+	return a.RegBatch.Deserialize(buff, offset)
+}
+
+type QueryTablesInRangeRequest struct {
+	ShardID  int
+	ClusterVersion int
+	KeyStart []byte
+	KeyEnd   []byte
+}
+
+func (a *QueryTablesInRangeRequest) Serialize(buff []byte) []byte {
+	buff = binary.BigEndian.AppendUint64(buff, uint64(a.ShardID))
+	buff = binary.BigEndian.AppendUint64(buff, uint64(a.ClusterVersion))
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(a.KeyStart)))
+	buff = append(buff, a.KeyStart...)
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(a.KeyEnd)))
+	buff = append(buff, a.KeyEnd...)
+	return buff
+}
+
+func (a *QueryTablesInRangeRequest) Deserialize(buff []byte, offset int) int {
+	a.ShardID = int(binary.BigEndian.Uint64(buff[offset:]))
+	offset += 8
+	a.ClusterVersion = int(binary.BigEndian.Uint64(buff[offset:]))
+	offset += 8
+	lks := int(binary.BigEndian.Uint32(buff[offset:]))
+	offset += 4
+	if lks > 0 {
+		a.KeyStart = common.ByteSliceCopy(buff[offset : offset+lks])
+		offset += lks
+	}
+	lke := int(binary.BigEndian.Uint32(buff[offset:]))
+	offset += 4
+	if lke > 0 {
+		a.KeyEnd = common.ByteSliceCopy(buff[offset : offset+lke])
+		offset += lke
+	}
+	return offset
+}

--- a/shard/rpcs_test.go
+++ b/shard/rpcs_test.go
@@ -1,0 +1,90 @@
+package shard
+
+import (
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSerializeDeserializeApplyChangesRequest(t *testing.T) {
+	req := ApplyChangesRequest{
+		ShardID: 12345,
+		ClusterVersion: 4555,
+		RegBatch: lsm.RegistrationBatch{
+			Compaction: true,
+			JobID:      "job-12345",
+			Registrations: []lsm.RegistrationEntry{{
+				Level:      23,
+				TableID:    sst.SSTableID("sometableid1"),
+				MaxVersion: 100001,
+				KeyStart:   []byte("keystart1"),
+				KeyEnd:     []byte("keyend1"),
+			}, {
+				Level:      12,
+				TableID:    sst.SSTableID("sometableid2"),
+				MaxVersion: 200002,
+				KeyStart:   []byte("keystart2"),
+				KeyEnd:     []byte("keyend2"),
+			}},
+			DeRegistrations: []lsm.RegistrationEntry{{
+				Level:    23,
+				TableID:  sst.SSTableID("sometableid11"),
+				KeyStart: []byte("keystart3"),
+				KeyEnd:   []byte("keyend3"),
+			}, {
+				Level:    27,
+				TableID:  sst.SSTableID("sometableid12"),
+				KeyStart: []byte("keystart4"),
+				KeyEnd:   []byte("keyend4"),
+			}},
+		},
+	}
+	var buff []byte
+	buff = append(buff, 1, 2, 3)
+	buff = req.Serialize(buff)
+	var req2 ApplyChangesRequest
+	off := req2.Deserialize(buff, 3)
+	require.Equal(t, req, req2)
+	require.Equal(t, off, len(buff))
+}
+
+func TestSerializeDeserializeQueryTablesInRangeRequest(t *testing.T) {
+	req := QueryTablesInRangeRequest{
+		ShardID:  123345,
+		ClusterVersion: 567456,
+		KeyStart: []byte("keystart1"),
+		KeyEnd:   []byte("keyend1"),
+	}
+	testSerializeDeserializeQueryTablesInRangeRequest(t, req)
+
+	// And with nil ranges
+	req = QueryTablesInRangeRequest{
+		ShardID:  123345,
+		ClusterVersion: 456456,
+		KeyStart: nil,
+		KeyEnd:   []byte("keyend1"),
+	}
+	testSerializeDeserializeQueryTablesInRangeRequest(t, req)
+
+	req = QueryTablesInRangeRequest{
+		ShardID:  123345,
+		ClusterVersion: 23424,
+		KeyStart: nil,
+		KeyEnd:   nil,
+	}
+	testSerializeDeserializeQueryTablesInRangeRequest(t, req)
+}
+
+func testSerializeDeserializeQueryTablesInRangeRequest(t *testing.T, req QueryTablesInRangeRequest) {
+
+	var buff []byte
+	buff = append(buff, 1, 2, 3)
+	buff = req.Serialize(buff)
+	var req2 QueryTablesInRangeRequest
+	off := req2.Deserialize(buff, 3)
+	require.Equal(t, req, req2)
+	require.Equal(t, off, len(buff))
+
+	// And with null ranges
+}

--- a/shard/shard.go
+++ b/shard/shard.go
@@ -1,0 +1,208 @@
+package shard
+
+import (
+	"github.com/spirit-labs/tektite/cluster"
+	"github.com/spirit-labs/tektite/common"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/objstore"
+
+	"sync"
+	"sync/atomic"
+)
+
+type LsmShard struct {
+	lock                   sync.RWMutex
+	objStore               objstore.Client
+	lsmOpts                lsm.ManagerOpts
+	clusteredData          *cluster.ClusteredData
+	lsmManager             *lsm.Manager
+	started                bool
+	hasQueuedRegistrations atomic.Bool
+	queuedRegistrations    []queuedRegistration
+}
+
+type queuedRegistration struct {
+	regBatch       lsm.RegistrationBatch
+	completionFunc func(error) error
+}
+
+func NewLsmShard(stateMachineBucketName string, stateMachineKeyPrefix string, dataBucketName string,
+	dataKeyPrefix string, objStoreClient objstore.Client, lsmOpts lsm.ManagerOpts) *LsmShard {
+	clusteredData := cluster.NewClusteredData(stateMachineBucketName, stateMachineKeyPrefix, dataBucketName, dataKeyPrefix,
+		objStoreClient, cluster.ClusteredDataOpts{})
+	return &LsmShard{
+		objStore:      objStoreClient,
+		lsmOpts:       lsmOpts,
+		clusteredData: clusteredData,
+	}
+}
+
+func (s *LsmShard) Start() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.started {
+		return nil
+	}
+	metaData, err := s.clusteredData.AcquireData()
+	if err != nil {
+		return err
+	}
+	lsmManager := lsm.NewManager(s.objStore, s.maybeRetryApplies, true, false, s.lsmOpts)
+	if err := lsmManager.Start(metaData); err != nil {
+		return err
+	}
+	s.lsmManager = lsmManager
+	s.started = true
+	return nil
+}
+
+func (s *LsmShard) Stop() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if !s.started {
+		return nil
+	}
+	return s.stop()
+}
+
+func (s *LsmShard) stop() error {
+	if err := s.lsmManager.Stop(); err != nil {
+		return err
+	}
+	s.clusteredData.Stop()
+	return nil
+}
+
+// ApplyLsmChanges - apply some changes to the LSM structure. Note that this method completes asynchronously as
+// L0 registrations will be queued if there is not enough free space
+func (s *LsmShard) ApplyLsmChanges(regBatch lsm.RegistrationBatch, completionFunc func(error) error) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if err := s.checkStarted(); err != nil {
+		return completionFunc(err)
+	}
+	ok, err := s.lsmManager.ApplyChanges(regBatch, false)
+	if err != nil {
+		return completionFunc(err)
+	}
+	if ok {
+		return s.afterApplyChanges(completionFunc)
+	}
+	// L0 is full - queue the registration - it will be retried when there is space in L0
+	s.hasQueuedRegistrations.Store(true)
+	s.queuedRegistrations = append(s.queuedRegistrations, queuedRegistration{
+		regBatch:       regBatch,
+		completionFunc: completionFunc,
+	})
+	return nil
+}
+
+func (s *LsmShard) afterApplyChanges(completionFunc func(error) error) error {
+	// Attempt to store the LSM state
+	ok, err := s.clusteredData.StoreData(s.lsmManager.GetMasterRecordBytes())
+	if err != nil {
+		return completionFunc(err)
+	}
+	if !ok {
+		// Failed to apply changes as epoch has changed
+		// Now we need to stop the controller as it's no longer valid
+		if err := s.stop(); err != nil {
+			log.Warnf("failed to stop controller: %v", err)
+		}
+		return completionFunc(common.NewTektiteErrorf(common.Unavailable, "shard failed to write as epoch changed"))
+	} else {
+		return completionFunc(nil)
+	}
+}
+
+func (s *LsmShard) maybeRetryApplies() {
+	// check atomic outside lock to reduce contention
+	if !s.hasQueuedRegistrations.Load() {
+		return
+	}
+	if err := s.maybeRetryApplies0(); err != nil {
+		log.Errorf("failed to retry applies: %v", err)
+	}
+}
+
+func (s *LsmShard) maybeRetryApplies0() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	pos := 0
+	var completionFuncs []func(error) error
+	for _, queuedReg := range s.queuedRegistrations {
+		ok, err := s.lsmManager.ApplyChanges(queuedReg.regBatch, false)
+		if err != nil {
+			return queuedReg.completionFunc(err)
+		}
+		if ok {
+			if queuedReg.completionFunc == nil {
+				log.Infof("foo")
+			}
+			completionFuncs = append(completionFuncs, queuedReg.completionFunc)
+			pos++
+		} else {
+			// full again
+			break
+		}
+	}
+	if pos > 0 {
+		// We applied one or more queued registrations, now store the state
+		ok, err := s.clusteredData.StoreData(s.lsmManager.GetMasterRecordBytes())
+		if !ok {
+			// Failed to store data as another controller has incremented the epoch - i.e. we are not leader any more
+			err = common.NewTektiteErrorf(common.Unavailable, "controller not leader")
+			// No longer leader so stop the controller
+			if err := s.stop(); err != nil {
+				log.Warnf("failed to stop controller: %v", err)
+			}
+		}
+		if err != nil {
+			// Send errors back to completions
+			for _, cf := range completionFuncs {
+				if err := cf(err); err != nil {
+					log.Errorf("failed to apply completion function: %v", err)
+				}
+			}
+			return err
+		}
+		// no errors - remove the elements we successfully applied
+		newQueueSize := len(s.queuedRegistrations) - pos
+		if newQueueSize > 0 {
+			newRegs := make([]queuedRegistration, len(s.queuedRegistrations)-pos)
+			copy(newRegs, s.queuedRegistrations[pos:])
+			s.queuedRegistrations = newRegs
+		} else {
+			s.queuedRegistrations = nil
+			s.hasQueuedRegistrations.Store(false)
+		}
+		// Call the completions
+		for _, cf := range completionFuncs {
+			log.Infof("calling cf %v", cf)
+			if cf == nil {
+				log.Infof("foo")
+			}
+			if err := cf(nil); err != nil {
+				log.Errorf("failed to apply completion function: %v", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *LsmShard) QueryTablesInRange(keyStart []byte, keyEnd []byte) (lsm.OverlappingTables, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if err := s.checkStarted(); err != nil {
+		return nil, err
+	}
+	return s.lsmManager.QueryTablesInRange(keyStart, keyEnd)
+}
+
+func (s *LsmShard) checkStarted() error {
+	if !s.started {
+		return common.NewTektiteErrorf(common.Unavailable, "shard is not started")
+	}
+	return nil
+}

--- a/shard/shard_test.go
+++ b/shard/shard_test.go
@@ -1,0 +1,233 @@
+package shard
+
+import (
+	"github.com/google/uuid"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/objstore/dev"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/spirit-labs/tektite/testutils"
+	"github.com/stretchr/testify/require"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const (
+	stateUpdatorBucketName = "state-updator-bucket"
+	stateUpdatorKeyprefix  = "state-updator-keyprefix"
+	dataBucketName         = "data-bucket"
+	dataKeyprefix          = "data-keyprefix"
+)
+
+func TestApplyChanges(t *testing.T) {
+	objStore := dev.NewInMemStore(0)
+	shard := NewLsmShard(stateUpdatorBucketName, stateUpdatorKeyprefix, dataBucketName, dataKeyprefix, objStore,
+		lsm.ManagerOpts{})
+	err := shard.Start()
+	require.NoError(t, err)
+
+	testApplyChanges(t, shard, []byte(uuid.New().String()))
+}
+
+func TestApplyChangesRestart(t *testing.T) {
+	objStore := dev.NewInMemStore(0)
+	shard := NewLsmShard(stateUpdatorBucketName, stateUpdatorKeyprefix, dataBucketName, dataKeyprefix, objStore,
+		lsm.ManagerOpts{})
+	err := shard.Start()
+	require.NoError(t, err)
+
+	tableID := []byte(uuid.New().String())
+	testApplyChanges(t, shard, tableID)
+
+	err = shard.Stop()
+	require.NoError(t, err)
+
+	// recreate shard
+	shard = NewLsmShard(stateUpdatorBucketName, stateUpdatorKeyprefix, dataBucketName, dataKeyprefix, objStore,
+		lsm.ManagerOpts{})
+	err = shard.Start()
+	require.NoError(t, err)
+
+	// Registration should still be there - as metadata was committed to object store after previous ApplyChanges
+	res, err := shard.QueryTablesInRange(nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(res[0]))
+	resTableID := res[0][0].ID
+	require.Equal(t, tableID, []byte(resTableID))
+}
+
+func testApplyChanges(t *testing.T, shard *LsmShard, tableID []byte) {
+	keyStart := []byte("key000001")
+	keyEnd := []byte("key000010")
+	batch := createBatch(1, tableID, keyStart, keyEnd)
+	ch := make(chan error, 1)
+	err := shard.ApplyLsmChanges(batch, func(err error) error {
+		ch <- err
+		return nil
+	})
+	require.NoError(t, err)
+	err = <-ch
+	require.NoError(t, err)
+
+	res, err := shard.QueryTablesInRange(keyStart, keyEnd)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(res[0]))
+	resTableID := res[0][0].ID
+	require.Equal(t, tableID, []byte(resTableID))
+}
+
+// TestApplyChangesL0Full tests the queueing behaviour of the shard when L0 is full
+func TestApplyChangesL0Full(t *testing.T) {
+	objStore := dev.NewInMemStore(0)
+	opts := lsm.ManagerOpts{
+		L0MaxTablesBeforeBlocking: 10,
+	}
+	shard := NewLsmShard(stateUpdatorBucketName, stateUpdatorKeyprefix, dataBucketName, dataKeyprefix, objStore,
+		opts)
+	err := shard.Start()
+	require.NoError(t, err)
+
+	keyStart := []byte("key000001")
+	keyEnd := []byte("key000010")
+
+	var tabIDs []sst.SSTableID
+
+	// We should be able to apply L0MaxTablesBeforeBlocking tables
+	for i := 0; i < opts.L0MaxTablesBeforeBlocking; i++ {
+		tableID := []byte(uuid.New().String())
+		tabIDs = append(tabIDs, tableID)
+		batch := createBatch(0, tableID, keyStart, keyEnd)
+		ch := make(chan error, 1)
+		err := shard.ApplyLsmChanges(batch, func(err error) error {
+			ch <- err
+			return nil
+		})
+		require.NoError(t, err)
+		err = <-ch
+		require.NoError(t, err)
+	}
+
+	// The next ones should queue (i.e. completion not called) until we free some space
+	numToQueue := 5
+	completionsCalled := make([]*atomic.Bool, numToQueue)
+	var chans []chan error
+	for i := 0; i < numToQueue; i++ {
+		cc := new(atomic.Bool)
+		completionsCalled[i] = cc
+		tableID := []byte(uuid.New().String())
+		batch := createBatch(0, tableID, keyStart, keyEnd)
+		ch := make(chan error, 1)
+		chans = append(chans, ch)
+		index := i
+		err = shard.ApplyLsmChanges(batch, func(err error) error {
+			log.Infof("calling completion %d", index)
+			cc.Store(true)
+			ch <- err
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	// They should be queued
+	time.Sleep(10 * time.Millisecond)
+	for _, cc := range completionsCalled {
+		require.False(t, cc.Load())
+	}
+
+	// Now free some space in L0 (two tables)
+	deregBatch := lsm.RegistrationBatch{DeRegistrations: []lsm.RegistrationEntry{
+		{
+			Level:    0,
+			TableID:  tabIDs[0],
+			KeyStart: keyStart,
+			KeyEnd:   keyEnd,
+		},
+		{
+			Level:    0,
+			TableID:  tabIDs[1],
+			KeyStart: keyStart,
+			KeyEnd:   keyEnd,
+		},
+	}}
+	ch := make(chan error, 1)
+	err = shard.ApplyLsmChanges(deregBatch, func(err error) error {
+		ch <- err
+		return nil
+	})
+	require.NoError(t, err)
+	err = <-ch
+	require.NoError(t, err)
+
+	// The first two queued completions should be called
+	testutils.WaitUntil(t, func() (bool, error) {
+		// Wait for 0, 1 to be called
+		return completionsCalled[0].Load() && completionsCalled[1].Load(), nil
+	})
+	// The others not
+	require.Equal(t, false, completionsCalled[2].Load())
+	require.Equal(t, false, completionsCalled[3].Load())
+	require.Equal(t, false, completionsCalled[4].Load())
+
+	// Now free the rest
+	deregBatch = lsm.RegistrationBatch{DeRegistrations: []lsm.RegistrationEntry{
+		{
+			Level:    0,
+			TableID:  tabIDs[2],
+			KeyStart: keyStart,
+			KeyEnd:   keyEnd,
+		},
+		{
+			Level:    0,
+			TableID:  tabIDs[3],
+			KeyStart: keyStart,
+			KeyEnd:   keyEnd,
+		},
+		{
+			Level:    0,
+			TableID:  tabIDs[4],
+			KeyStart: keyStart,
+			KeyEnd:   keyEnd,
+		},
+	}}
+	ch = make(chan error, 1)
+	err = shard.ApplyLsmChanges(deregBatch, func(err error) error {
+		ch <- err
+		return nil
+	})
+	require.NoError(t, err)
+	err = <-ch
+	require.NoError(t, err)
+
+	// All should now be called (async)
+	testutils.WaitUntil(t, func() (bool, error) {
+		// Wait for 2, 3, 4 to be called
+		return completionsCalled[2].Load() && completionsCalled[3].Load() && completionsCalled[4].Load(), nil
+	})
+
+	for _, ch := range chans {
+		err := <-ch
+		require.NoError(t, err)
+	}
+}
+
+func createBatch(level int, tableID []byte, keyStart []byte, keyEnd []byte) lsm.RegistrationBatch {
+	regEntry := lsm.RegistrationEntry{
+		Level:      level,
+		TableID:    tableID,
+		MinVersion: 123,
+		MaxVersion: 1235,
+		KeyStart:   keyStart,
+		KeyEnd:     keyEnd,
+		AddedTime:  uint64(time.Now().UnixMilli()),
+		NumEntries: 1234,
+		TableSize:  12345567,
+	}
+	return lsm.RegistrationBatch{
+		Registrations: []lsm.RegistrationEntry{regEntry},
+	}
+}

--- a/transport/handler_ids.go
+++ b/transport/handler_ids.go
@@ -1,0 +1,6 @@
+package transport
+
+const (
+	HandlerIDShardApplyChanges = iota + 10
+	HandlerIDShardQueryTablesInRange
+)


### PR DESCRIPTION
This PR introduces the shard manager and LSM shards.
An LsmShard represents a shard of the LSM. The manager responds to changes in cluster membership and starts and stops shards as appropriate on each agent.
For now, we just have operations: `ApplyChanges` and `QueryTablesInRange` - more will be added as needed.