### PR TITLE
Implement batch fetcher

### DIFF
--- a/agent/conf.go
+++ b/agent/conf.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spirit-labs/tektite/asl/conf"
 	"github.com/spirit-labs/tektite/cluster"
 	"github.com/spirit-labs/tektite/control"
+	"github.com/spirit-labs/tektite/fetcher"
 	"github.com/spirit-labs/tektite/lsm"
 	"github.com/spirit-labs/tektite/pusher"
 )
@@ -15,6 +16,7 @@ type Conf struct {
 	PusherConf              pusher.Conf
 	ControllerConf          control.Conf
 	CompactionWorkersConf   lsm.CompactionWorkerServiceConf
+	FetcherConf             fetcher.Conf
 }
 
 func NewConf() Conf {
@@ -23,6 +25,7 @@ func NewConf() Conf {
 		PusherConf:              pusher.NewConf(),
 		ControllerConf:          control.NewConf(),
 		CompactionWorkersConf:   lsm.NewCompactionWorkerServiceConf(),
+		FetcherConf:             fetcher.NewConf(),
 	}
 }
 
@@ -40,6 +43,9 @@ func (c *Conf) Validate() error {
 		return err
 	}
 	if err := c.ControllerConf.Validate(); err != nil {
+		return err
+	}
+	if err := c.FetcherConf.Validate(); err != nil {
 		return err
 	}
 	return nil

--- a/agent/kafka_api_client.go
+++ b/agent/kafka_api_client.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/binary"
 	"github.com/pkg/errors"
+	"github.com/spirit-labs/tektite/common"
 	"github.com/spirit-labs/tektite/kafkaprotocol"
 	"github.com/spirit-labs/tektite/sockserver"
 	"sync"
@@ -68,7 +69,7 @@ func (k *KafkaApiConnection) createRequestAndRegisterHandler(req KafkaProtocolRe
 	hdr.CorrelationId = k.correlationIDSeq
 	hdr.RequestApiKey = apiKey
 	hdr.RequestApiVersion = apiVersion
-	hdr.ClientId = strPtr("some-client-id")
+	hdr.ClientId = common.StrPtr("some-client-id")
 	requestHeaderVersion, responseHeaderVersion := req.HeaderVersions(apiVersion)
 	buff := hdr.Write(requestHeaderVersion, nil, nil)
 	buff = req.Write(apiVersion, buff, nil)
@@ -111,8 +112,4 @@ type KafkaProtocolMessage interface {
 type KafkaProtocolRequest interface {
 	KafkaProtocolMessage
 	HeaderVersions(version int16) (int16, int16)
-}
-
-func strPtr(s string) *string {
-	return &s
 }

--- a/agent/kafka_handler.go
+++ b/agent/kafka_handler.go
@@ -27,8 +27,7 @@ func (k *kafkaHandler) ProduceRequestErrorResponse(errorCode int16, errorMsg str
 }
 
 func (k *kafkaHandler) HandleFetchRequest(hdr *kafkaprotocol.RequestHeader, req *kafkaprotocol.FetchRequest, completionFunc func(resp *kafkaprotocol.FetchResponse) error) error {
-	//TODO implement me
-	panic("implement me")
+	return k.agent.batchFetcher.HandleFetchRequest(req, completionFunc)
 }
 
 func (k *kafkaHandler) FetchRequestErrorResponse(errorCode int16, errorMsg string, req *kafkaprotocol.FetchRequest) *kafkaprotocol.FetchResponse {

--- a/agent/produce_test.go
+++ b/agent/produce_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/spirit-labs/tektite/common"
 	"github.com/spirit-labs/tektite/control"
 	"github.com/spirit-labs/tektite/iteration"
+	"github.com/spirit-labs/tektite/kafkaencoding"
 	"github.com/spirit-labs/tektite/kafkaprotocol"
 	"github.com/spirit-labs/tektite/objstore"
 	"github.com/spirit-labs/tektite/objstore/dev"
 	"github.com/spirit-labs/tektite/parthash"
-	"github.com/spirit-labs/tektite/pusher"
 	"github.com/spirit-labs/tektite/sst"
 	"github.com/spirit-labs/tektite/testutils"
 	"github.com/spirit-labs/tektite/topicmeta"
@@ -51,7 +51,7 @@ func TestProduceSimple(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr(topicName),
+				Name: common.StrPtr(topicName),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: int32(partitionID),
@@ -125,7 +125,7 @@ func TestProduceMultipleTopicsAndPartitions(t *testing.T) {
 			})
 		}
 		topicData = append(topicData, kafkaprotocol.ProduceRequestTopicProduceData{
-			Name:          strPtr(fmt.Sprintf("topic-%02d", i)),
+			Name:          common.StrPtr(fmt.Sprintf("topic-%02d", i)),
 			PartitionData: partitionData,
 		})
 	}
@@ -223,7 +223,7 @@ func TestProduceMultipleBatches(t *testing.T) {
 			TimeoutMs:       1234,
 			TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 				{
-					Name: strPtr(topicName),
+					Name: common.StrPtr(topicName),
 					PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 						{
 							Index: int32(partitionID),
@@ -284,7 +284,7 @@ func TestProduceSimpleWithReload(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr(topicName),
+				Name: common.StrPtr(topicName),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: int32(partitionID),
@@ -331,7 +331,7 @@ func TestProduceSimpleWithReload(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr(topicName),
+				Name: common.StrPtr(topicName),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: int32(partitionID),
@@ -452,13 +452,13 @@ func verifyBatchesWritten(t *testing.T, topicID int, partitionID int, offsetStar
 	for _, nonOverLapIDs := range ids {
 		if len(nonOverLapIDs) == 1 {
 			info := nonOverLapIDs[0]
-			iter, err := sst.NewLazySSTableIterator(info.ID, tg, keyStart, keyEnd)
+			iter, err := sst.NewLazySSTableIterator(info.ID, tg.GetSSTable, keyStart, keyEnd)
 			require.NoError(t, err)
 			iters = append(iters, iter)
 		} else {
 			itersInChain := make([]iteration.Iterator, len(nonOverLapIDs))
 			for j, nonOverlapID := range nonOverLapIDs {
-				iter, err := sst.NewLazySSTableIterator(nonOverlapID.ID, tg, keyStart, keyEnd)
+				iter, err := sst.NewLazySSTableIterator(nonOverlapID.ID, tg.GetSSTable, keyStart, keyEnd)
 				require.NoError(t, err)
 				itersInChain[j] = iter
 			}
@@ -478,7 +478,7 @@ func verifyBatchesWritten(t *testing.T, topicID int, partitionID int, offsetStar
 		require.Equal(t, kv.Key, expectedKey)
 		recordBatch := kv.Value
 		require.Equal(t, expectedBatch, recordBatch)
-		numRecords := pusher.NumRecords(recordBatch)
+		numRecords := kafkaencoding.NumRecords(recordBatch)
 		expectedOffset += numRecords
 	}
 	ok, _, err := mi.Next()

--- a/common/util.go
+++ b/common/util.go
@@ -5,3 +5,7 @@ func ByteSliceCopy(byteSlice []byte) []byte {
 	copy(copied, byteSlice)
 	return copied
 }
+
+func StrPtr(s string) *string {
+	return &s
+}

--- a/fetcher/client_cache.go
+++ b/fetcher/client_cache.go
@@ -1,0 +1,89 @@
+package fetcher
+
+import (
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/lsm"
+	"sync"
+	"sync/atomic"
+)
+
+// clientCache is a goroutine-safe cache of controller clients
+type clientCache struct {
+	lock          sync.RWMutex
+	clientFactory controllerClientFactory
+	clients       []ControlClient
+	pos           int64
+}
+
+func newClientCache(maxClients int, clientFactory controllerClientFactory) *clientCache {
+	return &clientCache{
+		clients:       make([]ControlClient, maxClients),
+		clientFactory: clientFactory,
+	}
+}
+
+func (cc *clientCache) getClient() (ControlClient, error) {
+	cl, index := cc.getCachedClient()
+	if cl != nil {
+		return cl, nil
+	}
+	return cc.createClient(index)
+}
+
+func (cc *clientCache) getCachedClient() (ControlClient, int) {
+	cc.lock.RLock()
+	defer cc.lock.RUnlock()
+	pos := atomic.AddInt64(&cc.pos, 1) - 1
+	index := int(pos) % len(cc.clients)
+	return cc.clients[index], index
+}
+
+func (cc *clientCache) createClient(index int) (ControlClient, error) {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	cl := cc.clients[index]
+	if cl != nil {
+		return cl, nil
+	}
+	cl, err := cc.clientFactory()
+	if err != nil {
+		return nil, err
+	}
+	cc.clients[index] = &clientWrapper{
+		cc:     cc,
+		index:  index,
+		client: cl,
+	}
+	return cl, nil
+}
+
+func (cc *clientCache) deleteClient(index int) {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	cc.clients[index] = nil
+}
+
+func (cc *clientCache) close() {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	for _, cc := range cc.clients {
+		if err := cc.Close(); err != nil {
+			log.Warnf("failed to close controller client: %v", err)
+		}
+	}
+}
+
+type clientWrapper struct {
+	cc     *clientCache
+	index  int
+	client ControlClient
+}
+
+func (c *clientWrapper) FetchTablesForPrefix(topicID int, partitionID int, prefix []byte, offsetStart int64) (lsm.OverlappingTables, int64, error) {
+	return c.client.FetchTablesForPrefix(topicID, partitionID, prefix, offsetStart)
+}
+
+func (c *clientWrapper) Close() error {
+	c.cc.deleteClient(c.index)
+	return c.client.Close()
+}

--- a/fetcher/fetch_state.go
+++ b/fetcher/fetch_state.go
@@ -1,0 +1,376 @@
+package fetcher
+
+import (
+	"github.com/spirit-labs/tektite/asl/encoding"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/iteration"
+	"github.com/spirit-labs/tektite/kafkaencoding"
+	"github.com/spirit-labs/tektite/kafkaprotocol"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/sst"
+	"math"
+	"sync"
+	"time"
+)
+
+type FetchState struct {
+	lock            sync.Mutex
+	bf              *BatchFetcher
+	req             *kafkaprotocol.FetchRequest
+	resp            kafkaprotocol.FetchResponse
+	partitionStates map[int]map[int]*PartitionFetchState
+	completionFunc  func(resp *kafkaprotocol.FetchResponse) error
+	timeoutTimer    *time.Timer
+	readExec        *readExecutor
+	bytesFetched    int
+	first           bool
+}
+
+func (f *FetchState) init() error {
+	f.resp.Responses = make([]kafkaprotocol.FetchResponseFetchableTopicResponse, len(f.req.Topics))
+	for i, topicData := range f.req.Topics {
+		f.resp.Responses[i].Topic = topicData.Topic
+		partitionResponses := make([]kafkaprotocol.FetchResponsePartitionData, len(topicData.Partitions))
+		f.resp.Responses[i].Partitions = partitionResponses
+		topicName := *topicData.Topic
+		topicInfo, err := f.bf.topicProvider.GetTopicInfo(topicName)
+		topicExists := true
+		if err != nil {
+			if !common.IsTektiteErrorWithCode(err, common.TopicDoesNotExist) {
+				log.Warnf("failed to get topic info: %v", err)
+			}
+			topicExists = false
+		}
+		topicPartitionFetchStates := map[int]*PartitionFetchState{}
+		if topicExists {
+			topicPartitionFetchStates = map[int]*PartitionFetchState{}
+			f.partitionStates[topicInfo.ID] = topicPartitionFetchStates
+		}
+		for j, partitionData := range topicData.Partitions {
+			partitionResponses[j].PartitionIndex = partitionData.Partition
+			partitionID := int(partitionData.Partition)
+			if !topicExists {
+				partitionResponses[j].ErrorCode = int16(kafkaprotocol.ErrorCodeUnknownTopicOrPartition)
+			} else if partitionID < 0 || partitionID >= topicInfo.PartitionCount {
+				partitionResponses[j].ErrorCode = int16(kafkaprotocol.ErrorCodeUnknownTopicOrPartition)
+			} else {
+				partHash, err := f.bf.partitionHashes.GetPartitionHash(topicInfo.ID, partitionID)
+				if err != nil {
+					return err
+				}
+				topicPartitionFetchStates[partitionID] = &PartitionFetchState{
+					fs:                 f,
+					partitionFetchReq:  &partitionData,
+					partitionFetchResp: &partitionResponses[j],
+					partitionTables:    f.bf.recentTables.getPartitionTables(topicInfo.ID, partitionID),
+					topicID:            topicInfo.ID,
+					partitionID:        partitionID,
+					partitionHash:      partHash,
+					lastReadOffset:     -1,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// We read async on notifications to avoid blocking the transport thread that provides the notification and so we can
+// parallelise sending multiple responses and fetching from distributed cache
+func (f *FetchState) readAsync() {
+	f.readExec.ch <- f
+}
+
+func (f *FetchState) read() error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if f.completionFunc == nil {
+		// Response already sent
+		return nil
+	}
+	wouldExceedRequestMax := false
+outer:
+	for topicID, partitionFetchStates := range f.partitionStates {
+		for partitionID, partitionFetchState := range partitionFetchStates {
+			var err error
+			var wouldExceedPartitionMax bool
+			wouldExceedRequestMax, wouldExceedPartitionMax, err = partitionFetchState.read()
+			if err != nil {
+				return err
+			}
+			if wouldExceedRequestMax {
+				break outer
+			}
+			if wouldExceedPartitionMax {
+				delete(partitionFetchStates, partitionID)
+				if len(partitionFetchStates) == 0 {
+					delete(f.partitionStates, topicID)
+				}
+			}
+		}
+	}
+	if wouldExceedRequestMax || len(f.partitionStates) == 0 {
+		// We either exceeded request max size or exceeded partition max size on all partitions, so the request is
+		// complete
+		if err := f.sendResponse(); err != nil {
+			return err
+		}
+		return nil
+	}
+	if f.bytesFetched >= int(f.req.MinBytes) {
+		// We fetched enough data
+		if err := f.sendResponse(); err != nil {
+			return err
+		}
+		return nil
+	}
+	// We didn't fetch enough data
+	if f.req.MaxWaitMs == 0 {
+		// Give up now and return no data
+		f.clearFetchedRecords()
+		if err := f.sendResponse(); err != nil {
+			return err
+		}
+		return nil
+	}
+	if f.timeoutTimer == nil {
+		// Set a timeout if we haven't already set one - as we need to wait
+		time.AfterFunc(time.Duration(f.req.MaxWaitMs)*time.Millisecond, f.timeout)
+	}
+	// We register our partition states to receive notifications when new data arrives
+	return f.bf.recentTables.registerPartitionStates(f.partitionStates)
+}
+
+func (f *FetchState) clearFetchedRecords() {
+	// Clear any data that was fetched
+	for i := 0; i < len(f.resp.Responses); i++ {
+		for j := 0; j < len(f.resp.Responses[i].Partitions); j++ {
+			f.resp.Responses[i].Partitions[j].Records = nil
+		}
+	}
+}
+
+func (f *FetchState) sendResponse() error {
+	if f.completionFunc == nil {
+		// response already sent
+		return nil
+	}
+	if err := f.completionFunc(&f.resp); err != nil {
+		return err
+	}
+	if f.timeoutTimer != nil {
+		f.timeoutTimer.Stop()
+	}
+	f.completionFunc = nil
+	f.bf.recentTables.unregisterPartitionStates(f.partitionStates)
+	return nil
+}
+
+func (f *FetchState) timeout() {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if f.bytesFetched < int(f.req.MinBytes) {
+		f.clearFetchedRecords()
+	}
+	if err := f.sendResponse(); err != nil {
+		log.Errorf("failed to send fetch response: %v", err)
+	}
+}
+
+type PartitionFetchState struct {
+	fs                 *FetchState
+	partitionFetchReq  *kafkaprotocol.FetchRequestFetchPartition
+	partitionFetchResp *kafkaprotocol.FetchResponsePartitionData
+	partitionTables    *PartitionTables
+	iter               iteration.Iterator
+	topicID            int
+	partitionID        int
+	partitionHash      []byte
+	bytesFetched       int
+	lastReadOffset     int64
+}
+
+func (p *PartitionFetchState) read() (wouldExceedRequestMax bool, wouldExceedPartitionMax bool, err error) {
+	if p.iter == nil {
+		fetchOffset := p.partitionFetchReq.FetchOffset
+		// See if we can create an iterator from locally cached tables - this would be the case where we are fetching
+		// form a very recent offset, and avoids going to the controller to get the table ids
+		tabIds, lastReadableOffset := p.partitionTables.getCacheTables(fetchOffset)
+		if len(tabIds) > 0 {
+			// Yes we have locally cached tables
+			iter, err := p.createIteratorFromTabIDs(tabIds, p.partitionFetchReq.FetchOffset, lastReadableOffset)
+			if err != nil {
+				return false, false, err
+			}
+			log.Infof("serving from cache")
+			p.iter = iter
+		} else {
+			log.Infof("serving from controller")
+			// The fetchOffset is too old or there are no cached tables so we need to go to the controller
+			// to get table ids
+			if err := p.createIteratorFromControllerQuery(fetchOffset); err != nil {
+				return false, false, err
+			}
+		}
+	}
+	var batches [][]byte
+	for {
+		ok, kv, err := p.iter.Next()
+		if err != nil {
+			return false, false, err
+		}
+		if !ok {
+			break
+		}
+		batchSize := len(kv.Value)
+		if !p.fs.first {
+			if p.bytesFetched+batchSize > int(p.partitionFetchReq.PartitionMaxBytes) {
+				// Would exceed partition max size
+				wouldExceedPartitionMax = true
+				break
+			}
+			if p.fs.bytesFetched+batchSize > int(p.fs.req.MaxBytes) {
+				// would exceed total response max size
+				wouldExceedRequestMax = true
+				break
+			}
+		}
+		batches = append(batches, kv.Value)
+		p.bytesFetched += batchSize
+		p.fs.bytesFetched += batchSize
+		p.lastReadOffset = kafkaencoding.BaseOffset(kv.Value) + int64(kafkaencoding.NumRecords(kv.Value)) - 1
+	}
+	if len(batches) > 0 {
+		p.partitionFetchResp.Records = append(p.partitionFetchResp.Records, batches...)
+		p.fs.first = false
+	}
+	return
+}
+
+func (p *PartitionFetchState) createIteratorFromControllerQuery(offset int64) error {
+	cl, err := p.fs.bf.getClient()
+	if err != nil {
+		return err
+	}
+	ids, lastReadableOffset, err := cl.FetchTablesForPrefix(p.topicID, p.partitionID, p.partitionHash, offset)
+	if err != nil {
+		return err
+	}
+	keyStart := make([]byte, 0, 24)
+	keyStart = append(keyStart, p.partitionHash...)
+	keyStart = encoding.KeyEncodeInt(keyStart, offset)
+	keyEnd := make([]byte, 0, 24)
+	keyEnd = append(keyEnd, p.partitionHash...)
+	keyEnd = encoding.KeyEncodeInt(keyEnd, lastReadableOffset+1)
+	if err := p.createIteratorForKeyRange(ids, keyStart, keyEnd); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *PartitionFetchState) createIteratorForKeyRange(ids lsm.OverlappingTables, keyStart []byte, keyEnd []byte) error {
+	if len(ids) == 0 {
+		p.iter = &iteration.EmptyIterator{}
+		return nil
+	}
+	tableGetter := p.fs.bf.getTableFromCache
+	var iters []iteration.Iterator
+	for _, nonOverLapIDs := range ids {
+		if len(nonOverLapIDs) == 1 {
+			info := nonOverLapIDs[0]
+			iter, err := sst.NewLazySSTableIterator(info.ID, tableGetter, keyStart, keyEnd)
+			if err != nil {
+				return err
+			}
+			iters = append(iters, iter)
+		} else {
+			itersInChain := make([]iteration.Iterator, len(nonOverLapIDs))
+			for j, nonOverlapID := range nonOverLapIDs {
+				iter, err := sst.NewLazySSTableIterator(nonOverlapID.ID, tableGetter, keyStart, keyEnd)
+				if err != nil {
+					return err
+				}
+				itersInChain[j] = iter
+			}
+			iters = append(iters, iteration.NewChainingIterator(itersInChain))
+		}
+	}
+	var iter iteration.Iterator
+	if len(iters) > 1 {
+		var err error
+		iter, err = iteration.NewMergingIterator(iters, false, math.MaxUint64)
+		if err != nil {
+			return err
+		}
+	} else {
+		iter = iters[0]
+	}
+	p.iter = iter
+	return nil
+}
+
+func (p *PartitionFetchState) createIteratorFromTabIDs(tableIDs []*sst.SSTableID, fromOffset int64, lastReadableOffset int64) (iteration.Iterator, error) {
+	keyStart := make([]byte, 0, 24)
+	keyStart = append(keyStart, p.partitionHash...)
+	keyStart = encoding.KeyEncodeInt(keyStart, fromOffset)
+	keyEnd := make([]byte, 0, 24)
+	keyEnd = append(keyEnd, p.partitionHash...)
+	keyEnd = encoding.KeyEncodeInt(keyEnd, lastReadableOffset+1)
+	var iter iteration.Iterator
+	if len(tableIDs) > 0 {
+		iters := make([]iteration.Iterator, len(tableIDs))
+		for i, tid := range tableIDs {
+			sstIter, err := sst.NewLazySSTableIterator(*tid, p.fs.bf.getTableFromCache, keyStart, keyEnd)
+			if err != nil {
+				return nil, err
+			}
+			iters[i] = sstIter
+		}
+		iter = iteration.NewChainingIterator(iters)
+	} else {
+		var err error
+		iter, err = sst.NewLazySSTableIterator(*tableIDs[0], p.fs.bf.getTableFromCache, keyStart, keyEnd)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return iter, nil
+}
+
+func (p *PartitionFetchState) updateIterator(entries []RecentTableEntry) (*FetchState, error) {
+	p.fs.lock.Lock()
+	defer p.fs.lock.Unlock()
+	if p.fs.completionFunc == nil {
+		// response already sent - probably timed out
+		return nil, nil
+	}
+	// Find tables of interest
+	var tableIDs []*sst.SSTableID
+	for _, entry := range entries {
+		if entry.LastReadableOffset <= p.lastReadOffset {
+			// Skip past this table as it cannot have any offsets we are interested in
+			// Entries aren't added until all the offsets in a table are readable, so this is safe
+			continue
+		}
+		tableIDs = append(tableIDs, entry.TableID)
+	}
+	if len(tableIDs) == 0 {
+		// Nothing to update
+		return nil, nil
+	}
+	lastReadableOffset := entries[len(entries)-1].LastReadableOffset
+	// We know that we must have already iterated to previous last readable offset so we can throw away the previous
+	// iterator and replace it with a simple chaining iterator if we have more than one table or just a single iterator
+	var offsetStart int64
+	if p.lastReadOffset == -1 {
+		offsetStart = p.partitionFetchReq.FetchOffset
+	} else {
+		offsetStart = p.lastReadOffset
+	}
+	iter, err := p.createIteratorFromTabIDs(tableIDs, offsetStart, lastReadableOffset)
+	if err != nil {
+		return nil, err
+	}
+	p.iter = iter
+	return p.fs, nil
+}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -1,0 +1,174 @@
+package fetcher
+
+import (
+	"github.com/spirit-labs/tektite/kafkaprotocol"
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/parthash"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/spirit-labs/tektite/topicmeta"
+	"sync"
+	"sync/atomic"
+)
+
+type BatchFetcher struct {
+	objStore        objstore.Client
+	topicProvider   topicInfoProvider
+	partitionHashes *parthash.PartitionHashes
+	controlFactory  controllerClientFactory
+	tableGetter     sst.TableGetter
+	recentTables    PartitionRecentTables
+	controlClients  *clientCache
+	dataBucketName  string
+	readExecs       []readExecutor
+	localCache      *LocalSSTCache
+	execAssignPos   int64
+}
+
+func NewBatchFetcher(objStore objstore.Client, topicProvider topicInfoProvider, partitionHashes *parthash.PartitionHashes,
+	controlFactory controllerClientFactory, tableGetter sst.TableGetter, cfg Conf) (*BatchFetcher, error) {
+	localCache, err := NewLocalSSTCache(cfg.LocalCacheNumEntries, cfg.LocalCacheMaxBytes)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchFetcher{
+		objStore:        objStore,
+		topicProvider:   topicProvider,
+		partitionHashes: partitionHashes,
+		controlFactory:  controlFactory,
+		tableGetter:     tableGetter,
+		recentTables:    CreatePartitionRecentTables(cfg.MaxCachedTablesPerPartition),
+		controlClients:  newClientCache(cfg.MaxControllerConnections, controlFactory),
+		readExecs:       make([]readExecutor, cfg.NumReadExecutors),
+		localCache:      localCache,
+		dataBucketName:  cfg.DataBucketName,
+	}, nil
+}
+
+type Conf struct {
+	DataBucketName              string
+	MaxControllerConnections    int
+	MaxCachedTablesPerPartition int
+	NumReadExecutors            int
+	LocalCacheNumEntries        int
+	LocalCacheMaxBytes          int
+}
+
+func NewConf() Conf {
+	return Conf{
+		DataBucketName:              DefaultDataBucketName,
+		MaxControllerConnections:    DefaultMaxControllerConnections,
+		MaxCachedTablesPerPartition: DefaultMaxCachedTablesPerPartition,
+		NumReadExecutors:            DefaultNumReadExecutors,
+		LocalCacheNumEntries:        DefaultLocalCacheNumEntries,
+		LocalCacheMaxBytes:          DefaultLocalCacheMaxBytes,
+	}
+}
+
+func (c *Conf) Validate() error {
+	return nil
+}
+
+const (
+	DefaultDataBucketName              = "tektite-data"
+	DefaultMaxControllerConnections    = 10
+	DefaultMaxCachedTablesPerPartition = 100
+	DefaultNumReadExecutors            = 8
+	DefaultLocalCacheNumEntries        = 20
+	DefaultLocalCacheMaxBytes          = 256 * 1024 * 1024 // 256MiB
+	readExecChannelSize                = 10
+)
+
+type topicInfoProvider interface {
+	GetTopicInfo(topicName string) (topicmeta.TopicInfo, error)
+}
+
+type controllerClientFactory func() (ControlClient, error)
+
+type ControlClient interface {
+	FetchTablesForPrefix(topicID int, partitionID int, prefix []byte, offsetStart int64) (lsm.OverlappingTables, int64, error)
+	Close() error
+}
+
+func (b *BatchFetcher) Start() error {
+	for i := 0; i < len(b.readExecs); i++ {
+		b.readExecs[i].ch = make(chan *FetchState, readExecChannelSize)
+		b.readExecs[i].start()
+	}
+	return nil
+}
+
+func (b *BatchFetcher) Stop() error {
+	for i := 0; i < len(b.readExecs); i++ {
+		b.readExecs[i].stop()
+	}
+	return nil
+}
+
+func (b *BatchFetcher) HandleFetchRequest(req *kafkaprotocol.FetchRequest,
+	completionFunc func(resp *kafkaprotocol.FetchResponse) error) error {
+	pos := atomic.AddInt64(&b.execAssignPos, 1)
+	readExec := &b.readExecs[pos%int64(len(b.readExecs))]
+	// No need to shuffle partitions as golang map has non-deterministic iteration order - this ensures we don't have
+	// the same partition getting all the data and others starving
+	fetchState := FetchState{
+		bf:              b,
+		req:             req,
+		partitionStates: map[int]map[int]*PartitionFetchState{},
+		completionFunc:  completionFunc,
+		readExec:        readExec,
+	}
+	if err := fetchState.init(); err != nil {
+		return err
+	}
+	if len(fetchState.partitionStates) == 0 {
+		// all errored
+		return completionFunc(&fetchState.resp)
+	}
+	return fetchState.read()
+}
+
+func (b *BatchFetcher) getTableFromCache(tableID sst.SSTableID) (*sst.SSTable, error) {
+	// First look in local cache
+	table, ok := b.localCache.Get(tableID)
+	if ok {
+		return table, nil
+	}
+	// Then in distributed cache
+	table, err := b.tableGetter(tableID)
+	if err != nil {
+		return nil, err
+	}
+	// Add to local cache
+	b.localCache.Put(tableID, table)
+	return table, nil
+}
+
+func (b *BatchFetcher) getClient() (ControlClient, error) {
+	return b.controlClients.getClient()
+}
+
+type readExecutor struct {
+	ch     chan *FetchState
+	stopWG sync.WaitGroup
+}
+
+func (r *readExecutor) start() {
+	r.stopWG.Add(1)
+	go r.loop()
+}
+
+func (r *readExecutor) stop() {
+	close(r.ch)
+	r.stopWG.Wait()
+}
+
+func (r *readExecutor) loop() {
+	defer r.stopWG.Done()
+	for fs := range r.ch {
+		if err := fs.read(); err != nil {
+			log.Errorf("failed to execute read on fetch state: %v", err)
+		}
+	}
+}

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -75,8 +75,8 @@ const (
 	DefaultMaxControllerConnections    = 10
 	DefaultMaxCachedTablesPerPartition = 100
 	DefaultNumReadExecutors            = 8
-	DefaultLocalCacheNumEntries        = 20
-	DefaultLocalCacheMaxBytes          = 256 * 1024 * 1024 // 256MiB
+	DefaultLocalCacheNumEntries        = 10
+	DefaultLocalCacheMaxBytes          = 128 * 1024 * 1024 // 128MiB
 	readExecChannelSize                = 10
 )
 

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -1,0 +1,1547 @@
+package fetcher
+
+import (
+	"bytes"
+	"context"
+	"github.com/pkg/errors"
+	"github.com/spirit-labs/tektite/asl/encoding"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/kafkaprotocol"
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/objstore/dev"
+	"github.com/spirit-labs/tektite/parthash"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/spirit-labs/tektite/testutils"
+	"github.com/spirit-labs/tektite/topicmeta"
+	"github.com/stretchr/testify/require"
+	"math"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"testing"
+)
+
+/*
+Tests
+
+* Fuzz test, choose minBytes and request max bytes and partition max bytes randomly. Create data in random batch sizes. Make sure
+all data is consumed. Try this initially with 1 topic and partition, then do a version with multiple topics and partitions.
+
+* Test mixture of errors and successes
+* Test the async nature of read - hammer it multiple GRs?
+*/
+
+const (
+	databucketName       = "test-bucket"
+	defaultTopicName     = "default-test-topic"
+	defaultTopicID       = 1001
+	defaultPartitionID   = 23
+	defaultNumPartitions = 100
+	defaultMaxBytes      = math.MaxInt32
+)
+
+func TestFetcherSinglePartitionNoWaitFetchBeforeFirstOffsetFromZero(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 100, 10000, 10000, 1, 1, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 0, 5*time.Second, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	verifyDefaultResponse(t, resp, batches)
+}
+
+func TestFetcherSinglePartitionNoWaitFetchBeforeFirstOffsetFromNonZero(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 100, 10000, 10000, 1, 1, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 50, 5*time.Second, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	verifyDefaultResponse(t, resp, batches)
+}
+
+func TestFetcherSinglePartitionNoWaitFetchAtFirstOffset(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 100, 10000, 10000, 1, 1, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 100, 5*time.Second, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	verifyDefaultResponse(t, resp, batches)
+}
+
+func TestFetcherSinglePartitionNoWaitMultipleTablesAndBatches(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 100, 10000, 10000, 100, 10, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 0, 5*time.Second, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	verifyDefaultResponse(t, resp, batches)
+}
+
+func TestFetcherSinglePartitionNoWaitFetchAfterLastOffset(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	setupDataDefault(t, 100, 10000, 10000, 1, 1, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 10000, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// Should receive no batches
+	verifyDefaultResponse(t, resp, nil)
+}
+
+func TestFetcherSinglePartitionNoWaitFetchMuchAfterLastOffset(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	setupDataDefault(t, 100, 10000, 10000, 1, 1, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 20000, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// Should receive no batches
+	verifyDefaultResponse(t, resp, nil)
+}
+
+func TestFetcherSinglePartitionNoWaitFetchAfterBeginningOfFirstBatch(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	setupDataDefault(t, 100, 10000, 10000, 1, 1, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 101, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// If fetchOffset is greater than first offset in batch we do NOT return the batch - this is ok
+	// as the consumer wil only fetch with a fetchOffset equal to last offset + 1 so this will align with the start of
+	// next batch.
+	verifyDefaultResponse(t, resp, nil)
+}
+
+func TestFetcherSinglePartitionNoWaitFetch(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 10000, 10, 2, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 4000, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// We are fetching from offset 4000 out of offsets 0-9999, so we should not fetch the first 4 batches (0-3999)
+	verifyDefaultResponse(t, resp, batches[4:])
+}
+
+func TestFetcherSinglePartitionNoWaitFetchAfterLastReadable(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	setupDataDefault(t, 100, 10000, 99, 1, 1, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 100, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// Should receive no batches
+	verifyDefaultResponse(t, resp, nil)
+}
+
+func TestFetcherSinglePartitionNoWaitFetchWellAfterLastReadable(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	setupDataDefault(t, 100, 10000, 0, 1, 1, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 100, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// Should receive no batches
+	verifyDefaultResponse(t, resp, nil)
+}
+
+func TestFetcherSinglePartitionNoWaitFetchAlignedWithLastReadable(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 100, 10000, 10000, 1, 1, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 100, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// Should receive the batch
+	verifyDefaultResponse(t, resp, batches)
+}
+
+func TestFetcherSinglePartitionNoWaitFetchMultipleBatchesSomeAfterLastReadable(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 3999, 10, 2, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 0, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// batches 0-999, 1000-1999, 2000-2999 and 3000-3999 should be returned
+	// Note that lastReadableOffset always aligns with the last offset in a batch.
+	verifyDefaultResponse(t, resp, batches[:4])
+}
+
+func TestFetcherSinglePartitionNoWaitFetchMultipleBatchesSomeAfterLastReadableAndAfterFirstBatch(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 3999, 10, 2, topicProvider, controlClient, objStore)
+	resp := sendFetchDefault(t, 2000, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// batches 2000-2999 and 3000-3999 should be returned
+	// Note that lastReadableOffset always aligns with the last offset in a batch.
+	verifyDefaultResponse(t, resp, batches[2:4])
+}
+
+func TestFetcherSingleTopicMultiplePartitionsFetchAll(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	batches1, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 23, 1000, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	batches2, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batches3, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 25, 7000, 29999, 29999, 10, 2, topicProvider, controlClient, objStore)
+
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  0,
+		MaxBytes:  defaultMaxBytes,
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(defaultTopicName),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         24,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         25,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 23, batches1)
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 24, batches2)
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 25, batches3)
+}
+
+func TestFetcherSingleTopicMultiplePartitionsFetchPartial(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	batches1, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 23, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batches3, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 25, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  0,
+		MaxBytes:  defaultMaxBytes,
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(defaultTopicName),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         24,
+						FetchOffset:       130000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         25,
+						FetchOffset:       11000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 23, batches1[2:])
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 24, nil)
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 25, batches3[4:])
+}
+
+func TestFetcherMultipleTopicsMultiplePartitionsFetchAll(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	topicIdA := 1001
+	topicNameA := "topic-a"
+	batchesA1, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 23, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesA2, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesA3, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 25, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	topicIdB := 1002
+	topicNameB := "topic-b"
+	batchesB1, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 33, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesB2, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 34, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesB3, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 35, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	topicIdC := 1003
+	topicNameC := "topic-c"
+	batchesC1, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 43, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesC2, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 44, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesC3, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 45, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  0,
+		MaxBytes:  defaultMaxBytes,
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(topicNameA),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         24,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         25,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+			{
+				Topic: common.StrPtr(topicNameB),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         33,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         34,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         35,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+			{
+				Topic: common.StrPtr(topicNameC),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         43,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         44,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         45,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 23, batchesA1)
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 24, batchesA2)
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 25, batchesA3)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 33, batchesB1)
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 34, batchesB2)
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 35, batchesB3)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 43, batchesC1)
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 44, batchesC2)
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 45, batchesC3)
+}
+
+func TestFetcherMultipleTopicsMultiplePartitionsFetchPartial(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	topicIdA := 1001
+	topicNameA := "topic-a"
+	batchesA1, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 23, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	setupBatchesForPartition(t, topicIdA, topicNameA, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesA3, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 25, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	topicIdB := 1002
+	topicNameB := "topic-b"
+	batchesB1, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 33, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesB2, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 34, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesB3, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 35, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	topicIdC := 1003
+	topicNameC := "topic-c"
+	batchesC1, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 43, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesC2, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 44, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesC3, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 45, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  0,
+		MaxBytes:  defaultMaxBytes,
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(topicNameA),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       2000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         24,
+						FetchOffset:       13000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         25,
+						FetchOffset:       9000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+			{
+				Topic: common.StrPtr(topicNameB),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         33,
+						FetchOffset:       4000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         34,
+						FetchOffset:       0,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         35,
+						FetchOffset:       14000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+			{
+				Topic: common.StrPtr(topicNameC),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         43,
+						FetchOffset:       2000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         44,
+						FetchOffset:       5000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         45,
+						FetchOffset:       6000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 23, batchesA1[1:])
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 24, nil)
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 25, batchesA3[2:])
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 33, batchesB1[3:])
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 34, batchesB2)
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 35, batchesB3[7:])
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 43, batchesC1[1:])
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 44, batchesC2[2:])
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 45, batchesC3)
+}
+
+func TestFetcherSinglePartitionNoWaitPartitionMaxSizeExactlyFirstBatchSize(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	partitionMaxBytes := len(batches[0])
+	resp := sendFetchDefault(t, 0, 0, 0, defaultMaxBytes, partitionMaxBytes, fetcher)
+	// Only first batch should be fetched
+	verifyDefaultResponse(t, resp, batches[:1])
+}
+
+func TestFetcherSinglePartitionNoWaitPartitionMaxSizeSlightlyLessThanFirstBatchSize(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	partitionMaxBytes := len(batches[0]) - 1
+	resp := sendFetchDefault(t, 0, 0, 0, defaultMaxBytes, partitionMaxBytes, fetcher)
+	// No batches should be fetched
+	verifyDefaultResponse(t, resp, nil)
+}
+
+func TestFetcherSinglePartitionNoWaitPartitionMaxSizeExactlyFirstTwoBatchSizes(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	partitionMaxBytes := len(batches[0]) + len(batches[1])
+	resp := sendFetchDefault(t, 0, 0, 0, defaultMaxBytes, partitionMaxBytes, fetcher)
+	// First two batches should be fetched
+	verifyDefaultResponse(t, resp, batches[:2])
+}
+
+func TestFetcherSinglePartitionNoWaitPartitionMaxSizeSlightlyMoreThanTwoBatchSizes(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	partitionMaxBytes := len(batches[0]) + len(batches[1]) + 1
+	resp := sendFetchDefault(t, 0, 0, 0, defaultMaxBytes, partitionMaxBytes, fetcher)
+	// First two batches should be fetched
+	verifyDefaultResponse(t, resp, batches[:2])
+}
+
+func TestFetcherSingleTopicMultiplePartitionsNoWaitPartitionMax(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	batches1, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 23, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batches2, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batches3, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 25, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  0,
+		MaxBytes:  defaultMaxBytes,
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(defaultTopicName),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       1000,
+						PartitionMaxBytes: int32(len(batches1[0]) - 1),
+					},
+					{
+						Partition:         24,
+						FetchOffset:       3000,
+						PartitionMaxBytes: int32(len(batches2[0]) + len(batches2[1]) + len(batches2[2])),
+					},
+					{
+						Partition:         25,
+						FetchOffset:       7000,
+						PartitionMaxBytes: int32(len(batches3[0]) + len(batches3[1]) + len(batches3[2]) + len(batches3[3]) + 1),
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 23, nil)
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 24, batches2[:3])
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 25, batches3[:4])
+}
+
+func TestFetcherSinglePartitionNoWaitRequestMaxSizeExceeded(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	maxBytes := len(batches[0]) + len(batches[1]) + 1
+	resp := sendFetchDefault(t, 0, 0, 0, maxBytes, defaultMaxBytes, fetcher)
+	// First two batches should be fetched
+	verifyDefaultResponse(t, resp, batches[:2])
+}
+
+func TestFetcherSingleTopicMultiplePartitionsNoWaitRequestMaxSizeExceeded(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	batches1, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 23, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 25, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	maxBytes := len(batches1[0]) * 5
+
+	// The order in which partitions are fetched is not deterministic so we just validate total max size
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  0,
+		MaxBytes:  int32(maxBytes),
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(defaultTopicName),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         24,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         25,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	totSize := 0
+	for _, topicResp := range resp.Responses {
+		for _, partResp := range topicResp.Partitions {
+			require.Equal(t, kafkaprotocol.ErrorCodeNone, int(partResp.ErrorCode))
+			for _, rec := range partResp.Records {
+				totSize += len(rec)
+			}
+		}
+	}
+	// Should be exactly equal as our max size is in multiples of batches
+	require.Equal(t, totSize, maxBytes)
+}
+
+func TestFetcherSinglePartitionNoWaitAndMinBytesExactlyReached(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	totBatchSizes := 0
+	for _, batch := range batches {
+		totBatchSizes += len(batch)
+	}
+	resp := sendFetchDefault(t, 0, 0, totBatchSizes, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// All batches should be fetched
+	verifyDefaultResponse(t, resp, batches)
+}
+
+func TestFetcherSinglePartitionNoWaitAndMinBytesNotReached(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	totBatchSizes := 0
+	for _, batch := range batches {
+		totBatchSizes += len(batch)
+	}
+	resp := sendFetchDefault(t, 0, 0, totBatchSizes+1, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// No batches should be fetched
+	verifyDefaultResponse(t, resp, nil)
+}
+
+func TestFetcherSinglePartitionMoreThanMinBytesReached(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	totBatchSizes := 0
+	for _, batch := range batches {
+		totBatchSizes += len(batch)
+	}
+	resp := sendFetchDefault(t, 0, 0, totBatchSizes-1, defaultMaxBytes, defaultMaxBytes, fetcher)
+	// All batches should be fetched
+	verifyDefaultResponse(t, resp, batches)
+}
+
+func TestFetcherSinglePartitionMinBytesNotReachedMultiplePartitions(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	batches1, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 23, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batches2, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batches3, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 25, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	totSize := 0
+	for _, batch := range batches1 {
+		totSize += len(batch)
+	}
+	for _, batch := range batches2 {
+		totSize += len(batch)
+	}
+	for _, batch := range batches3 {
+		totSize += len(batch)
+	}
+
+	// The order in which partitions are fetched is not deterministic so we just validate total max size
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  int32(totSize + 1),
+		MaxBytes:  defaultMaxBytes,
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(defaultTopicName),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         24,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         25,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	// No batches should be returned
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 23, nil)
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 24, nil)
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 25, nil)
+}
+
+func TestFetcherSinglePartitionMinBytesReachedExactlyMultiplePartitions(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	batches1, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 23, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batches2, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batches3, _ := setupBatchesForPartition(t, defaultTopicID, defaultTopicName, 25, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+
+	totSize := 0
+	for _, batch := range batches1 {
+		totSize += len(batch)
+	}
+	for _, batch := range batches2 {
+		totSize += len(batch)
+	}
+	for _, batch := range batches3 {
+		totSize += len(batch)
+	}
+
+	// The order in which partitions are fetched is not deterministic so we just validate total max size
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  int32(totSize),
+		MaxBytes:  defaultMaxBytes,
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(defaultTopicName),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         24,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         25,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	// No batches should be returned
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 23, batches1)
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 24, batches2)
+	verifyPartitionRecordsInResponse(t, resp, defaultTopicName, 25, batches3)
+}
+
+func TestFetcherMinBytesNotReachedMultipleTopicsMultiplePartitions(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	var allBatches [][]byte
+
+	topicIdA := 1001
+	topicNameA := "topic-a"
+	batchesA1, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 23, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesA2, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesA3, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 25, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+	allBatches = append(allBatches, batchesA1...)
+	allBatches = append(allBatches, batchesA2...)
+	allBatches = append(allBatches, batchesA3...)
+
+	topicIdB := 1002
+	topicNameB := "topic-b"
+	batchesB1, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 33, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesB2, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 34, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesB3, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 35, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+	allBatches = append(allBatches, batchesB1...)
+	allBatches = append(allBatches, batchesB2...)
+	allBatches = append(allBatches, batchesB3...)
+
+	topicIdC := 1003
+	topicNameC := "topic-c"
+	batchesC1, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 43, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesC2, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 44, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesC3, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 45, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+	allBatches = append(allBatches, batchesC1...)
+	allBatches = append(allBatches, batchesC2...)
+	allBatches = append(allBatches, batchesC3...)
+
+	totSize := 0
+	for _, batch := range allBatches {
+		totSize += len(batch)
+	}
+
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  int32(totSize + 1),
+		MaxBytes:  defaultMaxBytes,
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(topicNameA),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         24,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         25,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+			{
+				Topic: common.StrPtr(topicNameB),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         33,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         34,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         35,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+			{
+				Topic: common.StrPtr(topicNameC),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         43,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         44,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         45,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 23, nil)
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 24, nil)
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 25, nil)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 33, nil)
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 34, nil)
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 35, nil)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 43, nil)
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 44, nil)
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 45, nil)
+}
+
+func TestFetcherMinBytesExactlyReachedMultipleTopicsMultiplePartitions(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+
+	var allBatches [][]byte
+
+	topicIdA := 1001
+	topicNameA := "topic-a"
+	batchesA1, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 23, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesA2, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 24, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesA3, _ := setupBatchesForPartition(t, topicIdA, topicNameA, 25, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+	allBatches = append(allBatches, batchesA1...)
+	allBatches = append(allBatches, batchesA2...)
+	allBatches = append(allBatches, batchesA3...)
+
+	topicIdB := 1002
+	topicNameB := "topic-b"
+	batchesB1, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 33, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesB2, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 34, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesB3, _ := setupBatchesForPartition(t, topicIdB, topicNameB, 35, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+	allBatches = append(allBatches, batchesB1...)
+	allBatches = append(allBatches, batchesB2...)
+	allBatches = append(allBatches, batchesB3...)
+
+	topicIdC := 1003
+	topicNameC := "topic-c"
+	batchesC1, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 43, 1000, 10999, 10999, 10, 2, topicProvider, controlClient, objStore)
+	batchesC2, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 44, 3000, 12999, 12999, 10, 2, topicProvider, controlClient, objStore)
+	batchesC3, _ := setupBatchesForPartition(t, topicIdC, topicNameC, 45, 7000, 16999, 16999, 10, 2, topicProvider, controlClient, objStore)
+	allBatches = append(allBatches, batchesC1...)
+	allBatches = append(allBatches, batchesC2...)
+	allBatches = append(allBatches, batchesC3...)
+
+	totSize := 0
+	for _, batch := range allBatches {
+		totSize += len(batch)
+	}
+
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 0,
+		MinBytes:  int32(totSize),
+		MaxBytes:  defaultMaxBytes,
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(topicNameA),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         23,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         24,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         25,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+			{
+				Topic: common.StrPtr(topicNameB),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         33,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         34,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         35,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+			{
+				Topic: common.StrPtr(topicNameC),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         43,
+						FetchOffset:       1000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         44,
+						FetchOffset:       3000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+					{
+						Partition:         45,
+						FetchOffset:       7000,
+						PartitionMaxBytes: defaultMaxBytes,
+					},
+				},
+			},
+		},
+	}
+	resp := sendFetch(t, &req, fetcher)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 23, batchesA1)
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 24, batchesA2)
+	verifyPartitionRecordsInResponse(t, resp, topicNameA, 25, batchesA3)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 33, batchesB1)
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 34, batchesB2)
+	verifyPartitionRecordsInResponse(t, resp, topicNameB, 35, batchesB3)
+
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 43, batchesC1)
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 44, batchesC2)
+	verifyPartitionRecordsInResponse(t, resp, topicNameC, 45, batchesC3)
+}
+
+func TestFetcherSinglePartitionMinBytesNotReachedTimeout(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 9999, 9999, 10, 2, topicProvider, controlClient, objStore)
+	totBatchSizes := 0
+	for _, batch := range batches {
+		totBatchSizes += len(batch)
+	}
+	timeout := 100 * time.Millisecond
+	start := time.Now()
+	resp := sendFetchDefault(t, 0, timeout, totBatchSizes+1, defaultMaxBytes, defaultMaxBytes, fetcher)
+	dur := time.Since(start)
+	require.GreaterOrEqual(t, dur, timeout)
+	// No batches should be fetched
+	verifyDefaultResponse(t, resp, nil)
+}
+
+func TestFetcherMultipleRequestsFetchFromCacheAfterFirstRequest(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, tabIDs := setupDataDefault(t, 0, 9999, 9999, 10, 10, topicProvider, controlClient, objStore)
+	totBatchSizes := 0
+	for _, batch := range batches {
+		totBatchSizes += len(batch)
+	}
+
+	resp := sendFetchDefault(t, 0, 0, 0, len(batches[0]), defaultMaxBytes, fetcher)
+
+	verifyDefaultResponse(t, resp, batches[0:1])
+
+	// send notification - should result in entry added to recent tables
+	// we add the first two tables
+	err := fetcher.recentTables.handleTableRegisteredNotification(TableRegisteredNotification{
+		ID: tabIDs[0],
+		PartitionReadableOffsets: map[int]map[int]int64{
+			defaultTopicID: {
+				defaultPartitionID: 999,
+			},
+		},
+	})
+	require.NoError(t, err)
+	err = fetcher.recentTables.handleTableRegisteredNotification(TableRegisteredNotification{
+		ID: tabIDs[1],
+		PartitionReadableOffsets: map[int]map[int]int64{
+			defaultTopicID: {
+				defaultPartitionID: 1999,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// reset ids from testControllerClient so won't fetch from controller
+	controlClient.queryRes = nil
+
+	// should fetch from recent tables
+	resp = sendFetchDefault(t, 1000, 0, 0, len(batches[1]), defaultMaxBytes, fetcher)
+	verifyDefaultResponse(t, resp, batches[1:2])
+
+	// Now add the rest to the cache
+	tabsToAdd := tabIDs[2:]
+	lros := []int64{2999, 3999, 4999, 5999, 6999, 7999, 8999, 9999}
+	for i, tabID := range tabsToAdd {
+		err = fetcher.recentTables.handleTableRegisteredNotification(TableRegisteredNotification{
+			ID: tabID,
+			PartitionReadableOffsets: map[int]map[int]int64{
+				defaultTopicID: {
+					defaultPartitionID: lros[i],
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+	// And get then one by one in different requests
+	offset := 2000
+	for i := 2; i < len(batches); i++ {
+		resp = sendFetchDefault(t, offset, 0, 0, len(batches[i]), defaultMaxBytes, fetcher)
+		verifyDefaultResponse(t, resp, batches[i:i+1])
+		offset += 1000
+	}
+
+	// Try and get another - shouldn't get anything
+	resp = sendFetchDefault(t, offset, 0, 0, defaultMaxBytes, defaultMaxBytes, fetcher)
+	verifyDefaultResponse(t, resp, nil)
+}
+
+func TestFetcherRequestNotEnoughBytesAndNotificationAddsSufficientData(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches, _ := setupDataDefault(t, 0, 999, 999, 1, 1, topicProvider, controlClient, objStore)
+
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 1000000,
+		MinBytes:  int32(len(batches[0]) + 1), // just too much
+		MaxBytes:  int32(defaultMaxBytes),
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(defaultTopicName),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         int32(defaultPartitionID),
+						FetchOffset:       0,
+						PartitionMaxBytes: int32(defaultMaxBytes),
+					},
+				},
+			},
+		},
+	}
+	var completionCalled atomic.Bool
+	resCh := make(chan *kafkaprotocol.FetchResponse, 1)
+	err := fetcher.HandleFetchRequest(&req, func(resp *kafkaprotocol.FetchResponse) error {
+		completionCalled.Store(true)
+		resCh <- resp
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Should wait, not complete yet
+	time.Sleep(100 * time.Millisecond)
+	require.False(t, completionCalled.Load())
+
+	batches2, tabIDs2 := setupDataDefault(t, 1000, 1999, 1999, 1, 1, topicProvider, controlClient, objStore)
+
+	// reset ids on controller client so no remote query can be served
+	controlClient.queryRes = nil
+
+	// send notification - should result in entry added to recent tables
+	// we add the first two tables
+	err = fetcher.recentTables.handleTableRegisteredNotification(TableRegisteredNotification{
+		ID: tabIDs2[0],
+		PartitionReadableOffsets: map[int]map[int]int64{
+			defaultTopicID: {
+				defaultPartitionID: 1999,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Now response should complete, and both batches should be received
+	resp := <-resCh
+
+	totBatches := append(batches, batches2[0])
+	verifyDefaultResponse(t, resp, totBatches)
+}
+
+func TestFetcherRequestNotEnoughBytesAndNotificationsDontAddSufficientData(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	batches1, _ := setupDataDefault(t, 0, 999, 999, 1, 1, topicProvider, controlClient, objStore)
+
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: 1000000,
+		// MinBytes is such that won't reach minBytes until all batches are added to cache
+		MinBytes: int32(3*len(batches1[0]) + 1),
+		MaxBytes: int32(defaultMaxBytes),
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(defaultTopicName),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         int32(defaultPartitionID),
+						FetchOffset:       0,
+						PartitionMaxBytes: int32(defaultMaxBytes),
+					},
+				},
+			},
+		},
+	}
+
+	var completionCalled atomic.Bool
+	resCh := make(chan *kafkaprotocol.FetchResponse, 1)
+	err := fetcher.HandleFetchRequest(&req, func(resp *kafkaprotocol.FetchResponse) error {
+		completionCalled.Store(true)
+		resCh <- resp
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Should wait, not complete yet
+	time.Sleep(100 * time.Millisecond)
+	require.False(t, completionCalled.Load())
+
+	batches2, tabIds2 := setupDataDefault(t, 1000, 1999, 1999, 1, 1, topicProvider, controlClient, objStore)
+	batches3, tabIds3 := setupDataDefault(t, 2000, 2999, 2999, 1, 1, topicProvider, controlClient, objStore)
+	batches4, tabIds4 := setupDataDefault(t, 3000, 3999, 3999, 1, 1, topicProvider, controlClient, objStore)
+
+	// reset ids on controller client so no remote query can be served
+	controlClient.queryRes = nil
+
+	// send notification - with second batch - not enough data so shouldn't complete yet
+	err = fetcher.recentTables.handleTableRegisteredNotification(TableRegisteredNotification{
+		ID: tabIds2[0],
+		PartitionReadableOffsets: map[int]map[int]int64{
+			defaultTopicID: {
+				defaultPartitionID: 1999,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Should wait, not complete yet
+	require.False(t, completionCalled.Load())
+
+	// send notification - with third batch - not enough data so shouldn't complete yet
+	err = fetcher.recentTables.handleTableRegisteredNotification(TableRegisteredNotification{
+		ID: tabIds3[0],
+		PartitionReadableOffsets: map[int]map[int]int64{
+			defaultTopicID: {
+				defaultPartitionID: 2999,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Should wait, not complete yet
+	require.False(t, completionCalled.Load())
+
+	// send notification - with fourth batch - should now complete
+	err = fetcher.recentTables.handleTableRegisteredNotification(TableRegisteredNotification{
+		ID: tabIds4[0],
+		PartitionReadableOffsets: map[int]map[int]int64{
+			defaultTopicID: {
+				defaultPartitionID: 3999,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Now response should complete, and all batches should be received
+	resp := <-resCh
+
+	totBatches := append(batches1, append(batches2, append(batches3, batches4...)...)...)
+	verifyDefaultResponse(t, resp, totBatches)
+}
+
+func TestFetcherHistoricConsumer(t *testing.T) {
+	fetcher, topicProvider, controlClient, objStore := setupFetcher(t)
+	defer stopFetcher(t, fetcher)
+	// Setup a bunch of batches
+	batches, tabIDs := setupDataDefault(t, 0, 9999, 9999, 10, 10, topicProvider, controlClient, objStore)
+	totBatchSizes := 0
+	for _, batch := range batches {
+		totBatchSizes += len(batch)
+	}
+
+	// Add just the last two to the cache - this simulates the case where we have older batches in storage but only
+	// newer ones cached
+	err := fetcher.recentTables.handleTableRegisteredNotification(TableRegisteredNotification{
+		ID: tabIDs[8],
+		PartitionReadableOffsets: map[int]map[int]int64{
+			defaultTopicID: {
+				defaultPartitionID: 8999,
+			},
+		},
+	})
+	require.NoError(t, err)
+	err = fetcher.recentTables.handleTableRegisteredNotification(TableRegisteredNotification{
+		ID: tabIDs[9],
+		PartitionReadableOffsets: map[int]map[int]int64{
+			defaultTopicID: {
+				defaultPartitionID: 9999,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Now fetch in batches of 10 - first 9 requests should go to the controller, last one should be served from the cache
+	offset := 0
+	for i := 0; i < 10; i++ {
+		if i == 9 {
+			// last one must be served from cache sao we set ids to nil to prevent any request to controller succeeding
+			controlClient.queryRes = nil
+		}
+		resp := sendFetchDefault(t, offset, 0, 0, len(batches[i]), defaultMaxBytes, fetcher)
+		verifyDefaultResponse(t, resp, batches[i:i+1])
+		offset += 1000
+	}
+}
+
+func setupFetcher(t *testing.T) (*BatchFetcher, *testTopicProvider, *testControlClient, objstore.Client) {
+	objStore := dev.NewInMemStore(0)
+	infoProvider := &testTopicProvider{infos: map[string]topicmeta.TopicInfo{}}
+	partHashes, err := parthash.NewPartitionHashes(0)
+	require.NoError(t, err)
+	getter := &testTableGetter{
+		bucketName: databucketName,
+		objStore:   objStore,
+	}
+	controlClient := newtestControlClient()
+	controlFactory := func() (ControlClient, error) {
+		return controlClient, nil
+	}
+	cfg := NewConf()
+	cfg.DataBucketName = databucketName
+	fetcher, err := NewBatchFetcher(objStore, infoProvider, partHashes, controlFactory, getter.getSSTable, cfg)
+	require.NoError(t, err)
+	err = fetcher.Start()
+	require.NoError(t, err)
+	return fetcher, infoProvider, controlClient, objStore
+}
+
+func setupTable(t *testing.T, batchInfos []partitionBatchInfo, objStore objstore.Client, bucketName string) (sst.SSTableID, [][]byte) {
+	partHashes, err := parthash.NewPartitionHashes(len(batchInfos))
+	require.NoError(t, err)
+	var kvs []common.KV
+	var batches [][]byte
+	for _, info := range batchInfos {
+		prefix, err := partHashes.GetPartitionHash(info.topicID, info.partitionID)
+		require.NoError(t, err)
+		key := make([]byte, 0, 24)
+		key = append(key, prefix...)
+		key = encoding.KeyEncodeInt(key, info.offsetStart)
+		key = encoding.EncodeVersion(key, 0)
+		batch := testutils.CreateKafkaRecordBatchWithIncrementingKVs(int(info.offsetStart), info.numRecords)
+		batches = append(batches, batch)
+		kvs = append(kvs, common.KV{
+			Key:   key,
+			Value: batch,
+		})
+	}
+	sort.SliceStable(kvs, func(i, j int) bool {
+		return bytes.Compare(kvs[i].Key, kvs[j].Key) < 0
+	})
+	iter := common.NewKvSliceIterator(kvs)
+	table, _, _, _, _, err := sst.BuildSSTable(common.DataFormatV1, 0, 0, iter)
+	require.NoError(t, err)
+	tableID := sst.CreateSSTableId()
+	tableData := table.Serialize()
+	err = objStore.Put(context.Background(), bucketName, tableID, tableData)
+	require.NoError(t, err)
+	return []byte(tableID), batches
+}
+
+type partitionBatchInfo struct {
+	topicID     int
+	partitionID int
+	offsetStart int64
+	numRecords  int
+}
+
+func setupDataDefault(t *testing.T, firstOffset int, lastOffset int, lastReadableOffset int, numBatches int,
+	numTables int, topicProvider *testTopicProvider, controlClient *testControlClient, objStore objstore.Client) ([][]byte, []sst.SSTableID) {
+	return setupBatchesForPartition(t, defaultTopicID, defaultTopicName, defaultPartitionID, firstOffset, lastOffset, lastReadableOffset, numBatches, numTables, topicProvider, controlClient, objStore)
+}
+
+func setupBatchesForPartition(t *testing.T, topicID int, topicName string, partitionID int, firstOffset int, lastOffset int, lastReadableOffset int, numBatches int,
+	numTables int, topicProvider *testTopicProvider, controlClient *testControlClient, objStore objstore.Client) ([][]byte, []sst.SSTableID) {
+	topicProvider.infos[topicName] = topicmeta.TopicInfo{
+		ID:             topicID,
+		Name:           topicName,
+		PartitionCount: defaultNumPartitions,
+	}
+	numRecords := lastOffset - firstOffset + 1
+	numRecordsPerBatch := numRecords / numBatches
+	offset := firstOffset
+	var batchInfos []partitionBatchInfo
+	for i := 0; i < numBatches; i++ {
+		batchInfos = append(batchInfos, partitionBatchInfo{
+			topicID:     topicID,
+			partitionID: partitionID,
+			offsetStart: int64(offset),
+			numRecords:  numRecordsPerBatch,
+		})
+		offset += numRecordsPerBatch
+	}
+	if len(batchInfos) != numBatches {
+		panic("num records must be divisible by num batches")
+	}
+	if numBatches%numTables != 0 {
+		panic("num batches must be divisible by num tables")
+	}
+	var tabIDs []sst.SSTableID
+	var ids lsm.OverlappingTables
+	var totBatches [][]byte
+	numBatchesPerTable := numBatches / numTables
+	var tableInfos []partitionBatchInfo
+	for i, batchInfo := range batchInfos {
+		tableInfos = append(tableInfos, batchInfo)
+		if (i+1)%numBatchesPerTable == 0 {
+
+			tableID, batches := setupTable(t, tableInfos, objStore, databucketName)
+			tabIDs = append(tabIDs, tableID)
+			ids = append(ids, lsm.NonOverlappingTables{{ID: tableID}})
+			totBatches = append(totBatches, batches...)
+			tableInfos = nil
+		}
+	}
+	require.Equal(t, numBatches, len(totBatches))
+	controlClient.queryRes = append(controlClient.queryRes, ids...)
+	controlClient.setLastReadableOffset(topicID, partitionID, int64(lastReadableOffset))
+	return totBatches, tabIDs
+}
+
+func sendFetchDefault(t *testing.T, fetchOffset int, maxWait time.Duration, minBytes int, maxBytes int, partitionMaxBytes int, fetcher *BatchFetcher) *kafkaprotocol.FetchResponse {
+	return sendFetchRequest(t, defaultTopicName, defaultPartitionID, fetchOffset, maxWait, minBytes, maxBytes, partitionMaxBytes, fetcher)
+}
+
+func sendFetchRequest(t *testing.T, topicName string, partitionID int, fetchOffset int, maxWait time.Duration, minBytes int, maxBytes int, partitionMaxBytes int, fetcher *BatchFetcher) *kafkaprotocol.FetchResponse {
+	req := kafkaprotocol.FetchRequest{
+		MaxWaitMs: int32(maxWait.Milliseconds()),
+		MinBytes:  int32(minBytes),
+		MaxBytes:  int32(maxBytes),
+		Topics: []kafkaprotocol.FetchRequestFetchTopic{
+			{
+				Topic: common.StrPtr(topicName),
+				Partitions: []kafkaprotocol.FetchRequestFetchPartition{
+					{
+						Partition:         int32(partitionID),
+						FetchOffset:       int64(fetchOffset),
+						PartitionMaxBytes: int32(partitionMaxBytes),
+					},
+				},
+			},
+		},
+	}
+	return sendFetch(t, &req, fetcher)
+}
+
+func sendFetch(t *testing.T, req *kafkaprotocol.FetchRequest, fetcher *BatchFetcher) *kafkaprotocol.FetchResponse {
+	ch := make(chan *kafkaprotocol.FetchResponse, 1)
+	err := fetcher.HandleFetchRequest(req, func(resp *kafkaprotocol.FetchResponse) error {
+		ch <- resp
+		return nil
+	})
+	require.NoError(t, err)
+	return <-ch
+}
+
+func stopFetcher(t *testing.T, fetcher *BatchFetcher) {
+	err := fetcher.Stop()
+	require.NoError(t, err)
+}
+
+func verifyDefaultResponse(t *testing.T, resp *kafkaprotocol.FetchResponse, batches [][]byte) {
+	verifySinglePartitionResponse(t, resp, defaultTopicName, defaultPartitionID, batches)
+}
+
+func verifySinglePartitionResponse(t *testing.T, resp *kafkaprotocol.FetchResponse, topicName string, partitionID int, batches [][]byte) {
+	require.Equal(t, 1, len(resp.Responses))
+	topicResp := resp.Responses[0]
+	require.Equal(t, topicName, *topicResp.Topic)
+	require.Equal(t, 1, len(topicResp.Partitions))
+	partitionResp := topicResp.Partitions[0]
+	require.Equal(t, partitionID, int(partitionResp.PartitionIndex))
+	require.Equal(t, kafkaprotocol.ErrorCodeNone, int(partitionResp.ErrorCode))
+	require.Equal(t, len(batches), len(partitionResp.Records))
+	require.Equal(t, batches, partitionResp.Records)
+}
+
+func verifyPartitionRecordsInResponse(t *testing.T, resp *kafkaprotocol.FetchResponse, topicName string, partitionID int, batches [][]byte) {
+	var tResp *kafkaprotocol.FetchResponseFetchableTopicResponse
+	for _, topicResp := range resp.Responses {
+		if *topicResp.Topic == topicName {
+			tResp = &topicResp
+		}
+	}
+	require.NotNil(t, tResp)
+	partResps := map[int]*kafkaprotocol.FetchResponsePartitionData{}
+	for _, partResp := range tResp.Partitions {
+		partResps[int(partResp.PartitionIndex)] = &partResp
+	}
+	partResp, ok := partResps[partitionID]
+	require.True(t, ok)
+	require.Equal(t, kafkaprotocol.ErrorCodeNone, int(partResp.ErrorCode))
+	require.Equal(t, len(batches), len(partResp.Records))
+}
+
+func newtestControlClient() *testControlClient {
+	return &testControlClient{
+		lastReadableOffsets: map[int]map[int]int64{},
+	}
+}
+
+type testControlClient struct {
+	queryRes            lsm.OverlappingTables
+	lastReadableOffsets map[int]map[int]int64
+}
+
+func (t *testControlClient) FetchTablesForPrefix(topicID int, partitionID int, prefix []byte, offsetStart int64) (lsm.OverlappingTables, int64, error) {
+	partMap, ok := t.lastReadableOffsets[topicID]
+	if !ok {
+		return nil, 0, errors.Errorf("unknown topic: %d", topicID)
+	}
+	off, ok := partMap[partitionID]
+	if !ok {
+		return nil, 0, errors.Errorf("unknown partition: %d", partitionID)
+	}
+	return t.queryRes, off, nil
+}
+
+func (t *testControlClient) setLastReadableOffset(topicID int, partitionID int, offset int64) {
+	partMap, ok := t.lastReadableOffsets[topicID]
+	if !ok {
+		partMap = map[int]int64{}
+		t.lastReadableOffsets[topicID] = partMap
+	}
+	partMap[partitionID] = offset
+}
+
+func (t *testControlClient) Close() error {
+	return nil
+}
+
+type testTableGetter struct {
+	bucketName string
+	objStore   objstore.Client
+}
+
+func (t *testTableGetter) getSSTable(id sst.SSTableID) (*sst.SSTable, error) {
+	buff, err := t.objStore.Get(context.Background(), t.bucketName, string(id))
+	if err != nil {
+		return nil, err
+	}
+	if len(buff) == 0 {
+		return nil, errors.New("table not found")
+	}
+	var table sst.SSTable
+	table.Deserialize(buff, 0)
+	return &table, nil
+}
+
+type testTopicProvider struct {
+	infos map[string]topicmeta.TopicInfo
+}
+
+func (t *testTopicProvider) GetTopicInfo(topicName string) (topicmeta.TopicInfo, error) {
+	info, ok := t.infos[topicName]
+	if !ok {
+		return topicmeta.TopicInfo{}, errors.Errorf("unknown topic: %s", topicName)
+	}
+	return info, nil
+}
+
+func checkNoResponseErrors(t *testing.T, respCh chan *kafkaprotocol.FetchResponse, req *kafkaprotocol.FetchRequest) *kafkaprotocol.FetchResponse {
+	resp := <-respCh
+	require.NotNil(t, resp)
+	require.Equal(t, len(req.Topics), len(resp.Responses))
+	for i, topicResp := range resp.Responses {
+		require.Equal(t, len(req.Topics[i].Partitions), len(topicResp.Partitions))
+		for _, pResp := range topicResp.Partitions {
+			require.Equalf(t, kafkaprotocol.ErrorCodeNone, int(pResp.ErrorCode),
+				"expected no error but got errorCode: %d", pResp.ErrorCode)
+		}
+	}
+	return resp
+}
+
+func checkResponseErrors(t *testing.T, respCh chan *kafkaprotocol.FetchResponse, expectedCodes [][]int) {
+	resp := <-respCh
+	require.NotNil(t, resp)
+	require.Equal(t, len(expectedCodes), len(resp.Responses))
+	for i, topicResp := range resp.Responses {
+		require.Equal(t, len(expectedCodes[i]), len(topicResp.Partitions))
+		for j, pResp := range topicResp.Partitions {
+			var errMsg string
+			expectedCode := expectedCodes[i][j]
+			require.Equalf(t, expectedCode, int(pResp.ErrorCode),
+				"expected errorCode: %d but got: %dmsg: %s", expectedCode, pResp.ErrorCode, errMsg)
+		}
+	}
+}

--- a/fetcher/local_cache.go
+++ b/fetcher/local_cache.go
@@ -1,0 +1,49 @@
+package fetcher
+
+import (
+	"github.com/dgraph-io/ristretto"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/sst"
+)
+
+/*
+LocalSSTCache caches the most recently retrieved SSTables locally. When there are multiple fetch requests for different
+partitions being processed around the same time on an agent, and those fetch requests are for recently produced data,
+it's likely that the data for multiple partitions lives in the same recently pushed SSTables. Without a local SSTable
+cache, each fetcher would independently pull SSTables from the distributed fetch cache which would often result in
+remote calls. To make this more efficient we cache a reasonably small number of the most recently retrieved SSTables
+locally on the agent, so that recent fetchers can retrieve them from there rather than making duplicate remote calls.
+*/
+type LocalSSTCache struct {
+	cache *ristretto.Cache
+}
+
+func NewLocalSSTCache(maxTablesEstimate int, maxSizeBytes int) (*LocalSSTCache, error) {
+	cache, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters: int64(10 * maxTablesEstimate),
+		MaxCost:     int64(maxSizeBytes),
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &LocalSSTCache{
+		cache: cache,
+	}, nil
+}
+
+func (m *LocalSSTCache) Put(key sst.SSTableID, value *sst.SSTable) bool {
+	sKey := common.ByteSliceToStringZeroCopy(key)
+	ok := m.cache.Set(sKey, value, int64(value.SizeBytes()))
+	m.cache.Wait()
+	return ok
+}
+
+func (m *LocalSSTCache) Get(key sst.SSTableID) (*sst.SSTable, bool) {
+	sKey := common.ByteSliceToStringZeroCopy(key)
+	v, ok := m.cache.Get(sKey)
+	if !ok {
+		return nil, false
+	}
+	return v.(*sst.SSTable), true
+}

--- a/fetcher/local_cache.go
+++ b/fetcher/local_cache.go
@@ -34,9 +34,7 @@ func NewLocalSSTCache(maxTablesEstimate int, maxSizeBytes int) (*LocalSSTCache, 
 
 func (m *LocalSSTCache) Put(key sst.SSTableID, value *sst.SSTable) bool {
 	sKey := common.ByteSliceToStringZeroCopy(key)
-	ok := m.cache.Set(sKey, value, int64(value.SizeBytes()))
-	m.cache.Wait()
-	return ok
+	return m.cache.Set(sKey, value, int64(value.SizeBytes()))
 }
 
 func (m *LocalSSTCache) Get(key sst.SSTableID) (*sst.SSTable, bool) {

--- a/fetcher/local_cache_test.go
+++ b/fetcher/local_cache_test.go
@@ -1,0 +1,44 @@
+package fetcher
+
+import (
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/sst"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestLocalCache(t *testing.T) {
+	localCache, err := NewLocalSSTCache(100, 32*1024*1024)
+	require.NoError(t, err)
+
+	entriesMap := map[string]*sst.SSTable{}
+
+	numEntries := 100
+	for i := 0; i < numEntries; i++ {
+		entriesMap[uuid.New().String()] = &sst.SSTable{}
+	}
+
+	for id, table := range entriesMap {
+		bid := []byte(id)
+		localCache.Put(bid, table)
+		tab, ok := localCache.Get(bid)
+		require.True(t, ok)
+		require.Equal(t, table, tab)
+	}
+}
+
+func BenchmarkLocalCache(b *testing.B) {
+
+	localCache, err := NewLocalSSTCache(100, 64*1024*1024)
+	require.NoError(b, err)
+
+	var keys [][]byte
+	for i := 0; i < 100; i++ {
+		keys = append(keys, []byte(uuid.New().String()))
+	}
+
+	for i := 0; i < b.N; i++ {
+		key := keys[i%100]
+		localCache.Put(key, &sst.SSTable{})
+	}
+}

--- a/fetcher/local_cache_test.go
+++ b/fetcher/local_cache_test.go
@@ -21,6 +21,7 @@ func TestLocalCache(t *testing.T) {
 	for id, table := range entriesMap {
 		bid := []byte(id)
 		localCache.Put(bid, table)
+		localCache.cache.Wait()
 		tab, ok := localCache.Get(bid)
 		require.True(t, ok)
 		require.Equal(t, table, tab)

--- a/fetcher/recent_tables.go
+++ b/fetcher/recent_tables.go
@@ -167,12 +167,12 @@ func (p *PartitionRecentTables) unregisterPartitionStates(partitionStates map[in
 	for topicID, partitionFetchStates := range partitionStates {
 		partitionMap, ok := p.topicMap[topicID]
 		if !ok {
-			panic("topic not registered")
+			continue
 		}
 		for partitionID, partitionFetchState := range partitionFetchStates {
 			partitionTables, ok := partitionMap[partitionID]
 			if !ok {
-				panic("partition not registered")
+				continue
 			}
 			partitionTables.removeListener(partitionFetchState)
 		}

--- a/fetcher/recent_tables.go
+++ b/fetcher/recent_tables.go
@@ -1,0 +1,243 @@
+package fetcher
+
+import (
+	"github.com/spirit-labs/tektite/sst"
+	"sync"
+)
+
+type PartitionRecentTables struct {
+	lock                   sync.RWMutex
+	topicMap               map[int]map[int]*PartitionTables
+	maxEntriesPerPartition int
+}
+
+func CreatePartitionRecentTables(maxEntriesPerPartition int) PartitionRecentTables {
+	return PartitionRecentTables{
+		topicMap:               make(map[int]map[int]*PartitionTables),
+		maxEntriesPerPartition: maxEntriesPerPartition,
+	}
+}
+
+type PartitionTables struct {
+	lock                   sync.RWMutex
+	maxEntriesPerPartition int
+	entries                []RecentTableEntry
+	listeners              []*PartitionFetchState
+}
+
+func (p *PartitionRecentTables) getPartitionTables(topicID int, partitionID int) *PartitionTables {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	partitionMap, ok := p.topicMap[topicID]
+	if !ok {
+		partitionMap = p.createPartitionMap(topicID)
+	}
+	partitionTables, ok := partitionMap[partitionID]
+	if !ok {
+		partitionTables = p.createPartitionTables(partitionID, partitionMap)
+	}
+	return partitionTables
+}
+
+func (p *PartitionTables) getCacheTables(fetchOffset int64) ([]*sst.SSTableID, int64) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	if len(p.entries) == 0 {
+		return nil, 0
+	}
+	// We find the rightmost table where the lastReadableOffset < fetchOffset
+	// Then we know that any table to the left of that must contain only offsets < fetchOffset and we have all the
+	// table ids we need for the iterator.
+	// If we can't find any such table it means all tables lastReadableOffset must be >= fetchOffset and we don't have
+	// enough tables cached to return the data
+	pos := -1
+	for i := len(p.entries) - 1; i >= 0; i-- {
+		if p.entries[i].LastReadableOffset >= fetchOffset {
+			continue
+		}
+		pos = i
+		break
+	}
+	if pos == -1 {
+		return nil, 0
+	}
+	tabIDs := make([]*sst.SSTableID, len(p.entries)-pos)
+	for i := pos; i < len(p.entries); i++ {
+		tabIDs[i-pos] = p.entries[i].TableID
+	}
+	return tabIDs, p.entries[len(p.entries)-1].LastReadableOffset
+}
+
+func (p *PartitionTables) addEntry(tableID *sst.SSTableID, lastReadableOffset int64, fetchStates map[*FetchState]struct{}) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.entries = append(p.entries, RecentTableEntry{tableID, lastReadableOffset})
+	if len(p.entries) == p.maxEntriesPerPartition {
+		// remove the first one.
+		p.entries = p.entries[1:]
+	}
+	// Call listeners
+	for _, listener := range p.listeners {
+		fs, err := listener.updateIterator(p.entries)
+		if err != nil {
+			return err
+		}
+		if fs != nil {
+			fetchStates[fs] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func (p *PartitionTables) addListener(listener *PartitionFetchState) (*FetchState, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	for _, entry := range p.listeners {
+		if entry == listener {
+			panic("listener already registered")
+		}
+	}
+	p.listeners = append(p.listeners, listener)
+	if len(p.entries) > 0 {
+		// data might have been added between us executing the controller query and registering listeners in the case
+		// that the agent was already registered for updates. so we need to update the partition fetch state's
+		// iterator
+		return listener.updateIterator(p.entries)
+	}
+	return nil, nil
+}
+
+func (p *PartitionTables) removeListener(listener *PartitionFetchState) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	var newListeners []*PartitionFetchState
+	for _, entry := range p.listeners {
+		if entry != listener {
+			newListeners = append(newListeners, entry)
+		}
+	}
+	p.listeners = newListeners
+}
+
+type RecentTableEntry struct {
+	TableID            *sst.SSTableID
+	LastReadableOffset int64
+}
+
+type TableRegisteredNotification struct {
+	ID                       sst.SSTableID
+	PartitionReadableOffsets map[int]map[int]int64
+}
+
+func (p *PartitionRecentTables) registerPartitionStates(partitionStates map[int]map[int]*PartitionFetchState) error {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	fetchStates := map[*FetchState]struct{}{}
+	for topicID, partitionFetchStates := range partitionStates {
+		partitionMap, ok := p.topicMap[topicID]
+		if !ok {
+			partitionMap = p.createPartitionMap(topicID)
+		}
+		for partitionID, partitionFetchState := range partitionFetchStates {
+			partitionTables, ok := partitionMap[partitionID]
+			if !ok {
+				partitionTables = p.createPartitionTables(partitionID, partitionMap)
+			}
+			// data might have been added between us executing the controller query and registering listeners in the case
+			// that the agent was already registered for updates. so we need to update the partition fetch state's
+			// iterator and collect a unique set of fetch states so we can call read on them again
+			fs, err := partitionTables.addListener(partitionFetchState)
+			if err != nil {
+				return err
+			}
+			if fs != nil {
+				fetchStates[fs] = struct{}{}
+			}
+		}
+	}
+	for fs := range fetchStates {
+		fs.readAsync()
+	}
+	return nil
+}
+
+func (p *PartitionRecentTables) unregisterPartitionStates(partitionStates map[int]map[int]*PartitionFetchState) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	for topicID, partitionFetchStates := range partitionStates {
+		partitionMap, ok := p.topicMap[topicID]
+		if !ok {
+			panic("topic not registered")
+		}
+		for partitionID, partitionFetchState := range partitionFetchStates {
+			partitionTables, ok := partitionMap[partitionID]
+			if !ok {
+				panic("partition not registered")
+			}
+			partitionTables.removeListener(partitionFetchState)
+		}
+	}
+}
+
+func (p *PartitionRecentTables) createPartitionMap(topicID int) map[int]*PartitionTables {
+	p.lock.RUnlock()
+	p.lock.Lock()
+	defer func() {
+		p.lock.Unlock()
+		p.lock.RLock()
+	}()
+	partitionMap, ok := p.topicMap[topicID]
+	if ok {
+		return partitionMap
+	}
+	partitionMap = map[int]*PartitionTables{}
+	p.topicMap[topicID] = partitionMap
+	return partitionMap
+}
+
+func (p *PartitionRecentTables) createPartitionTables(partitionID int, partitionMap map[int]*PartitionTables) *PartitionTables {
+	p.lock.RUnlock()
+	p.lock.Lock()
+	defer func() {
+		p.lock.Unlock()
+		p.lock.RLock()
+	}()
+	partitionTables, ok := partitionMap[partitionID]
+	if ok {
+		return partitionTables
+	}
+	partitionTables = &PartitionTables{
+		maxEntriesPerPartition: p.maxEntriesPerPartition,
+	}
+	partitionMap[partitionID] = partitionTables
+	return partitionTables
+}
+
+func (p *PartitionRecentTables) handleTableRegisteredNotification(notif TableRegisteredNotification) error {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	// Get unique set of fetch states to read
+	fetchStates := map[*FetchState]struct{}{}
+	for topicID, topicNotif := range notif.PartitionReadableOffsets {
+		partitionMap, ok := p.topicMap[topicID]
+		if !ok {
+			// Even though we register write before waiting, there is a race with the notification coming in after we
+			// called to fetch on the controller, and a new table gets registered really quickly, so we need to create
+			// here if necessary
+			partitionMap = p.createPartitionMap(topicID)
+		}
+		for partitionID, offset := range topicNotif {
+			partitionTables, ok := partitionMap[partitionID]
+			if !ok {
+				partitionTables = p.createPartitionTables(partitionID, partitionMap)
+			}
+			if err := partitionTables.addEntry(&notif.ID, offset, fetchStates); err != nil {
+				return err
+			}
+		}
+	}
+	for fs := range fetchStates {
+		fs.readAsync()
+	}
+	return nil
+}

--- a/iteration/empty_iter.go
+++ b/iteration/empty_iter.go
@@ -1,0 +1,18 @@
+package iteration
+
+import "github.com/spirit-labs/tektite/common"
+
+type EmptyIterator struct {
+}
+
+func (e EmptyIterator) Next() (bool, common.KV, error) {
+	return false, common.KV{}, nil
+}
+
+func (e EmptyIterator) Current() common.KV {
+	return common.KV{}
+}
+
+func (e EmptyIterator) Close() {
+}
+

--- a/kafkaencoding/encoding.go
+++ b/kafkaencoding/encoding.go
@@ -104,3 +104,11 @@ func varintLength(x int64) int {
 	}
 	return i + 1
 }
+
+func NumRecords(records []byte) int {
+	return int(binary.BigEndian.Uint32(records[57:]))
+}
+
+func BaseOffset(records []byte) int64 {
+	return int64(binary.BigEndian.Uint64(records))
+}

--- a/kafkaserver2/kafka_server_test.go
+++ b/kafkaserver2/kafka_server_test.go
@@ -26,7 +26,7 @@ func TestProduce(t *testing.T) {
 		RequestApiKey:     kafkaprotocol.APIKeyProduce,
 		RequestApiVersion: 3,
 		CorrelationId:     23,
-		ClientId:          strPtr("some-client-id"),
+		ClientId:          common.StrPtr("some-client-id"),
 	}
 	req := kafkaprotocol.ProduceRequest{
 		TransactionalId: nil,
@@ -34,7 +34,7 @@ func TestProduce(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 12,
@@ -49,7 +49,7 @@ func TestProduce(t *testing.T) {
 	resp := kafkaprotocol.ProduceResponse{
 		Responses: []kafkaprotocol.ProduceResponseTopicProduceResponse{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionResponses: []kafkaprotocol.ProduceResponsePartitionProduceResponse{
 					{
 						Index:      12,
@@ -93,10 +93,6 @@ func TestProduce(t *testing.T) {
 
 	require.Equal(t, &requestHeader, receivedHdr)
 	require.Equal(t, &req, receivedReq)
-}
-
-func strPtr(s string) *string {
-	return &s
 }
 
 type testConnHandlers struct {

--- a/levels/compaction_worker.go
+++ b/levels/compaction_worker.go
@@ -3,7 +3,6 @@ package levels
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/uuid"
 	"github.com/spirit-labs/tektite/asl/conf"
 	"github.com/spirit-labs/tektite/asl/errwrap"
 	"github.com/spirit-labs/tektite/common"
@@ -225,7 +224,7 @@ func (c *compactionWorker) processJob(job *CompactionJob) ([]RegistrationEntry, 
 	// Now push the tables to the cloud store
 	var ids []sst.SSTableID
 	for _, info := range infos {
-		id := []byte(fmt.Sprintf("sst-%s", uuid.New().String()))
+		id := []byte(sst.CreateSSTableId())
 		log.Debugf("compaction job %s created sstable %v", job.id, id)
 		ids = append(ids, id)
 		for {

--- a/lsm/compaction_worker.go
+++ b/lsm/compaction_worker.go
@@ -3,7 +3,6 @@ package lsm
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/spirit-labs/tektite/asl/errwrap"
 	"github.com/spirit-labs/tektite/common"
@@ -283,7 +282,7 @@ func (c *compactionWorker) processJob(job *CompactionJob) ([]RegistrationEntry, 
 	// Now push the tables to the cloud store
 	var ids []sst.SSTableID
 	for _, info := range infos {
-		id := []byte(fmt.Sprintf("sst-%s", uuid.New().String()))
+		id := []byte(sst.CreateSSTableId())
 		log.Debugf("compaction job %s created sstable %v", job.id, id)
 		ids = append(ids, id)
 		for {

--- a/offsets/offsets_test.go
+++ b/offsets/offsets_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"container/heap"
 	"context"
-	"fmt"
-	"github.com/google/uuid"
 	"github.com/spirit-labs/tektite/asl/encoding"
 	"github.com/spirit-labs/tektite/common"
 	"github.com/spirit-labs/tektite/objstore"
@@ -537,7 +535,7 @@ func setupInitialOffsets(t *testing.T, objStore objstore.Client, dataBucketName 
 	table, _, _, _, _, err := sst.BuildSSTable(common.DataFormatV1,
 		0, 0, iter)
 	require.NoError(t, err)
-	tableID := fmt.Sprintf("sst-%s", uuid.New().String())
+	tableID := sst.CreateSSTableId()
 	// Push sstable to object store
 	tableData := table.Serialize()
 	err = objStore.Put(context.Background(), dataBucketName, tableID, tableData)

--- a/proc/storage.go
+++ b/proc/storage.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/google/uuid"
 	"github.com/spirit-labs/tektite/asl/arenaskl"
 	"github.com/spirit-labs/tektite/asl/arista"
 	"github.com/spirit-labs/tektite/asl/errwrap"
@@ -286,7 +285,7 @@ func (ps *ProcessorStore) buildAndPushTable(entry *flushQueueEntry) error {
 			return err
 		}
 		// Push and register the SSTable
-		sid := fmt.Sprintf("sst-%s", uuid.New().String())
+		sid := sst2.CreateSSTableId()
 		id := []byte(sid)
 		tableBytes := ssTable.Serialize()
 		for {
@@ -494,7 +493,7 @@ func (ps *ProcessorStore) createSSTableIterators(keyStart []byte, keyEnd []byte)
 		if len(nonOverLapIDs) == 1 {
 			log.Debugf("using sstable %v in iterator [%d, 0] for key start %v", nonOverLapIDs[0], i, keyStart)
 			info := nonOverLapIDs[0]
-			iter, err := sst2.NewLazySSTableIterator(info.ID, ps.pm.tableCache, keyStart, keyEnd)
+			iter, err := sst2.NewLazySSTableIterator(info.ID, ps.pm.tableCache.GetSSTable, keyStart, keyEnd)
 			if err != nil {
 				return nil, err
 			}
@@ -506,7 +505,7 @@ func (ps *ProcessorStore) createSSTableIterators(keyStart []byte, keyEnd []byte)
 			itersInChain := make([]iteration.Iterator, len(nonOverLapIDs))
 			for j, nonOverlapID := range nonOverLapIDs {
 				log.Debugf("using sstable %v in iterator [%d, %d] for key start %v", nonOverlapID, i, j, keyStart)
-				iter, err := sst2.NewLazySSTableIterator(nonOverlapID.ID, ps.pm.tableCache, keyStart, keyEnd)
+				iter, err := sst2.NewLazySSTableIterator(nonOverlapID.ID, ps.pm.tableCache.GetSSTable, keyStart, keyEnd)
 				if err != nil {
 					return nil, err
 				}

--- a/pusher/conf.go
+++ b/pusher/conf.go
@@ -19,7 +19,7 @@ func NewConf() Conf {
 		WriteTimeout:              DefaultWriteTimeout,
 		AvailabilityRetryInterval: DefaultAvailabilityRetryInterval,
 		DataFormat:                DefaultDataFormat,
-		DataBucketName: "tektite-data",
+		DataBucketName:            DefaultDataBucketName,
 	}
 }
 
@@ -32,4 +32,5 @@ const (
 	DefaultAvailabilityRetryInterval = 1 * time.Second
 	DefaultBufferSizeMaxBytes        = 4 * 1024 * 1024
 	DefaultDataFormat                = common.DataFormatV1
+	DefaultDataBucketName            = "tektite-data"
 )

--- a/pusher/table_pusher_test.go
+++ b/pusher/table_pusher_test.go
@@ -56,7 +56,9 @@ func TestTablePusherHandleProduceBatchSimple(t *testing.T) {
 	topicProvider := &simpleTopicInfoProvider{infos: map[string]topicmeta.TopicInfo{
 		"topic1": {ID: topicID, PartitionCount: 20},
 	}}
-	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory)
+	partHashes, err := parthash.NewPartitionHashes(100)
+	require.NoError(t, err)
+	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory, partHashes)
 	require.NoError(t, err)
 	err = pusher.Start()
 	require.NoError(t, err)
@@ -73,7 +75,7 @@ func TestTablePusherHandleProduceBatchSimple(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 12,
@@ -150,7 +152,9 @@ func TestTablePusherHandleProduceBatchMultipleTopicsAndPartitions(t *testing.T) 
 		"topic1": {ID: topicID1, PartitionCount: 20},
 		"topic2": {ID: topicID2, PartitionCount: 30},
 	}}
-	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory)
+	partHashes, err := parthash.NewPartitionHashes(100)
+	require.NoError(t, err)
+	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory, partHashes)
 	require.NoError(t, err)
 
 	err = pusher.Start()
@@ -171,7 +175,7 @@ func TestTablePusherHandleProduceBatchMultipleTopicsAndPartitions(t *testing.T) 
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 12,
@@ -194,7 +198,7 @@ func TestTablePusherHandleProduceBatchMultipleTopicsAndPartitions(t *testing.T) 
 				},
 			},
 			{
-				Name: strPtr("topic2"),
+				Name: common.StrPtr("topic2"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 23,
@@ -328,7 +332,9 @@ func TestTablePusherPushWhenBufferIsFull(t *testing.T) {
 		"topic1": {ID: topicID, PartitionCount: 30},
 	}}
 
-	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory)
+	partHashes, err := parthash.NewPartitionHashes(100)
+	require.NoError(t, err)
+	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory, partHashes)
 	require.NoError(t, err)
 
 	err = pusher.Start()
@@ -344,7 +350,7 @@ func TestTablePusherPushWhenBufferIsFull(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 12,
@@ -378,7 +384,7 @@ func TestTablePusherPushWhenBufferIsFull(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 23,
@@ -435,7 +441,9 @@ func TestTablePusherPushWhenTimeoutIsExceeded(t *testing.T) {
 		"topic1": {ID: topicID, PartitionCount: 20},
 	}}
 
-	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory)
+	partHashes, err := parthash.NewPartitionHashes(100)
+	require.NoError(t, err)
+	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory, partHashes)
 	require.NoError(t, err)
 
 	start := time.Now()
@@ -452,7 +460,7 @@ func TestTablePusherPushWhenTimeoutIsExceeded(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 12,
@@ -524,7 +532,9 @@ func TestTablePusherHandleProduceBatchMixtureErrorsAndSuccesses(t *testing.T) {
 		"topic2": {ID: topicID2, PartitionCount: 30},
 	}}
 
-	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory)
+	partHashes, err := parthash.NewPartitionHashes(100)
+	require.NoError(t, err)
+	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory, partHashes)
 	require.NoError(t, err)
 
 	err = pusher.Start()
@@ -550,7 +560,7 @@ func TestTablePusherHandleProduceBatchMixtureErrorsAndSuccesses(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 12,
@@ -579,7 +589,7 @@ func TestTablePusherHandleProduceBatchMixtureErrorsAndSuccesses(t *testing.T) {
 				},
 			},
 			{
-				Name: strPtr("topic2"),
+				Name: common.StrPtr("topic2"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 23,
@@ -590,7 +600,7 @@ func TestTablePusherHandleProduceBatchMixtureErrorsAndSuccesses(t *testing.T) {
 				},
 			},
 			{
-				Name: strPtr("topic_unknown"),
+				Name: common.StrPtr("topic_unknown"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 11,
@@ -707,7 +717,9 @@ func TestTablePusherUnexpectedError(t *testing.T) {
 	topicProvider := &simpleTopicInfoProvider{infos: map[string]topicmeta.TopicInfo{
 		"topic1": {ID: topicID, PartitionCount: 20},
 	}}
-	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory)
+	partHashes, err := parthash.NewPartitionHashes(100)
+	require.NoError(t, err)
+	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory, partHashes)
 	require.NoError(t, err)
 	err = pusher.Start()
 	require.NoError(t, err)
@@ -731,7 +743,7 @@ func TestTablePusherUnexpectedError(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 12,
@@ -781,7 +793,9 @@ func TestTablePusherTemporaryUnavailability(t *testing.T) {
 	topicProvider := &simpleTopicInfoProvider{infos: map[string]topicmeta.TopicInfo{
 		"topic1": {ID: topicID, PartitionCount: 30},
 	}}
-	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory)
+	partHashes, err := parthash.NewPartitionHashes(100)
+	require.NoError(t, err)
+	pusher, err := NewTablePusher(cfg, topicProvider, objStore, clientFactory, partHashes)
 	require.NoError(t, err)
 	err = pusher.Start()
 	require.NoError(t, err)
@@ -807,7 +821,7 @@ func TestTablePusherTemporaryUnavailability(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 12,
@@ -835,7 +849,7 @@ func TestTablePusherTemporaryUnavailability(t *testing.T) {
 		TimeoutMs:       1234,
 		TopicData: []kafkaprotocol.ProduceRequestTopicProduceData{
 			{
-				Name: strPtr("topic1"),
+				Name: common.StrPtr("topic1"),
 				PartitionData: []kafkaprotocol.ProduceRequestPartitionProduceData{
 					{
 						Index: 20,
@@ -1002,10 +1016,6 @@ func (t *testControllerClient) GetOffsets(infos []offsets.GetOffsetTopicInfo) ([
 
 func (t *testControllerClient) Close() error {
 	return nil
-}
-
-func strPtr(s string) *string {
-	return &s
 }
 
 type failingObjectStoreClient struct {

--- a/queryutils/query.go
+++ b/queryutils/query.go
@@ -1,0 +1,44 @@
+package queryutils
+
+import (
+	"github.com/spirit-labs/tektite/iteration"
+	"github.com/spirit-labs/tektite/lsm"
+	"github.com/spirit-labs/tektite/sst"
+	"math"
+)
+
+type Querier interface {
+	QueryTablesInRange(keyStart []byte, keyEnd []byte) (lsm.OverlappingTables, error)
+}
+
+func CreateIteratorForKeyRange(keyStart []byte, keyEnd []byte, querier Querier, tableGetter sst.TableGetter) (iteration.Iterator, error) {
+	ids, err := querier.QueryTablesInRange(keyStart, keyEnd)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var iters []iteration.Iterator
+	for _, nonOverLapIDs := range ids {
+		if len(nonOverLapIDs) == 1 {
+			info := nonOverLapIDs[0]
+			iter, err := sst.NewLazySSTableIterator(info.ID, tableGetter, keyStart, keyEnd)
+			if err != nil {
+				return nil, err
+			}
+			iters = append(iters, iter)
+		} else {
+			itersInChain := make([]iteration.Iterator, len(nonOverLapIDs))
+			for j, nonOverlapID := range nonOverLapIDs {
+				iter, err := sst.NewLazySSTableIterator(nonOverlapID.ID, tableGetter, keyStart, keyEnd)
+				if err != nil {
+					return nil, err
+				}
+				itersInChain[j] = iter
+			}
+			iters = append(iters, iteration.NewChainingIterator(itersInChain))
+		}
+	}
+	return iteration.NewMergingIterator(iters, false, math.MaxUint64)
+}

--- a/sst/iters.go
+++ b/sst/iters.go
@@ -68,22 +68,18 @@ func (si *SSTableIterator) Current() common.KV {
 func (si *SSTableIterator) Close() {
 }
 
-type tableGetter interface {
-	GetSSTable(tableID SSTableID) (*SSTable, error)
-}
+type TableGetter func(tableID SSTableID) (*SSTable, error)
 
 type LazySSTableIterator struct {
 	tableID  SSTableID
-	getter   tableGetter
+	getter   TableGetter
 	keyStart []byte
-	keyEnd     []byte
-	iter       iteration.Iterator
+	keyEnd   []byte
+	iter     iteration.Iterator
 }
 
-func NewLazySSTableIterator(
-	tableID SSTableID, tableGetter tableGetter,
-	keyStart []byte, keyEnd []byte,
-) (iteration.Iterator, error) {
+func NewLazySSTableIterator(tableID SSTableID, tableGetter TableGetter,	keyStart []byte,
+	keyEnd []byte) (iteration.Iterator, error) {
 	it := &LazySSTableIterator{
 		tableID:  tableID,
 		getter:   tableGetter,
@@ -137,7 +133,7 @@ func dumpSST(id SSTableID, sst *SSTable) {
 
 func (l *LazySSTableIterator) getIter() (iteration.Iterator, error) {
 	if l.iter == nil {
-		ssTable, err := l.getter.GetSSTable(l.tableID)
+		ssTable, err := l.getter(l.tableID)
 		if err != nil {
 			return nil, err
 		}

--- a/sst/sstable.go
+++ b/sst/sstable.go
@@ -3,6 +3,8 @@ package sst
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"github.com/google/uuid"
 	"github.com/spirit-labs/tektite/asl/encoding"
 	"github.com/spirit-labs/tektite/asl/errwrap"
 	"github.com/spirit-labs/tektite/common"
@@ -251,4 +253,8 @@ func (s *SSTable) findOffset(key []byte) int {
 	valueStart := recordStart + maxKeyLength
 	off, _ := encoding.ReadUint32FromBufferLE(s.data, valueStart)
 	return int(off)
+}
+
+func CreateSSTableId() string {
+	return fmt.Sprintf("sst-%s", uuid.New().String())
 }

--- a/testutils/kafka.go
+++ b/testutils/kafka.go
@@ -39,8 +39,8 @@ func CreateKafkaRecordBatchWithIncrementingKVs(offsetStart int, numMessages int)
 	for i := offsetStart; i < offsetStart+numMessages; i++ {
 		msgs = append(msgs, RawKafkaMessage{
 			Timestamp: time.Now().UnixMilli(),
-			Key:       []byte(fmt.Sprintf("key%d", i)),
-			Value:     []byte(fmt.Sprintf("val%d", i)),
+			Key:       []byte(fmt.Sprintf("key%09d", i)),
+			Value:     []byte(fmt.Sprintf("val%09d", i)),
 		})
 	}
 	return CreateKafkaRecordBatch(msgs, int64(offsetStart))


### PR DESCRIPTION
This PR implements BatchFetcher. There is one BatchFetcher for agent, and it is responsible for handling all fetch requests and implementing the entire read path.
For each partition in the fetch request, the fetcher will figure out what table ids contain the required data - this information is either obtained from locally cache info or by querying the controller. 
Once ids are known an iterator can be created, and this iterator will retrieve the actual tables by first looking in a local table cache and then looking in the distributed fetch cache.
As new tables are registered with the controller, the controller will send notifications to all interested agents with the table id and last readable offsets for partitions in that table. On receipt of that information, the BatchFetcher caches it, so that subsequent fetches for recent data do not have to go to the controller, thus reducing controller traffic. In the happy case of all up to date consumers, fetches do not result in any significant controller requests.
Please see the source code comment on BatchFetcher for more information
Note, this PR does not contain the distributed fetch cache or the controller notification sending. Those will follow in subsequent PRs.
