### PR TITLE
MINOR: Add configurable logger per package

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -40,6 +40,10 @@ var globalLevel zapcore.Level
 var DebugEnabled = false
 var loggersByName = make(map[string]*TektiteLogger)
 
+func init() {
+	initialise(zapcore.InfoLevel, "console", false)
+}
+
 type Config struct {
 	Format string `help:"Format to write log lines in" enum:"console,json" default:"console"`
 	Level  string `help:"Lowest log level that will be emitted" enum:"debug,info,warn,error" default:"info"`

--- a/logger/log.go
+++ b/logger/log.go
@@ -1,6 +1,28 @@
+/*
+log.go provides a centralized logging system for the application.
+
+It offers a global logger as well as the ability to create named loggers
+for different parts of Tektite. The package wraps the zap logging
+library, providing a simplified interface while leveraging zap's performance.
+
+Usage:
+
+	// Using the global logger
+	import log "github.com/spirit-labs/tektite/logger"
+	log.Info("Application started")
+	log.Errorf("Failed to connect: %v", err)
+	=> "Failed  to connect: connection refused"
+
+	// Creating and using a named logger
+	log, _ := logger.GetLogger("clustered_data.go")
+	log.Debug("Something happened!")
+	=> "[clustered_data.go] Something happened!"
+*/
 package logger
 
 import (
+	"fmt"
+	"github.com/pkg/errors"
 	"github.com/spirit-labs/tektite/asl/errwrap"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -9,14 +31,14 @@ import (
 	"time"
 )
 
-var logger *zap.Logger
-var log *zap.SugaredLogger
+var globalLogger *zap.Logger
+var globalLog *zap.SugaredLogger
 var initLock sync.Mutex
 var initialised bool
-
-func init() {
-	initialise(zapcore.InfoLevel, "console", false)
-}
+var globalEncoding string
+var globalLevel zapcore.Level
+var DebugEnabled = false
+var loggersByName = make(map[string]*TektiteLogger)
 
 type Config struct {
 	Format string `help:"Format to write log lines in" enum:"console,json" default:"console"`
@@ -32,14 +54,8 @@ func (cfg *Config) Configure() error {
 	if format != "console" && format != "json" {
 		return errwrap.New("log-format must be one of 'console' or 'json'")
 	}
-	Initialise(level, format)
+	initialise(level, format, true)
 	return nil
-}
-
-var DebugEnabled = false
-
-func Initialise(level zapcore.Level, encoding string) {
-	initialise(level, encoding, true)
 }
 
 func initialise(level zapcore.Level, encoding string, override bool) {
@@ -48,11 +64,12 @@ func initialise(level zapcore.Level, encoding string, override bool) {
 	if initialised && !override {
 		return
 	}
-	logger = CreateLogger(level, encoding)
-	log = logger.Sugar()
-
+	globalLogger = CreateLogger(level, encoding)
+	globalLog = globalLogger.Sugar()
 	// Cache as simple bool to avoid atomics - we never change it after initialisation so this is ok
-	DebugEnabled = log.Desugar().Core().Enabled(zap.DebugLevel)
+	DebugEnabled = globalLog.Desugar().Core().Enabled(zap.DebugLevel)
+	globalEncoding = encoding
+	globalLevel = level
 
 	initialised = true
 }
@@ -73,16 +90,19 @@ func CreateLogger(level zapcore.Level, encoding string) *zap.Logger {
 		EncodeCaller:   zapcore.ShortCallerEncoder,
 	}
 	conf := zap.Config{
-		Level:            zap.NewAtomicLevelAt(level),
-		Development:      false,
-		Sampling:         nil,
-		Encoding:         encoding,
-		EncoderConfig:    encoderConf,
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stdout"},
+		Level:       zap.NewAtomicLevelAt(level),
+		Development: false,
+		Sampling: &zap.SamplingConfig{
+			Initial:    150,
+			Thereafter: 150,
+		},
+		Encoding:          encoding,
+		EncoderConfig:     encoderConf,
+		OutputPaths:       []string{"stdout"},
+		ErrorOutputPaths:  []string{"stdout"},
+		DisableCaller:     true,
+		DisableStacktrace: true,
 	}
-	conf.DisableCaller = true
-	conf.DisableStacktrace = true
 	l, _ := conf.Build()
 	return l
 }
@@ -92,44 +112,128 @@ func timeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 }
 
 func Info(args ...interface{}) {
-	log.Info(args)
+	globalLog.Info(args)
 }
 
 func Infof(format string, args ...interface{}) {
-	log.Infof(format, args...)
+	globalLog.Infof(format, args...)
 }
 
 func Debug(args ...interface{}) {
 	if !DebugEnabled {
 		return
 	}
-	log.Debug(args)
+	globalLog.Debug(args)
 }
 
 func Debugf(format string, args ...interface{}) {
-	log.Debugf(format, args...)
+	globalLog.Debugf(format, args...)
 }
 
 func Warn(args ...interface{}) {
-	log.Warn(args)
+	globalLog.Warn(args)
 }
 
 func Warnf(format string, args ...interface{}) {
-	log.Warnf(format, args...)
+	globalLog.Warnf(format, args...)
 }
 
 func Error(args ...interface{}) {
-	log.Error(args)
+	globalLog.Error(args)
 }
 
 func Errorf(format string, args ...interface{}) {
-	log.Errorf(format, args...)
+	globalLog.Errorf(format, args...)
 }
 
 func Fatal(args ...interface{}) {
-	log.Fatal(args)
+	globalLog.Fatal(args)
 }
 
 func Fatalf(format string, args ...interface{}) {
-	log.Fatalf(format, args...)
+	globalLog.Fatalf(format, args...)
+}
+
+// GetLogger gets a logger with the given name. The name is logged as a prefix for any message coming from this logger.
+func GetLogger(loggerName string) (*TektiteLogger, error) {
+	return GetLoggerWithLevel(loggerName, globalLevel)
+}
+
+func GetLoggerWithLevel(loggerName string, level zapcore.Level) (*TektiteLogger, error) {
+	initLock.Lock()
+	defer initLock.Unlock()
+	if !initialised {
+		return nil, errors.Errorf("cannot create a logger with name %s before the global logger is initialised", loggerName)
+	}
+
+	if value, exists := loggersByName[loggerName]; exists {
+		Warnf("tried to create a duplicate logger with name %s", loggerName)
+		return value, nil
+	}
+
+	logger := CreateLogger(level, globalEncoding)
+	tektiteLogger := NewTektiteLogger(logger, loggerName)
+	loggersByName[loggerName] = tektiteLogger
+	return tektiteLogger, nil
+}
+
+type TektiteLogger struct {
+	logger       *zap.Logger
+	log          *zap.SugaredLogger
+	debugEnabled bool
+	prefix       string
+}
+
+func NewTektiteLogger(logger *zap.Logger, loggerName string) *TektiteLogger {
+	log := logger.Sugar()
+
+	return &TektiteLogger{
+		logger:       logger,
+		log:          log,
+		debugEnabled: log.Desugar().Core().Enabled(zap.DebugLevel),
+		prefix:       fmt.Sprintf("[%s] ", loggerName),
+	}
+}
+
+func (t *TektiteLogger) Info(args ...interface{}) {
+	t.log.Info(append([]interface{}{t.prefix}, args...)...)
+}
+
+func (t *TektiteLogger) Infof(format string, args ...interface{}) {
+	t.log.Infof(t.prefix+format, args...)
+}
+
+func (t *TektiteLogger) Debug(args ...interface{}) {
+	if !DebugEnabled {
+		return
+	}
+	t.log.Debug(append([]interface{}{t.prefix}, args...)...)
+}
+
+func (t *TektiteLogger) Debugf(format string, args ...interface{}) {
+	t.log.Debugf(t.prefix+format, args...)
+}
+
+func (t *TektiteLogger) Warn(args ...interface{}) {
+	t.log.Warn(append([]interface{}{t.prefix}, args...)...)
+}
+
+func (t *TektiteLogger) Warnf(format string, args ...interface{}) {
+	t.log.Warnf(t.prefix+format, args...)
+}
+
+func (t *TektiteLogger) Error(args ...interface{}) {
+	t.log.Error(append([]interface{}{t.prefix}, args...)...)
+}
+
+func (t *TektiteLogger) Errorf(format string, args ...interface{}) {
+	t.log.Errorf(t.prefix+format, args...)
+}
+
+func (t *TektiteLogger) Fatal(args ...interface{}) {
+	t.log.Fatal(append([]interface{}{t.prefix}, args...)...)
+}
+
+func (t *TektiteLogger) Fatalf(format string, args ...interface{}) {
+	t.log.Fatalf(t.prefix+format, args...)
 }

--- a/logger/log.go
+++ b/logger/log.go
@@ -204,7 +204,7 @@ func (t *TektiteLogger) Infof(format string, args ...interface{}) {
 }
 
 func (t *TektiteLogger) Debug(args ...interface{}) {
-	if !DebugEnabled {
+	if !t.debugEnabled {
 		return
 	}
 	t.log.Debug(append([]interface{}{t.prefix}, args...)...)

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -1,0 +1,62 @@
+package logger
+
+import (
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"testing"
+)
+
+func TestTektiteLoggerEnabledLevels(t *testing.T) {
+	config := Config{
+		Level:  "warn",
+		Format: "console",
+	}
+	loggerName := "Test Tektite Logger"
+	err := config.Configure()
+	require.NoError(t, err)
+
+	testTektiteLogger, err := GetLogger(loggerName)
+	require.NoError(t, err)
+	testTektiteLogger.Infof("testing logging")
+	testTektiteLogger.Warnf("WARN testing logging %s", "args")
+	testTektiteLogger.Warn("msg 1", "msg 2")
+
+	// assert it uses the globally-configured log level by default
+	require.False(t, testTektiteLogger.logger.Core().Enabled(zap.DebugLevel), "Expected the logger to be disabled for Debug level because the default is Warn")
+	require.False(t, testTektiteLogger.logger.Core().Enabled(zap.InfoLevel), "Expected the logger to be disabled for Info level because the default is Warn")
+	require.True(t, testTektiteLogger.logger.Core().Enabled(zap.WarnLevel), "Expected the logger to be enabled for Warn level because the default is Warn")
+
+	// assert you can't override it with the same name
+	testSameTektiteLogger, err := GetLoggerWithLevel(loggerName, zap.DebugLevel)
+	// assert the log level hasn't changed
+	require.False(t, testSameTektiteLogger.logger.Core().Enabled(zap.DebugLevel), "Expected the logger to be disabled for Debug level because the default is Warn")
+	require.False(t, testSameTektiteLogger.logger.Core().Enabled(zap.InfoLevel), "Expected the logger to be disabled for Info level because the default is Warn")
+	require.True(t, testSameTektiteLogger.logger.Core().Enabled(zap.WarnLevel), "Expected the logger to be enabled for Warn level because the default is Warn")
+}
+
+func TestTektiteLogger(t *testing.T) {
+	config := Config{
+		Level:  "debug",
+		Format: "console",
+	}
+	loggerName := "Test-Tektite-Logger"
+	err := config.Configure()
+	require.NoError(t, err)
+
+	testTektiteLogger, err := GetLogger(loggerName)
+	require.NoError(t, err)
+
+	testTektiteLogger.Debug("debug 1", " debug 2")
+	testTektiteLogger.Debugf("debug %d debug %d", 1, 2)
+	testTektiteLogger.Info("info 1", " info 2")
+	testTektiteLogger.Infof("info %d info %d", 1, 2)
+	testTektiteLogger.Warn("warn 1", " warn 2")
+	testTektiteLogger.Warnf("warn %d warn %d", 1, 2)
+	testTektiteLogger.Error("error 1", " error 2")
+	testTektiteLogger.Errorf("error %d error %d", 1, 2)
+}
+
+func TestTektiteLoggerReturnsErrorIfGlobalLoggerUninitialized(t *testing.T) {
+	_, err := GetLogger("test logger")
+	require.Error(t, err, "should not be able to get a logger before the global one is initialized")
+}

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -62,8 +62,3 @@ func TestTektiteLogger(t *testing.T) {
 	testTektiteLogger.Error("error 1", " error 2")
 	testTektiteLogger.Errorf("error %d error %d", 1, 2)
 }
-
-func TestTektiteLoggerReturnsErrorIfGlobalLoggerUninitialized(t *testing.T) {
-	_, err := GetLogger("test logger")
-	require.Error(t, err, "should not be able to get a logger before the global one is initialized")
-}

--- a/logger/log_test.go
+++ b/logger/log_test.go
@@ -6,6 +6,13 @@ import (
 	"testing"
 )
 
+func TestGlobalLoggerWithoutExplicitlyInitializing(t *testing.T) {
+	Debugf("testing %s", "test")
+	Infof("testing %s", "test")
+	Warnf("testing %s", "test")
+	Errorf("testing %s", "test")
+}
+
 func TestTektiteLoggerEnabledLevels(t *testing.T) {
 	config := Config{
 		Level:  "warn",


### PR DESCRIPTION
This patch extends log.go to provide prefix-logging functionality, allowing each file/struct/component to define their own logger that'll get prepended to every log message:
```
	log, _ := logger.GetLogger("clustered_data.go")
	log.Debug("Something happened!")
	=> "[clustered_data.go] Something happened!"
```

I hacked around with zap's own benchmark suite and ran the suite 3 times comparing against the usual Zap Sugar logger and this Tektite wrapper. Long-story short:

- for simple messages (like `"Test logging, but use a somewhat realistic message length. (10))`, it's 2x slower - 58 ns/op to 114 ns/op. This is still better than libraries like `apex/log` that do 639 ns/op, `go-kit/kit/log` which does 142 ns/op, `logrus` which does 1129 ns/op and `slog` which does 140 ns/op

- for large messages, like `logger.Infof("%v %v %v %s %v %v %v %v %v %s\n", fakeFmtArgs()...)`, it's roughly the same - 1275 ns/op to 1338 ns/op

```
| Benchmark                               | ns/op      |
|-----------------------------------------|------------|
| Zap.Sugar                               | 58.57      |
| Zap.Sugar_with_TektiteLogger            | 114.00     |
| Zap.SugarFormatting                     | 1275.67    |
| Zap.SugarFormatting_with_TektiteLogger  | 1338.00    |
```

- The suite: https://github.com/uber-go/zap/blob/master/benchmarks/scenario_bench_test.go
- My fork: https://github.com/stanislavkozlovski/zap/commit/5075d2f8651cd1550ab82eda5e9fd162a8e64708

