### PR TITLE
Offsets cache

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -966,8 +966,6 @@ github.com/tidwall/rtred v0.1.2/go.mod h1:hd69WNXQ5RP9vHd7dqekAz+RIdtfBogmglkZSR
 github.com/tidwall/tinyqueue v0.1.1/go.mod h1:O/QNHwrnjqr6IHItYrzoHAKYhBkLI67Q096fQP5zMYw=
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375 h1:QB54BJwA6x8QU9nHY3xJSZR2kX9bgpZekRKGkLTmEXA=
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375/go.mod h1:xRroudyp5iVtxKqZCrA6n2TLFRBf8bmnjr1UD4x+z7g=
-github.com/timandy/routine v1.1.1 h1:6/Z7qLFZj3GrzuRksBFzIG8YGUh8CLhjnnMePBQTrEI=
-github.com/timandy/routine v1.1.1/go.mod h1:OZHPOKSvqL/ZvqXFkNZyit0xIVelERptYXdAHH00adQ=
 github.com/timandy/routine v1.1.4 h1:L9eAli/ROJcW6LhmwZcusYQcdAqxAXGOQhEXLQSNWOA=
 github.com/timandy/routine v1.1.4/go.mod h1:siBcl8iIsGmhLCajRGRcy7Y7FVcicNXkr97JODdt9fc=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=

--- a/objstore/api_test_util.go
+++ b/objstore/api_test_util.go
@@ -33,7 +33,6 @@ func TestApi(t *testing.T, client Client) {
 		}
 
 		t.Run(tc.testName, func(t *testing.T) {
-			log.Infof("running test: %s", tc.testName)
 			tc.test(t, client)
 		})
 	}
@@ -226,7 +225,6 @@ func testListAllObjects(t *testing.T, client Client) {
 			require.LessOrEqual(t, info.LastModified.UnixMilli(), afterMs)
 		}
 	}
-	log.Info("done testListAllObjects")
 }
 
 func testListSomeObjects(t *testing.T, client Client) {

--- a/shard/offsets.go
+++ b/shard/offsets.go
@@ -1,0 +1,126 @@
+package shard
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"sync"
+	"sync/atomic"
+)
+
+/*
+OffsetsCache caches next available offset for a topic partition in memory. Before an agent can write topic data to object storage
+it must first obtain partition offsets for the data it's writing. It does this by requesting the shard controller for a
+number of offsets for each partition that's being written.
+The actual last stored offset is stored by the agent in the same batch that the topic data resides in. When the
+OffsetCache loads it loads the actual last offset from there.
+*/
+type OffsetsCache struct {
+	lock                  sync.RWMutex
+	started               bool
+	shardID               int
+	topicOffsets          map[int][]int64
+	topicInfoProvider     topicInfoProvider
+	partitionOffsetLoader partitionOffsetLoader
+}
+
+func NewOffsetsCache(shardID int, provider topicInfoProvider, loader partitionOffsetLoader) *OffsetsCache {
+	return &OffsetsCache{
+		shardID:               shardID,
+		topicInfoProvider:     provider,
+		partitionOffsetLoader: loader,
+		topicOffsets:          make(map[int][]int64),
+	}
+}
+
+type GetOffsetInfo struct {
+	TopicID     int
+	PartitionID int
+	NumOffsets  int
+}
+
+type TopicInfo struct {
+	TopicID        int
+	PartitionCount int
+}
+
+type topicInfoProvider interface {
+	GetTopicsForShard(shardID int) ([]TopicInfo, error)
+}
+
+type partitionOffsetLoader interface {
+	LoadOffsetsForShard(shardID int) ([]StoredOffset, error)
+}
+
+type StoredOffset struct {
+	topicID     int
+	partitionID int
+	offset      int64
+}
+
+func (o *OffsetsCache) Start() error {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	if o.started {
+		return nil
+	}
+	topicInfos, err := o.topicInfoProvider.GetTopicsForShard(o.shardID)
+	if err != nil {
+		return err
+	}
+	for _, topicInfo := range topicInfos {
+		o.topicOffsets[topicInfo.TopicID] = make([]int64, topicInfo.PartitionCount)
+	}
+
+	offsets, err := o.partitionOffsetLoader.LoadOffsetsForShard(o.shardID)
+	if err != nil {
+		return err
+	}
+	for _, offset := range offsets {
+		offsets, ok := o.topicOffsets[offset.topicID]
+		if !ok {
+			return errors.Errorf("unknown topic id: %d", offset.topicID)
+		}
+		if offset.partitionID >= len(offsets) {
+			return errors.Errorf("partition offset out of range: %d", offset.partitionID)
+		}
+		offsets[offset.partitionID] = offset.offset + 1
+	}
+	o.started = true
+	return nil
+}
+
+// GetOffsets returns an offset for each of the provider GetOffsetInfo instances
+func (o *OffsetsCache) GetOffsets(infos []GetOffsetInfo) ([]int64, error) {
+	if len(infos) == 0 {
+		return nil, errors.New("empty infos")
+	}
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	if !o.started {
+		return nil, errors.New("not started")
+	}
+	res := make([]int64, len(infos))
+	for i, id := range infos {
+		off, err := o.getOffset(id)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = off
+	}
+	return res, nil
+}
+
+func (o *OffsetsCache) getOffset(info GetOffsetInfo) (int64, error) {
+	if info.NumOffsets < 1 {
+		// OK to panic as would be programming error
+		panic(fmt.Sprintf("invalid value for NumOffsets: %d", info.NumOffsets))
+	}
+	offsets, ok := o.topicOffsets[info.TopicID]
+	if !ok {
+		return 0, errors.Errorf("unknown topic id: %d", info.TopicID)
+	}
+	numOffsets := int64(info.NumOffsets)
+	// We increment the next offset count and return the previous offset
+	offset := atomic.AddInt64(&offsets[info.PartitionID], numOffsets) - numOffsets
+	return offset, nil
+}

--- a/shard/offsets_test.go
+++ b/shard/offsets_test.go
@@ -1,0 +1,295 @@
+package shard
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestOffsetsCacheNotStarted(t *testing.T) {
+	topicProvider := &testTopicInfoProvider{}
+	partitionLoader := &testPartitionOffsetLoader{}
+
+	oc := NewOffsetsCache(23, topicProvider, partitionLoader)
+	_, err := oc.GetOffsets([]GetOffsetInfo{{NumOffsets: 10}})
+	require.Error(t, err)
+	require.Equal(t, "not started", err.Error())
+}
+
+// Get an offset with a previous stored non zero value
+func TestOffsetsCacheGetSingleAlreadyStoredOffsetNonZero(t *testing.T) {
+	oc := setupAndStartCache(t)
+
+	offsets, err := oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 2,
+			NumOffsets:  100,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 1, int(offsets[0]))
+
+	offsets, err = oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 2,
+			NumOffsets:  33,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 1+100, int(offsets[0]))
+
+	offsets, err = oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 2,
+			NumOffsets:  33,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 1+100+33, int(offsets[0]))
+}
+
+// Get an offset with a previous stored zero value
+func TestOffsetsCacheGetSingleAlreadyStoredOffsetZero(t *testing.T) {
+	oc := setupAndStartCache(t)
+
+	offsets, err := oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 1,
+			NumOffsets:  100,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 3456+1, int(offsets[0]))
+
+	offsets, err = oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 1,
+			NumOffsets:  33,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 3456+1+100, int(offsets[0]))
+
+	offsets, err = oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 1,
+			NumOffsets:  33,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 3456+1+100+33, int(offsets[0]))
+}
+
+// Get an offset with a previous unstored value
+func TestOffsetsCacheGetSingleNotStored(t *testing.T) {
+	oc := setupAndStartCache(t)
+
+	offsets, err := oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 3,
+			NumOffsets:  100,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 0, int(offsets[0]))
+
+	offsets, err = oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 3,
+			NumOffsets:  33,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 100, int(offsets[0]))
+
+	offsets, err = oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 3,
+			NumOffsets:  33,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(offsets))
+	require.Equal(t, 100+33, int(offsets[0]))
+}
+
+func TestOffsetsCacheGetMultiple(t *testing.T) {
+	oc := setupAndStartCache(t)
+
+	offsets, err := oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 0,
+			NumOffsets:  100,
+		},
+		{
+			TopicID:     7,
+			PartitionID: 1,
+			NumOffsets:  200,
+		},
+		{
+			TopicID:     7,
+			PartitionID: 2,
+			NumOffsets:  300,
+		},
+		{
+			TopicID:     7,
+			PartitionID: 3,
+			NumOffsets:  400,
+		},
+		{
+			TopicID:     8,
+			PartitionID: 0,
+			NumOffsets:  150,
+		},
+		{
+			TopicID:     8,
+			PartitionID: 1,
+			NumOffsets:  250,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 6, len(offsets))
+
+	require.Equal(t, 1234+1, int(offsets[0]))
+	require.Equal(t, 3456+1, int(offsets[1]))
+	require.Equal(t, 0+1, int(offsets[2]))
+	require.Equal(t, 0, int(offsets[3]))
+	require.Equal(t, 5678+1, int(offsets[4]))
+	require.Equal(t, 3456+1, int(offsets[5]))
+
+	offsets, err = oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     7,
+			PartitionID: 0,
+			NumOffsets:  100,
+		},
+		{
+			TopicID:     7,
+			PartitionID: 1,
+			NumOffsets:  200,
+		},
+		{
+			TopicID:     7,
+			PartitionID: 2,
+			NumOffsets:  300,
+		},
+		{
+			TopicID:     7,
+			PartitionID: 3,
+			NumOffsets:  400,
+		},
+		{
+			TopicID:     8,
+			PartitionID: 0,
+			NumOffsets:  150,
+		},
+		{
+			TopicID:     8,
+			PartitionID: 1,
+			NumOffsets:  250,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 6, len(offsets))
+
+	require.Equal(t, 1234+1+100, int(offsets[0]))
+	require.Equal(t, 3456+1+200, int(offsets[1]))
+	require.Equal(t, 0+1+300, int(offsets[2]))
+	require.Equal(t, 0+400, int(offsets[3]))
+	require.Equal(t, 5678+1+150, int(offsets[4]))
+	require.Equal(t, 3456+1+250, int(offsets[5]))
+}
+
+func TestOffsetsCacheUnknownTopicID(t *testing.T) {
+	oc := setupAndStartCache(t)
+
+	_, err := oc.GetOffsets([]GetOffsetInfo{
+		{
+			TopicID:     2323,
+			PartitionID: 0,
+			NumOffsets:  1,
+		},
+	})
+	require.Error(t, err)
+	require.Equal(t, "unknown topic id: 2323", err.Error())
+}
+
+func TestOffsetsCacheEmptyInfos(t *testing.T) {
+	oc := setupAndStartCache(t)
+
+	_, err := oc.GetOffsets(nil)
+	require.Error(t, err)
+	require.Equal(t, "empty infos", err.Error())
+}
+
+var testTopicProvider = &testTopicInfoProvider{
+	infos: []TopicInfo{
+		{
+			TopicID:        7,
+			PartitionCount: 4,
+		},
+		{
+			TopicID:        8,
+			PartitionCount: 2,
+		},
+	},
+}
+
+var testOffsetLoader = &testPartitionOffsetLoader{
+	offsets: []StoredOffset{
+		{
+			topicID:     7,
+			partitionID: 0,
+			offset:      1234,
+		},
+		{
+			topicID:     7,
+			partitionID: 1,
+			offset:      3456,
+		},
+		{
+			topicID:     7,
+			partitionID: 2,
+			offset:      0,
+		},
+		{
+			topicID:     7,
+			partitionID: 3,
+			offset:      -1,
+		},
+		{
+			topicID:     8,
+			partitionID: 0,
+			offset:      5678,
+		},
+		{
+			topicID:     8,
+			partitionID: 1,
+			offset:      3456,
+		},
+	},
+}
+
+func setupAndStartCache(t *testing.T) *OffsetsCache {
+	oc := NewOffsetsCache(23, testTopicProvider, testOffsetLoader)
+	err := oc.Start()
+	require.NoError(t, err)
+	return oc
+}

--- a/shard/rpcs.go
+++ b/shard/rpcs.go
@@ -7,9 +7,9 @@ import (
 )
 
 type ApplyChangesRequest struct {
-	ShardID  int
+	ShardID        int
 	ClusterVersion int
-	RegBatch lsm.RegistrationBatch
+	RegBatch       lsm.RegistrationBatch
 }
 
 func (a *ApplyChangesRequest) Serialize(buff []byte) []byte {
@@ -27,38 +27,98 @@ func (a *ApplyChangesRequest) Deserialize(buff []byte, offset int) int {
 }
 
 type QueryTablesInRangeRequest struct {
-	ShardID  int
+	ShardID        int
 	ClusterVersion int
-	KeyStart []byte
-	KeyEnd   []byte
+	KeyStart       []byte
+	KeyEnd         []byte
 }
 
-func (a *QueryTablesInRangeRequest) Serialize(buff []byte) []byte {
-	buff = binary.BigEndian.AppendUint64(buff, uint64(a.ShardID))
-	buff = binary.BigEndian.AppendUint64(buff, uint64(a.ClusterVersion))
-	buff = binary.BigEndian.AppendUint32(buff, uint32(len(a.KeyStart)))
-	buff = append(buff, a.KeyStart...)
-	buff = binary.BigEndian.AppendUint32(buff, uint32(len(a.KeyEnd)))
-	buff = append(buff, a.KeyEnd...)
+func (q *QueryTablesInRangeRequest) Serialize(buff []byte) []byte {
+	buff = binary.BigEndian.AppendUint64(buff, uint64(q.ShardID))
+	buff = binary.BigEndian.AppendUint64(buff, uint64(q.ClusterVersion))
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(q.KeyStart)))
+	buff = append(buff, q.KeyStart...)
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(q.KeyEnd)))
+	buff = append(buff, q.KeyEnd...)
 	return buff
 }
 
-func (a *QueryTablesInRangeRequest) Deserialize(buff []byte, offset int) int {
-	a.ShardID = int(binary.BigEndian.Uint64(buff[offset:]))
+func (q *QueryTablesInRangeRequest) Deserialize(buff []byte, offset int) int {
+	q.ShardID = int(binary.BigEndian.Uint64(buff[offset:]))
 	offset += 8
-	a.ClusterVersion = int(binary.BigEndian.Uint64(buff[offset:]))
+	q.ClusterVersion = int(binary.BigEndian.Uint64(buff[offset:]))
 	offset += 8
 	lks := int(binary.BigEndian.Uint32(buff[offset:]))
 	offset += 4
 	if lks > 0 {
-		a.KeyStart = common.ByteSliceCopy(buff[offset : offset+lks])
+		q.KeyStart = common.ByteSliceCopy(buff[offset : offset+lks])
 		offset += lks
 	}
 	lke := int(binary.BigEndian.Uint32(buff[offset:]))
 	offset += 4
 	if lke > 0 {
-		a.KeyEnd = common.ByteSliceCopy(buff[offset : offset+lke])
+		q.KeyEnd = common.ByteSliceCopy(buff[offset : offset+lke])
 		offset += lke
+	}
+	return offset
+}
+
+type GetOffsetsRequest struct {
+	ShardID        int
+	ClusterVersion int
+	Infos          []GetOffsetInfo
+}
+
+func (g *GetOffsetsRequest) Serialize(buff []byte) []byte {
+	buff = binary.BigEndian.AppendUint64(buff, uint64(g.ShardID))
+	buff = binary.BigEndian.AppendUint64(buff, uint64(g.ClusterVersion))
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(g.Infos)))
+	for _, info := range g.Infos {
+		buff = binary.BigEndian.AppendUint64(buff, uint64(info.TopicID))
+		buff = binary.BigEndian.AppendUint64(buff, uint64(info.PartitionID))
+		buff = binary.BigEndian.AppendUint32(buff, uint32(info.NumOffsets))
+	}
+	return buff
+}
+
+func (g *GetOffsetsRequest) Deserialize(buff []byte, offset int) int {
+	g.ShardID = int(binary.BigEndian.Uint64(buff[offset:]))
+	offset += 8
+	g.ClusterVersion = int(binary.BigEndian.Uint64(buff[offset:]))
+	offset += 8
+	lInfos := int(binary.BigEndian.Uint32(buff[offset:]))
+	offset += 4
+	g.Infos = make([]GetOffsetInfo, lInfos)
+	for i := 0; i < lInfos; i++ {
+		g.Infos[i].TopicID = int(binary.BigEndian.Uint64(buff[offset:]))
+		offset += 8
+		g.Infos[i].PartitionID = int(binary.BigEndian.Uint64(buff[offset:]))
+		offset += 8
+		g.Infos[i].NumOffsets = int(binary.BigEndian.Uint32(buff[offset:]))
+		offset += 4
+	}
+	return offset
+}
+
+type GetOffsetsResponse struct {
+	Offsets []int64
+}
+
+func (g *GetOffsetsResponse) Serialize(buff []byte) []byte {
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(g.Offsets)))
+	for _, offset := range g.Offsets {
+		buff = binary.BigEndian.AppendUint64(buff, uint64(offset))
+	}
+	return buff
+}
+
+func (g *GetOffsetsResponse) Deserialize(buff []byte, offset int) int {
+	numOffsets := int(binary.BigEndian.Uint32(buff[offset:]))
+	offset += 4
+	g.Offsets = make([]int64, numOffsets)
+	for i := 0; i < numOffsets; i++ {
+		g.Offsets[i] = int64(binary.BigEndian.Uint64(buff[offset:]))
+		offset += 8
 	}
 	return offset
 }

--- a/shard/shard.go
+++ b/shard/shard.go
@@ -137,9 +137,6 @@ func (s *LsmShard) maybeRetryApplies0() error {
 			return queuedReg.completionFunc(err)
 		}
 		if ok {
-			if queuedReg.completionFunc == nil {
-				log.Infof("foo")
-			}
 			completionFuncs = append(completionFuncs, queuedReg.completionFunc)
 			pos++
 		} else {
@@ -179,10 +176,6 @@ func (s *LsmShard) maybeRetryApplies0() error {
 		}
 		// Call the completions
 		for _, cf := range completionFuncs {
-			log.Infof("calling cf %v", cf)
-			if cf == nil {
-				log.Infof("foo")
-			}
 			if err := cf(nil); err != nil {
 				log.Errorf("failed to apply completion function: %v", err)
 			}

--- a/shard/shard_test.go
+++ b/shard/shard_test.go
@@ -2,7 +2,6 @@ package shard
 
 import (
 	"github.com/google/uuid"
-	log "github.com/spirit-labs/tektite/logger"
 	"github.com/spirit-labs/tektite/lsm"
 	"github.com/spirit-labs/tektite/objstore/dev"
 	"github.com/spirit-labs/tektite/sst"
@@ -123,9 +122,7 @@ func TestApplyChangesL0Full(t *testing.T) {
 		batch := createBatch(0, tableID, keyStart, keyEnd)
 		ch := make(chan error, 1)
 		chans = append(chans, ch)
-		index := i
 		err = shard.ApplyLsmChanges(batch, func(err error) error {
-			log.Infof("calling completion %d", index)
 			cc.Store(true)
 			ch <- err
 			return nil

--- a/transport/handler_ids.go
+++ b/transport/handler_ids.go
@@ -3,4 +3,5 @@ package transport
 const (
 	HandlerIDShardApplyChanges = iota + 10
 	HandlerIDShardQueryTablesInRange
+	HandlerIDShardGetOffsets
 )


### PR DESCRIPTION
This PR implements an offsets cache that lives on the shard controller.
The offsets cache caches next available offset for a topic partition in memory. Before batches of topic data are written to S3, offsets must be obtained and this is where they are obtained from.
The actual offset is stored in the topic data when pushed to S3, and when the shard controller starts it loads the last offset from there.

This PR is based on https://github.com/spirit-labs/tektite/pull/250 so pls only review last commit