### PR TITLE
Implement fetch cache

### DIFF
--- a/agent/conf.go
+++ b/agent/conf.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spirit-labs/tektite/asl/conf"
 	"github.com/spirit-labs/tektite/cluster"
 	"github.com/spirit-labs/tektite/control"
+	"github.com/spirit-labs/tektite/fetchcache"
 	"github.com/spirit-labs/tektite/fetcher"
 	"github.com/spirit-labs/tektite/lsm"
 	"github.com/spirit-labs/tektite/pusher"
@@ -17,6 +18,7 @@ type Conf struct {
 	ControllerConf          control.Conf
 	CompactionWorkersConf   lsm.CompactionWorkerServiceConf
 	FetcherConf             fetcher.Conf
+	FetchCacheConf fetchcache.Conf
 }
 
 func NewConf() Conf {
@@ -26,6 +28,7 @@ func NewConf() Conf {
 		ControllerConf:          control.NewConf(),
 		CompactionWorkersConf:   lsm.NewCompactionWorkerServiceConf(),
 		FetcherConf:             fetcher.NewConf(),
+		FetchCacheConf:          fetchcache.NewConf(),
 	}
 }
 

--- a/agent/fetch_test.go
+++ b/agent/fetch_test.go
@@ -111,6 +111,7 @@ func testFetch(t *testing.T, numAgents int, writeTimeout time.Duration, numBatch
 	}
 	cfg := NewConf()
 	cfg.PusherConf.WriteTimeout = writeTimeout
+	cfg.FetchCacheConf.MaxSizeBytes = 16 * 1024 * 1024
 	var agents []*Agent
 	var tearDowns []func(*testing.T)
 	objStore := dev.NewInMemStore(0)
@@ -432,4 +433,12 @@ func produceBatch(t *testing.T, topicName string, partitionID int, address strin
 	require.Equal(t, int16(kafkaprotocol.ErrorCodeNone), partResp.ErrorCode)
 	require.Equal(t, (*string)(nil), partResp.ErrorMessage)
 	return batch
+}
+
+func waitForDeliveredClusterVersion(t *testing.T, agents ...*Agent) {
+	for _, agent := range agents {
+		testutils.WaitUntil(t, func() (bool, error) {
+			return agent.DeliveredClusterVersion() > 0, nil
+		})
+	}
 }

--- a/agent/produce_test.go
+++ b/agent/produce_test.go
@@ -386,6 +386,7 @@ func setupAgentWithArgs(t *testing.T, cfg Conf, objStore objstore.Client, inMemM
 	require.NoError(t, err)
 	err = agent.Start()
 	require.NoError(t, err)
+	waitForDeliveredClusterVersion(t, agent)
 	tearDown := func(t *testing.T) {
 		err := agent.Stop()
 		require.NoError(t, err)

--- a/cluster/clustered_data.go
+++ b/cluster/clustered_data.go
@@ -149,7 +149,7 @@ func (m *ClusteredData) StoreData(data []byte) (bool, error) {
 	currEpoch := buffToEpoch(buff)
 	if currEpoch != m.epoch {
 		// Epoch has changed - fail the store
-		log.Warn("%s controller failed to store metadata as epoch has changed to %d (expected epoch %d)", m.logPrefix, currEpoch, m.epoch)
+		log.Warnf("%s controller failed to store metadata as epoch has changed to %d (expected epoch %d)", m.logPrefix, currEpoch, m.epoch)
 		return false, nil
 	}
 	return true, nil

--- a/common/structs.go
+++ b/common/structs.go
@@ -1,0 +1,28 @@
+package common
+
+import "encoding/binary"
+
+type MembershipData struct {
+	ListenAddress string
+	AZInfo        string
+}
+
+func (g *MembershipData) Serialize(buff []byte) []byte {
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(g.ListenAddress)))
+	buff = append(buff, g.ListenAddress...)
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(g.AZInfo)))
+	buff = append(buff, g.AZInfo...)
+	return buff
+}
+
+func (g *MembershipData) Deserialize(buff []byte, offset int) int {
+	ln := int(binary.BigEndian.Uint32(buff[offset:]))
+	offset += 4
+	g.ListenAddress = string(buff[offset : offset+ln])
+	offset += ln
+	ln = int(binary.BigEndian.Uint32(buff[offset:]))
+	offset += 4
+	g.AZInfo = string(buff[offset : offset+ln])
+	offset += ln
+	return offset
+}

--- a/common/structs_test.go
+++ b/common/structs_test.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSerializeDeserializeMembershipData(t *testing.T) {
+	data := MembershipData{
+		ListenAddress: "some-address",
+		AZInfo:        "az-12345",
+	}
+	var buff []byte
+	buff = append(buff, 1, 2, 3)
+	buff = data.Serialize(buff)
+	var data2 MembershipData
+	off := data2.Deserialize(buff, 3)
+	require.Equal(t, data, data2)
+	require.Equal(t, off, len(buff))
+}

--- a/consistent/consistent.go
+++ b/consistent/consistent.go
@@ -1,0 +1,112 @@
+package consistent
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+/*
+HashRing is an implementation of consistent hashing using virtual nodes.
+The hash ring contains members which can be added or removed dynamically. The method Get returns a member for a given
+key - it will always return the same member as long as it's in the ring.
+With consistent hashing, as members are added or removed only a fraction of the mappings of key->member change.
+Typically this should be approximately 1/N where N is number of members. Contrast this with a naive member selection
+which hashes the key and then uses a modulus to select a member. In that method almost every key->member mapping changes
+when a member is added or removed.
+For each member we maintain multiple virtual nodes by generating keys, hashing them and laying them out in sorted order
+in a slice. To choose a member for a key, we hash the key, then we find the smallest key in the ring smaller than the
+given key, using binary search. We then lookup which member that was generated for and return that.
+We create multiple virtual nodes for each member rather than just hashing the member once, as this provides a more
+uniform distribution. Increasing the virtualFactor increase uniformity at the expense of memory usage and processing time
+in adding/removing members.
+The HashRing currently uses SHA-256 hashing to hash keys and virtual nodes.
+ */
+type HashRing struct {
+	lock          sync.RWMutex
+	virtualFactor int
+	hashMemberMap map[uint64]string
+	memberHashes  map[string][]uint64
+	sorted        []uint64
+}
+
+func NewConsistentHash(virtualFactor int) *HashRing {
+	return &HashRing{
+		virtualFactor: virtualFactor,
+		hashMemberMap: map[uint64]string{},
+		memberHashes:  map[string][]uint64{},
+	}
+}
+
+func (c *HashRing) Add(member string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	hashes := make([]uint64, c.virtualFactor)
+	for i := 0; i < c.virtualFactor; i++ {
+		key := []byte(fmt.Sprintf("%s-%d", member, i))
+		h := hash(key)
+		hashes[i] = h
+		_, exists := c.hashMemberMap[h]
+		if exists {
+			// should never happen with sha-256
+			panic("hash collision")
+		}
+		c.hashMemberMap[h] = member
+	}
+	c.memberHashes[member] = hashes
+	c.createSortedKeys()
+}
+
+func (c *HashRing) Remove(member string) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	hashes, ok := c.memberHashes[member]
+	if !ok {
+		return false
+	}
+	for _, h := range hashes {
+		delete(c.hashMemberMap, h)
+	}
+	c.createSortedKeys()
+	return true
+}
+
+func (c *HashRing) createSortedKeys() {
+	all := make([]uint64, 0, len(c.hashMemberMap))
+	for h := range c.hashMemberMap {
+		all = append(all, h)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i] < all[j]
+	})
+	c.sorted = all
+}
+
+func (c *HashRing) Get(key []byte) (string, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if len(c.sorted) == 0 {
+		return "", false
+	}
+	h := hash(key)
+	pos := sort.Search(len(c.sorted), func(x int) bool {
+		return c.sorted[x] > h
+	})
+	if pos >= len(c.sorted) {
+		pos = 0
+	}
+	v := c.sorted[pos]
+	member := c.hashMemberMap[v]
+	return member, true
+}
+
+func hash(key []byte) uint64 {
+	h := sha256.New()
+	if _, err := h.Write(key); err != nil {
+		panic(err)
+	}
+	bytes := h.Sum(nil)
+	return binary.BigEndian.Uint64(bytes)
+}

--- a/consistent/consistent_test.go
+++ b/consistent/consistent_test.go
@@ -1,0 +1,153 @@
+package consistent
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+func TestGetNoMembers(t *testing.T) {
+	consist := NewConsistentHash(100)
+	_, ok := consist.Get([]byte("foo"))
+	require.False(t, ok)
+}
+
+func TestAddRemoveNodes(t *testing.T) {
+	consist := NewConsistentHash(100)
+	active := map[string]struct{}{}
+	numMembers := 10
+	// first add
+	for i := 0; i < numMembers; i++ {
+		member := uuid.New().String()
+		active[member] = struct{}{}
+		consist.Add(member)
+		for i := 0; i < 1000; i++ {
+			m, ok := consist.Get([]byte(uuid.New().String()))
+			require.True(t, ok)
+			// Make sure it's from the active set
+			_, exists := active[m]
+			require.True(t, exists)
+		}
+	}
+	// then remove
+	for member := range active {
+		consist.Remove(member)
+		delete(active, member)
+		if len(active) == 0 {
+			_, ok := consist.Get([]byte(uuid.New().String()))
+			require.False(t, ok)
+		} else {
+			for i := 0; i < 1000; i++ {
+				m, ok := consist.Get([]byte(uuid.New().String()))
+				require.True(t, ok)
+				// Make sure it's from the active set
+				_, exists := active[m]
+				require.True(t, exists)
+			}
+		}
+	}
+}
+
+// TestConsistDistribution - test the distribution of the consistent hash
+func TestConsistDistribution(t *testing.T) {
+
+	numKeys := 100000
+	var keys []string
+	for i := 0; i < numKeys; i++ {
+		keys = append(keys, fmt.Sprintf("key-%09d", i))
+	}
+
+	consist := NewConsistentHash(250)
+
+	numMembers := 10
+	for i := 0; i < numMembers; i++ {
+		consist.Add(fmt.Sprintf("member-%05d", i))
+	}
+
+	keyMemberAssignment := map[string]string{}
+
+	memberCounts := map[string]int{}
+	for _, key := range keys {
+		member, ok := consist.Get([]byte(key))
+		require.True(t, ok)
+		keyMemberAssignment[key] = member
+		memberCounts[member]++
+	}
+
+	minMemberCount := math.MaxInt
+	maxMemberCount := 0
+	for _, count := range memberCounts {
+		if count < minMemberCount {
+			minMemberCount = count
+		}
+		if count > maxMemberCount {
+			maxMemberCount = count
+		}
+	}
+	diff := maxMemberCount - minMemberCount
+
+	avgKeysPerMember := float64(numKeys) / float64(numMembers)
+
+	perCentDiff := 100 * float64(diff) / avgKeysPerMember
+
+	require.LessOrEqual(t, perCentDiff, 20.0)
+
+	// add a new member
+	consist.Add(fmt.Sprintf("member-%05d", numMembers))
+
+	keyMemberAssignment2 := map[string]string{}
+	for _, key := range keys {
+		member, ok := consist.Get([]byte(key))
+		require.True(t, ok)
+		keyMemberAssignment2[key] = member
+	}
+	numChanged := 0
+	for key, member := range keyMemberAssignment {
+		newMember, ok := keyMemberAssignment2[key]
+		require.True(t, ok)
+		if member != newMember {
+			numChanged++
+		}
+	}
+
+	percentChanged := 100 * float64(numChanged) / float64(numKeys)
+
+	require.LessOrEqual(t, percentChanged, 10.0)
+}
+
+func BenchmarkConsistGet(b *testing.B) {
+
+	consist := NewConsistentHash(10)
+
+	numMembers := 10
+	for i := 0; i < numMembers; i++ {
+		consist.Add(uuid.New().String())
+	}
+
+	numKeys := 10000
+	var keys [][]byte
+	for i := 0; i < numKeys; i++ {
+		keys = append(keys, []byte(uuid.New().String()))
+	}
+
+	start := rand.Int()
+
+	b.ResetTimer()
+
+	l := 0
+	for i := 0; i < b.N; i++ {
+		key := keys[(start+i)%numKeys]
+		member, ok := consist.Get(key)
+		if !ok {
+			panic("member not found")
+		}
+		l += len(member)
+	}
+
+	b.StopTimer()
+
+	fmt.Println(l)
+}

--- a/control/client.go
+++ b/control/client.go
@@ -19,7 +19,7 @@ type Client interface {
 
 	QueryTablesInRange(keyStart []byte, keyEnd []byte) (lsm.OverlappingTables, error)
 
-	RegisterTableListener(topicID int, partitionID int, address string, resetSequence int64) (int64, error)
+	RegisterTableListener(topicID int, partitionID int, memberID string, resetSequence int64) (int64, error)
 
 	PollForJob() (lsm.CompactionJob, error)
 
@@ -93,7 +93,7 @@ func (c *client) QueryTablesInRange(keyStart []byte, keyEnd []byte) (lsm.Overlap
 	return queryRes, nil
 }
 
-func (c *client) RegisterTableListener(topicID int, partitionID int, address string, resetSequence int64) (int64, error) {
+func (c *client) RegisterTableListener(topicID int, partitionID int, memberID string, resetSequence int64) (int64, error) {
 	conn, err := c.getConnection()
 	if err != nil {
 		return 0, err
@@ -102,7 +102,7 @@ func (c *client) RegisterTableListener(topicID int, partitionID int, address str
 		LeaderVersion: c.leaderVersion,
 		TopicID:       topicID,
 		PartitionID:   partitionID,
-		Address:       address,
+		MemberID:       memberID,
 		ResetSequence: resetSequence,
 	}
 	request := req.Serialize(createRequestBuffer())

--- a/control/controller_test.go
+++ b/control/controller_test.go
@@ -399,7 +399,8 @@ func setupControllersWithObjectStoreAndConfigSetter(t *testing.T, numMembers int
 		if configSetter != nil {
 			configSetter(&cfg)
 		}
-		ctrl := NewController(cfg, objStore, localTransports.CreateConnection, transportServer)
+		membershipID := fmt.Sprintf("id-%d", i)
+		ctrl := NewController(cfg, objStore, localTransports.CreateConnection, transportServer, membershipID)
 		err = ctrl.Start()
 		require.NoError(t, err)
 		controllers = append(controllers, ctrl)
@@ -436,8 +437,10 @@ func createMembership(clusterVersion int, leaderVersion int, controllers []*Cont
 	now := time.Now().UnixMilli()
 	var members []cluster.MembershipEntry
 	for _, memberIndex := range memberIndexes {
+		membershipData := common.MembershipData{ListenAddress: controllers[memberIndex].transportServer.Address()}
 		members = append(members, cluster.MembershipEntry{
-			Address:    controllers[memberIndex].transportServer.Address(),
+			ID:         fmt.Sprintf("id-%d", memberIndex),
+			Data:       membershipData.Serialize(nil),
 			UpdateTime: now,
 		})
 	}

--- a/control/rpcs.go
+++ b/control/rpcs.go
@@ -82,7 +82,7 @@ type RegisterTableListenerRequest struct {
 	LeaderVersion int
 	TopicID       int
 	PartitionID   int
-	Address       string
+	MemberID       string
 	ResetSequence int64
 }
 
@@ -90,8 +90,8 @@ func (f *RegisterTableListenerRequest) Serialize(buff []byte) []byte {
 	buff = binary.BigEndian.AppendUint64(buff, uint64(f.LeaderVersion))
 	buff = binary.BigEndian.AppendUint64(buff, uint64(f.TopicID))
 	buff = binary.BigEndian.AppendUint64(buff, uint64(f.PartitionID))
-	buff = binary.BigEndian.AppendUint32(buff, uint32(len(f.Address)))
-	buff = append(buff, f.Address...)
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(f.MemberID)))
+	buff = append(buff, f.MemberID...)
 	buff = binary.BigEndian.AppendUint64(buff, uint64(f.ResetSequence))
 	return buff
 }
@@ -106,7 +106,7 @@ func (f *RegisterTableListenerRequest) Deserialize(buff []byte, offset int) int 
 	la := int(binary.BigEndian.Uint32(buff[offset:]))
 	offset += 4
 	if la > 0 {
-		f.Address = string(buff[offset : offset+la])
+		f.MemberID = string(buff[offset : offset+la])
 	}
 	offset += la
 	f.ResetSequence = int64(binary.BigEndian.Uint64(buff[offset:]))

--- a/control/rpcs_test.go
+++ b/control/rpcs_test.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"github.com/google/uuid"
 	"github.com/spirit-labs/tektite/lsm"
 	"github.com/spirit-labs/tektite/offsets"
 	"github.com/spirit-labs/tektite/sst"
@@ -117,7 +118,7 @@ func TestSerializeDeserializeRegisterTableListenerRequest(t *testing.T) {
 		LeaderVersion: 567456,
 		TopicID:       123123,
 		PartitionID:   34546,
-		Address:       "some address",
+		MemberID:      uuid.New().String(),
 		ResetSequence: 123456,
 	}
 	var buff []byte

--- a/fetchcache/cache.go
+++ b/fetchcache/cache.go
@@ -1,0 +1,271 @@
+package fetchcache
+
+import (
+	"encoding/binary"
+	"github.com/dgraph-io/ristretto"
+	"github.com/pkg/errors"
+	"github.com/spirit-labs/tektite/cluster"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/consistent"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/transport"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+/*
+Cache is a distributed read cache of byte slices. It used to cache sstables across multiple agents so that fetch
+requests for different consumers, requesting partition data from the same sstables, which is extremely common for
+recent data, don't go to the object store each time, which would be inefficient and expensive.
+In an agent cluster we actually maintain multiple distributed caches - one for each availability zone that the agents
+are running in. This is because we do not want cache requests to cross availability zones to reduce cross-AZ costs on AWS.
+When requesting an entry from the cache, we use a consistent hash ring to determine the target agent for the entry, if
+the target is the same agent it is served directly from there otherwise an RPC is sent to the target node to request the
+bytes.
+On receipt of the request, the key is looked up in the in-memory cache. We use ristretto for this, which is a highly
+concurrent LRU cache. If not found in the cache it is looked up from the object store, added to the cache and returned.
+As we use consistent hashing, as agents are added or removed from the cluster, most keys will still map to the same
+agents so keys won't be re-requested from the object store. If keys do migrate, then old bytes in cache will eventually
+get pushed out by the LRU mechanism.
+*/
+type Cache struct {
+	lock            sync.RWMutex
+	objStore        objstore.Client
+	connFactory     transport.ConnectionFactory
+	transportServer transport.Server
+	cache           *ristretto.Cache
+	consist         *consistent.HashRing
+	connCaches      map[string]*ConnectionCache
+	members         map[string]struct{}
+	cfg             Conf
+	stats           CacheStats
+}
+
+type CacheStats struct {
+	Misses   int64
+	Hits     int64
+	Gets     int64
+	NotFound int64
+}
+
+func NewCache(objStore objstore.Client, connFactory transport.ConnectionFactory,
+	transportServer transport.Server, cfg Conf) (*Cache, error) {
+	tableSizeEstimate := 16 * 1024 * 1024
+	if cfg.MaxSizeBytes < tableSizeEstimate {
+		return nil, errors.Errorf("fetch cache maxSizeBytes must be >= %d", tableSizeEstimate)
+	}
+	maxItemsEstimate := cfg.MaxSizeBytes / tableSizeEstimate
+	cache, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters: int64(10 * maxItemsEstimate),
+		MaxCost:     int64(cfg.MaxSizeBytes),
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Cache{
+		objStore:        objStore,
+		connFactory:     connFactory,
+		transportServer: transportServer,
+		connCaches:      make(map[string]*ConnectionCache),
+		members:         make(map[string]struct{}),
+		cache:           cache,
+		consist:         consistent.NewConsistentHash(cfg.VirtualFactor),
+		cfg:             cfg,
+	}, nil
+}
+
+type Conf struct {
+	MaxSizeBytes             int
+	DataBucketName           string
+	AzInfo                   string
+	VirtualFactor            int
+	MaxConnectionsPerAddress int
+	ObjStoreCallTimeout      time.Duration
+}
+
+func NewConf() Conf {
+	return Conf{
+		MaxConnectionsPerAddress: DefaultMaxConnectionsPerAddress,
+		ObjStoreCallTimeout:      DefaultObjStoreCallTimeout,
+		VirtualFactor:            DefaultVirtualFactor,
+		DataBucketName:           DefaultDataBucketName,
+		MaxSizeBytes:             DefaultMaxSizeBytes,
+	}
+}
+
+const (
+	DefaultMaxConnectionsPerAddress = 5
+	DefaultObjStoreCallTimeout      = 5 * time.Second
+	DefaultVirtualFactor            = 100
+	DefaultDataBucketName           = "tektite-data"
+	DefaultMaxSizeBytes             = 128 * 1024 * 1024
+)
+
+func (c *Cache) Start() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.transportServer.RegisterHandler(transport.HandlerIDFetchCacheGetTableBytes, c.handleGetTableBytes)
+}
+
+func (c *Cache) Stop() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for _, connCache := range c.connCaches {
+		connCache.Close()
+	}
+}
+
+func (c *Cache) MembershipChanged(membership cluster.MembershipState) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	newMembers := make(map[string]struct{}, len(membership.Members))
+	for _, member := range membership.Members {
+		newMembers[member.ID] = struct{}{}
+		_, exists := c.members[member.ID]
+		if !exists {
+			// member added
+			var membershipData common.MembershipData
+			membershipData.Deserialize(member.Data, 0)
+			if membershipData.AZInfo == c.cfg.AzInfo {
+				// Each AZ has it's own cache so we don't have cross AZ calls when looking up in cache
+				c.consist.Add(membershipData.ListenAddress)
+			}
+		}
+	}
+	for member := range c.members {
+		_, exists := newMembers[member]
+		if !exists {
+			// member removed
+			c.consist.Remove(member)
+		}
+	}
+	c.members = newMembers
+	return nil
+}
+
+func (c *Cache) GetTableBytes(key []byte) ([]byte, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	target, ok := c.getTargetForKey(key)
+	if !ok {
+		return nil, common.NewTektiteErrorf(common.Unavailable, "no cache members")
+	}
+	if target == c.transportServer.Address() {
+		// Target is this node - we can do a direct call
+		return c.getFromCache(key)
+	}
+	conn, err := c.getConnection(target)
+	if err != nil {
+		return nil, err
+	}
+	req := createRequestBuffer()
+	req = binary.BigEndian.AppendUint32(req, uint32(len(key)))
+	req = append(req, key...)
+	resp, err := conn.SendRPC(transport.HandlerIDFetchCacheGetTableBytes, req)
+	if err != nil {
+		// Always close connection on error
+		if err := conn.Close(); err != nil {
+			// Ignore
+		}
+		return nil, err
+	}
+	lb := binary.BigEndian.Uint32(resp)
+	bytes := make([]byte, lb)
+	copy(bytes, resp[4:4+lb])
+	return bytes, nil
+}
+
+func (c *Cache) getTargetForKey(key []byte) (string, bool) {
+	return c.consist.Get(key)
+}
+
+func (c *Cache) handleGetTableBytes(_ *transport.ConnectionContext, request []byte, responseBuff []byte,
+	responseWriter transport.ResponseWriter) error {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if err := checkRPCVersion(request); err != nil {
+		return responseWriter(nil, err)
+	}
+	lb := binary.BigEndian.Uint32(request[2:])
+	key := request[6 : 6+lb]
+
+	bytes, err := c.getFromCache(key)
+	if err != nil {
+		return responseWriter(nil, err)
+	}
+	return sendBytesResponse(responseWriter, responseBuff, bytes)
+}
+
+func (c *Cache) getFromCache(key []byte) ([]byte, error) {
+	atomic.AddInt64(&c.stats.Gets, 1)
+	v, ok := c.cache.Get(key)
+	if ok {
+		atomic.AddInt64(&c.stats.Hits, 1)
+		return v.([]byte), nil
+	}
+	bytes, err := objstore.GetWithTimeout(c.objStore, c.cfg.DataBucketName, string(key), c.cfg.ObjStoreCallTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if len(bytes) > 0 {
+		atomic.AddInt64(&c.stats.Misses, 1)
+		c.cache.Set(key, bytes, int64(len(bytes)))
+	} else {
+		atomic.AddInt64(&c.stats.NotFound, 1)
+	}
+	return bytes, nil
+}
+
+func (c *Cache) GetStats() CacheStats {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.stats
+}
+
+func sendBytesResponse(responseWriter transport.ResponseWriter, responseBuff []byte, tableBytes []byte) error {
+	responseBuff = binary.BigEndian.AppendUint32(responseBuff, uint32(len(tableBytes)))
+	responseBuff = append(responseBuff, tableBytes...)
+	return responseWriter(responseBuff, nil)
+}
+
+func checkRPCVersion(request []byte) error {
+	rpcVersion := binary.BigEndian.Uint16(request)
+	if rpcVersion != 1 {
+		// Currently just 1
+		return errors.New("invalid rpc version")
+	}
+	return nil
+}
+
+func createRequestBuffer() []byte {
+	buff := make([]byte, 0, 128)                  // Initial size guess
+	buff = binary.BigEndian.AppendUint16(buff, 1) // rpc version - currently 1
+	return buff
+}
+
+func (c *Cache) getConnection(address string) (transport.Connection, error) {
+	connCache, ok := c.connCaches[address]
+	if !ok {
+		connCache = c.createConnCache(address)
+	}
+	return connCache.GetConnection()
+}
+
+func (c *Cache) createConnCache(address string) *ConnectionCache {
+	c.lock.RUnlock()
+	c.lock.Lock()
+	defer func() {
+		c.lock.Unlock()
+		c.lock.RLock()
+	}()
+	connCache, ok := c.connCaches[address]
+	if ok {
+		return connCache
+	}
+	connCache = NewConnectionCache(address, c.cfg.MaxConnectionsPerAddress, c.connFactory)
+	c.connCaches[address] = connCache
+	return connCache
+}

--- a/fetchcache/cache_test.go
+++ b/fetchcache/cache_test.go
@@ -1,0 +1,330 @@
+package fetchcache
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/cluster"
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/objstore"
+	"github.com/spirit-labs/tektite/objstore/dev"
+	"github.com/spirit-labs/tektite/transport"
+	"github.com/stretchr/testify/require"
+	mrand "math/rand"
+	"testing"
+)
+
+func TestCacheSingleNode(t *testing.T) {
+	objStore := dev.NewInMemStore(0)
+	localTransports := transport.NewLocalTransports()
+	transportServer, err := localTransports.NewLocalServer("server-address-1")
+	require.NoError(t, err)
+
+	cfg := NewConf()
+	cfg.DataBucketName = "test-bucket"
+	cfg.AzInfo = "test-az"
+	cfg.MaxSizeBytes = 16 * 1024 * 1024
+	cfg.MaxConnectionsPerAddress = 100
+
+	cache, err := NewCache(objStore, localTransports.CreateConnection, transportServer, cfg)
+	require.NoError(t, err)
+
+	cache.Start()
+	defer cache.Stop()
+
+	membershipData := common.MembershipData{
+		ListenAddress: transportServer.Address(),
+		AZInfo:        cfg.AzInfo,
+	}
+	err = cache.MembershipChanged(cluster.MembershipState{
+		ClusterVersion: 1,
+		Members: []cluster.MembershipEntry{
+			{
+				ID:   uuid.New().String(),
+				Data: membershipData.Serialize(nil),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	stats := cache.GetStats()
+	require.Equal(t, 0, int(stats.Hits))
+	require.Equal(t, 0, int(stats.Misses))
+
+	key1 := []byte("some-key-1")
+	bytes, err := cache.GetTableBytes(key1)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(bytes))
+
+	stats = cache.GetStats()
+	require.Equal(t, 0, int(stats.Hits))
+	require.Equal(t, 0, int(stats.Misses))
+	require.Equal(t, 1, int(stats.NotFound))
+
+	tableBytes := []byte("quwdhiquwhdiquwhdiuqd")
+	err = objStore.Put(context.Background(), cfg.DataBucketName, string(key1), tableBytes)
+	require.NoError(t, err)
+
+	bytes, err = cache.GetTableBytes(key1)
+	require.NoError(t, err)
+	require.Equal(t, tableBytes, bytes)
+
+	stats = cache.GetStats()
+	require.Equal(t, 0, int(stats.Hits))
+	require.Equal(t, 1, int(stats.Misses))
+
+	// ristretto has async put
+	cache.cache.Wait()
+
+	bytes, err = cache.GetTableBytes(key1)
+	require.NoError(t, err)
+	require.Equal(t, tableBytes, bytes)
+
+	stats = cache.GetStats()
+	require.Equal(t, 1, int(stats.Hits))
+	require.Equal(t, 1, int(stats.Misses))
+
+	bytes, err = cache.GetTableBytes(key1)
+	require.NoError(t, err)
+	require.Equal(t, tableBytes, bytes)
+
+	stats = cache.GetStats()
+	require.Equal(t, 2, int(stats.Hits))
+	require.Equal(t, 1, int(stats.Misses))
+}
+
+func TestCacheMultipleNodes(t *testing.T) {
+	objStore := dev.NewInMemStore(0)
+	localTransports := transport.NewLocalTransports()
+
+	cfg := NewConf()
+	cfg.DataBucketName = "test-bucket"
+	cfg.AzInfo = "test-az"
+	cfg.MaxSizeBytes = 16 * 1024 * 1024
+	cfg.MaxConnectionsPerAddress = 100
+
+	numNodes := 5
+
+	var caches []*Cache
+	var members []cluster.MembershipEntry
+
+	for i := 0; i < numNodes; i++ {
+		transportServer, err := localTransports.NewLocalServer(uuid.New().String())
+		require.NoError(t, err)
+		cache, err := NewCache(objStore, localTransports.CreateConnection, transportServer, cfg)
+		require.NoError(t, err)
+		cache.Start()
+		membershipData := common.MembershipData{
+			ListenAddress: transportServer.Address(),
+			AZInfo:        cfg.AzInfo,
+		}
+		members = append(members, cluster.MembershipEntry{
+			ID:   uuid.New().String(),
+			Data: membershipData.Serialize(nil),
+		})
+		caches = append(caches, cache)
+	}
+	defer func() {
+		for _, cache := range caches {
+			cache.Stop()
+		}
+	}()
+
+	membership := cluster.MembershipState{
+		LeaderVersion:  1,
+		ClusterVersion: 1,
+		Members:        members,
+	}
+	for _, cache := range caches {
+		err := cache.MembershipChanged(membership)
+		require.NoError(t, err)
+	}
+
+	numKeys := 1000
+	kvs := setupData(t, numKeys, objStore, cfg.DataBucketName)
+
+	numGetsPerKey := 10
+	for i := 0; i < numGetsPerKey; i++ {
+		for _, kv := range kvs {
+			clientCache := caches[mrand.Intn(len(caches))]
+
+			v, err := clientCache.GetTableBytes(kv.Key)
+			require.NoError(t, err)
+
+			require.Equal(t, kv.Value, v)
+		}
+	}
+
+	totHits := 0
+	totMisses := 0
+	totGets := 0
+	expectedMissRatio := 1 / float64(numGetsPerKey)
+	expectedHitRatio := 1 - expectedMissRatio
+	avgGetsPerNode := float64(numKeys*numGetsPerKey) / float64(numNodes)
+
+	for _, cache := range caches {
+		stats := cache.GetStats()
+		require.GreaterOrEqual(t, float64(stats.Hits), 0.5*avgGetsPerNode) // Allow for imbalance
+		totGets += int(stats.Gets)
+		totHits += int(stats.Hits)
+		totMisses += int(stats.Misses)
+		missRatio := float64(stats.Misses) / float64(stats.Gets)
+		hitRatio := float64(stats.Hits) / float64(stats.Gets)
+		require.Equal(t, expectedMissRatio, missRatio)
+		require.Equal(t, expectedHitRatio, hitRatio)
+	}
+
+	require.Equal(t, numKeys*numGetsPerKey, totGets)
+	require.Equal(t, numKeys*(numGetsPerKey-1), totHits)
+	require.Equal(t, numKeys, totMisses)
+
+	nodesToRemove := 3
+	for i := 0; i < nodesToRemove; i++ {
+		memberToRemove := mrand.Intn(len(members))
+
+		newCaches := append([]*Cache{}, caches[:memberToRemove]...)
+		newMembers := append([]cluster.MembershipEntry{}, members[:memberToRemove]...)
+		newCaches = append(newCaches, caches[memberToRemove+1:]...)
+		newMembers = append(newMembers, members[memberToRemove+1:]...)
+
+		for _, c := range newCaches {
+			err := c.MembershipChanged(cluster.MembershipState{
+				LeaderVersion:  1,
+				ClusterVersion: 2,
+				Members:        members,
+			})
+			require.NoError(t, err)
+		}
+
+		// get keys again
+		for i := 0; i < numGetsPerKey; i++ {
+			for _, kv := range kvs {
+				clientCache := caches[mrand.Intn(len(caches))]
+				v, err := clientCache.GetTableBytes(kv.Key)
+				require.NoError(t, err)
+				require.Equal(t, kv.Value, v)
+			}
+		}
+	}
+}
+
+func TestMultipleAZs(t *testing.T) {
+	// Setup, say 9 nodes, 3 in each AZ
+	numAzs := 3
+	numNodesPerAz := 5
+
+	objStore := dev.NewInMemStore(0)
+	localTransports := transport.NewLocalTransports()
+
+	cfg := NewConf()
+	cfg.DataBucketName = "test-bucket"
+	cfg.AzInfo = "test-az"
+	cfg.MaxSizeBytes = 16 * 1024 * 1024
+	cfg.MaxConnectionsPerAddress = 100
+
+	var allCaches []*Cache
+	var members []cluster.MembershipEntry
+	var allAzCaches [][]*Cache
+
+	for i := 0; i < numAzs; i++ {
+		az := fmt.Sprintf("AZ-%d", i)
+		var azCaches []*Cache
+		for j := 0; j < numNodesPerAz; j++ {
+			transportServer, err := localTransports.NewLocalServer(uuid.New().String())
+			require.NoError(t, err)
+			cfgCopy := cfg
+			cfgCopy.AzInfo = az
+			cache, err := NewCache(objStore, localTransports.CreateConnection, transportServer, cfgCopy)
+			require.NoError(t, err)
+			cache.Start()
+			membershipData := common.MembershipData{
+				ListenAddress: transportServer.Address(),
+				AZInfo:        az,
+			}
+			members = append(members, cluster.MembershipEntry{
+				ID:   uuid.New().String(),
+				Data: membershipData.Serialize(nil),
+			})
+			allCaches = append(allCaches, cache)
+			azCaches = append(azCaches, cache)
+		}
+		allAzCaches = append(allAzCaches, azCaches)
+	}
+
+	membership := cluster.MembershipState{
+		LeaderVersion:  1,
+		ClusterVersion: 1,
+		Members:        members,
+	}
+	for _, cache := range allCaches {
+		err := cache.MembershipChanged(membership)
+		require.NoError(t, err)
+	}
+
+	numKeys := 1000
+	kvs := setupData(t, numKeys, objStore, cfg.DataBucketName)
+
+	numGetsPerKey := 10
+
+	// Do all the gets against each az in turn - make sure the hits don't reach other AZs
+	for i, azCaches := range allAzCaches {
+		for j := 0; j < numGetsPerKey; j++ {
+			for _, kv := range kvs {
+				clientCache := azCaches[mrand.Intn(len(azCaches))]
+				v, err := clientCache.GetTableBytes(kv.Key)
+				require.NoError(t, err)
+				require.Equal(t, kv.Value, v)
+			}
+		}
+		otherAzGetsBefore := getOtherAzGets(allAzCaches, i)
+
+		// All the gets should be in same AZ
+		var azGets int64
+		for _, cache := range azCaches {
+			azGets += cache.GetStats().Gets
+		}
+		require.Equal(t, numKeys*numGetsPerKey, int(azGets))
+
+		otherAzGetsAfter := getOtherAzGets(allAzCaches, i)
+
+		// verify no gets on other AZs
+		require.Equal(t, otherAzGetsBefore, otherAzGetsAfter)
+	}
+}
+
+func getOtherAzGets(allAzCaches [][]*Cache, exceptIndex int) int64 {
+	var otherAZGets int64
+	for j, azCaches := range allAzCaches {
+		if j != exceptIndex {
+			for _, azCache := range azCaches {
+				otherAZGets += azCache.GetStats().Gets
+			}
+		}
+	}
+	return otherAZGets
+}
+
+func setupData(t *testing.T, numKeys int, objectStore objstore.Client, dataBucketName string) []common.KV {
+	var kvs []common.KV
+	for i := 0; i < numKeys; i++ {
+		key := []byte(uuid.New().String())
+		value := randomBytes(1000)
+		kvs = append(kvs, common.KV{
+			Key:   key,
+			Value: value,
+		})
+		err := objectStore.Put(context.Background(), dataBucketName, string(key), value)
+		require.NoError(t, err)
+	}
+	return kvs
+}
+
+func randomBytes(n int) []byte {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/fetchcache/conn_cache.go
+++ b/fetchcache/conn_cache.go
@@ -1,0 +1,111 @@
+package fetchcache
+
+import (
+	log "github.com/spirit-labs/tektite/logger"
+	"github.com/spirit-labs/tektite/transport"
+	"sync"
+	"sync/atomic"
+)
+
+// ConnectionCache caches a set of connections for a particular target address
+type ConnectionCache struct {
+	lock        sync.RWMutex
+	address     string
+	connFactory transport.ConnectionFactory
+	connections []*connectionWrapper
+	pos         int64
+}
+
+func NewConnectionCache(address string, maxConnections int, connFactory transport.ConnectionFactory) *ConnectionCache {
+	return &ConnectionCache{
+		address:     address,
+		connections: make([]*connectionWrapper, maxConnections),
+		connFactory: connFactory,
+	}
+}
+
+func (cc *ConnectionCache) GetConnection() (transport.Connection, error) {
+	cl, index := cc.getCachedConnection()
+	if cl != nil {
+		return cl, nil
+	}
+	return cc.createConnection(index)
+}
+
+func (cc *ConnectionCache) Close() {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	for i, client := range cc.connections {
+		if client != nil {
+			if err := client.conn.Close(); err != nil {
+				log.Warnf("failed to close connection: %v", err)
+			}
+		}
+		cc.connections[i] = nil
+	}
+}
+
+func (cc *ConnectionCache) NumConnections() int {
+	cc.lock.RLock()
+	defer cc.lock.RUnlock()
+	num := 0
+	for _, client := range cc.connections {
+		if client != nil {
+			num++
+		}
+	}
+	return num
+}
+
+func (cc *ConnectionCache) getCachedConnection() (*connectionWrapper, int) {
+	cc.lock.RLock()
+	defer cc.lock.RUnlock()
+	pos := atomic.AddInt64(&cc.pos, 1) - 1
+	index := int(pos) % len(cc.connections)
+	return cc.connections[index], index
+}
+
+func (cc *ConnectionCache) createConnection(index int) (*connectionWrapper, error) {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	cl := cc.connections[index]
+	if cl != nil {
+		return cl, nil
+	}
+	conn, err := cc.connFactory(cc.address)
+	if err != nil {
+		return nil, err
+	}
+	cl = &connectionWrapper{
+		cc:    cc,
+		index: index,
+		conn:  conn,
+	}
+	cc.connections[index] = cl
+	return cl, nil
+}
+
+func (cc *ConnectionCache) deleteClient(index int) {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+	cc.connections[index] = nil
+}
+
+type connectionWrapper struct {
+	cc    *ConnectionCache
+	index int
+	conn  transport.Connection
+}
+
+func (c *connectionWrapper) SendOneway(handlerID int, message []byte) error {
+	return c.conn.SendOneway(handlerID, message)
+}
+
+func (c *connectionWrapper) SendRPC(handlerID int, request []byte) ([]byte, error) {
+	return c.conn.SendRPC(handlerID, request)
+}
+
+func (c *connectionWrapper) Close() error {
+	c.cc.deleteClient(c.index)
+	return c.conn.Close()
+}

--- a/fetchcache/conn_cache_test.go
+++ b/fetchcache/conn_cache_test.go
@@ -1,0 +1,78 @@
+package fetchcache
+
+import (
+	"github.com/google/uuid"
+	"github.com/spirit-labs/tektite/transport"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestConnCacheGetConnections(t *testing.T) {
+
+	localTransports := transport.NewLocalTransports()
+
+	localTransport, err := localTransports.NewLocalServer(uuid.New().String())
+	require.NoError(t, err)
+
+	maxConnections := 10
+
+	connCache := NewConnectionCache(localTransport.Address(), maxConnections, localTransports.CreateConnection)
+
+	require.Equal(t, 0, connCache.NumConnections())
+
+	allConns := map[transport.Connection]struct{}{}
+	for i := 0; i < 10*maxConnections; i++ {
+		conn, err := connCache.GetConnection()
+		require.NoError(t, err)
+		maxConn := i + 1
+		if maxConn > maxConnections {
+			maxConn = maxConnections
+		}
+		require.Equal(t, maxConn, connCache.NumConnections())
+		require.NotNil(t, conn)
+		allConns[conn] = struct{}{}
+	}
+
+	require.Equal(t, maxConnections, len(allConns))
+
+	connCache.Close()
+
+	require.Equal(t, 0, connCache.NumConnections())
+}
+
+func TestCloseInvidualConnections(t *testing.T) {
+
+	localTransports := transport.NewLocalTransports()
+
+	localTransport, err := localTransports.NewLocalServer(uuid.New().String())
+	require.NoError(t, err)
+
+	maxConnections := 10
+
+	connCache := NewConnectionCache(localTransport.Address(), maxConnections, localTransports.CreateConnection)
+
+	require.Equal(t, 0, connCache.NumConnections())
+
+	var conns []transport.Connection
+	for i := 0; i < maxConnections; i++ {
+		conn, err := connCache.GetConnection()
+		require.NoError(t, err)
+		conns = append(conns, conn)
+	}
+
+	require.Equal(t, maxConnections, connCache.NumConnections())
+
+	for i, conn := range conns {
+		err := conn.Close()
+		require.NoError(t, err)
+		require.Equal(t, maxConnections-i-1, connCache.NumConnections())
+	}
+
+	// Now create more
+	for i := 0; i < maxConnections; i++ {
+		_, err := connCache.GetConnection()
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, maxConnections, connCache.NumConnections())
+}

--- a/fetcher/fetch_state.go
+++ b/fetcher/fetch_state.go
@@ -108,7 +108,7 @@ outer:
 			var wouldExceedPartitionMax bool
 			wouldExceedRequestMax, wouldExceedPartitionMax, err = partitionFetchState.read()
 			if err != nil {
-				log.Warnf("failed to fetch on partition %v", err)
+				log.Warnf("failed to fetch from partition %v", err)
 				if common.IsUnavailableError(err) {
 					partitionFetchState.partitionFetchResp.ErrorCode = kafkaprotocol.ErrorCodeLeaderNotAvailable
 				} else {
@@ -225,7 +225,7 @@ func (p *PartitionFetchState) read() (wouldExceedRequestMax bool, wouldExceedPar
 			cl, err := p.fs.bf.getClient()
 			var alreadyInitialised bool
 			lastReadableOffset, alreadyInitialised, err = p.partitionTables.initialise(func() (int64, error) {
-				return cl.RegisterTableListener(p.topicID, p.partitionID, p.fs.bf.address, atomic.LoadInt64(&p.fs.bf.resetSequence))
+				return cl.RegisterTableListener(p.topicID, p.partitionID, p.fs.bf.memberID, atomic.LoadInt64(&p.fs.bf.resetSequence))
 			})
 			if err != nil {
 				return false, false, err

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -43,7 +43,7 @@ type BatchFetcher struct {
 	partitionHashes *parthash.PartitionHashes
 	controlFactory  controllerClientFactory
 	tableGetter     sst.TableGetter
-	address         string
+	memberID         string
 	recentTables    PartitionRecentTables
 	controlClients  *clientCache
 	dataBucketName  string
@@ -54,7 +54,7 @@ type BatchFetcher struct {
 }
 
 func NewBatchFetcher(objStore objstore.Client, topicProvider topicInfoProvider, partitionHashes *parthash.PartitionHashes,
-	controlFactory controllerClientFactory, tableGetter sst.TableGetter, address string, cfg Conf) (*BatchFetcher, error) {
+	controlFactory controllerClientFactory, tableGetter sst.TableGetter, memberID string, cfg Conf) (*BatchFetcher, error) {
 	localCache, err := NewLocalSSTCache(cfg.LocalCacheNumEntries, cfg.LocalCacheMaxBytes)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func NewBatchFetcher(objStore objstore.Client, topicProvider topicInfoProvider, 
 		partitionHashes: partitionHashes,
 		controlFactory:  controlFactory,
 		tableGetter:     tableGetter,
-		address:         address,
+		memberID:         memberID,
 		controlClients:  newClientCache(cfg.MaxControllerConnections, controlFactory),
 		readExecs:       make([]readExecutor, cfg.NumReadExecutors),
 		localCache:      localCache,
@@ -116,7 +116,7 @@ type topicInfoProvider interface {
 type controllerClientFactory func() (ControlClient, error)
 
 type ControlClient interface {
-	RegisterTableListener(topicID int, partitionID int, address string, resetSequence int64) (int64, error)
+	RegisterTableListener(topicID int, partitionID int, memberID string, resetSequence int64) (int64, error)
 	QueryTablesInRange(keyStart []byte, keyEnd []byte) (lsm.OverlappingTables, error)
 	Close() error
 }

--- a/pusher/table_pusher.go
+++ b/pusher/table_pusher.go
@@ -265,7 +265,6 @@ func (t *TablePusher) handleRecords(topicID int, partitionID int, records [][]by
 		topicMap = make(map[int][]bufferedEntry)
 		t.partitionRecords[topicID] = topicMap
 	}
-	// TODO protocol needs to be fixed so records is just []byte not [][]byte as record batches are concatenated
 	if len(records) > 1 {
 		panic("too many records")
 	}

--- a/topicmeta/cache_test.go
+++ b/topicmeta/cache_test.go
@@ -28,16 +28,19 @@ func TestNotifications(t *testing.T) {
 
 	numLocalCaches := 3
 	var localCaches []*LocalCache
-	var addresses []string
 	var memberEntries []cluster.MembershipEntry
 	var localCacheTransports []*transport.LocalServer
 	for i := 0; i < numLocalCaches; i++ {
 		localCache := NewLocalCache(controlClientFactory)
 		localCaches = append(localCaches, localCache)
+		memberID := uuid.New().String()
 		address := uuid.New().String()
-		addresses = append(addresses, address)
+		memberData := common.MembershipData{
+			ListenAddress: address,
+		}
 		memberEntries = append(memberEntries, cluster.MembershipEntry{
-			Address: address,
+			ID:   memberID,
+			Data: memberData.Serialize(nil),
 		})
 		localServer, err := transports.NewLocalServer(address)
 		require.NoError(t, err)

--- a/topicmeta/manager.go
+++ b/topicmeta/manager.go
@@ -362,8 +362,9 @@ func (m *Manager) SendTopicNotification(handlerID int, topicInfo TopicInfo) {
 		}
 		bytes := notif.Serialize(nil)
 		for i := 0; i < len(m.membership.Members); i++ {
-			if err := m.sendNotificationToAddress(handlerID,
-				m.membership.Members[i].Address, bytes); err != nil {
+			var memberData common.MembershipData
+			memberData.Deserialize(m.membership.Members[i].Data, 0)
+			if err := m.sendNotificationToAddress(handlerID, memberData.ListenAddress, bytes); err != nil {
 				// best effort - continue
 				log.Warnf("Unable to send topic added notification: %v", err)
 			}

--- a/transport/handler_ids.go
+++ b/transport/handler_ids.go
@@ -12,5 +12,6 @@ const (
 	HandlerIDControllerDeleteTopic
 	HandlerIDMetaLocalCacheTopicAdded
 	HandlerIDMetaLocalCacheTopicDeleted
+	HandlerIDFetchCacheGetTableBytes
 	HandlerIDFetcherTableRegisteredNotification
 )


### PR DESCRIPTION
Implements the distributed fetch cache. When processing fetch requests, it's likely that partition data being fetched by different consumers resides in the same, recently added sstables. We do not want to go to the object store for each fetch as this would result in lots of unnecessary traffic and expense.
Instead, when a particular sstable is requested, we first look in a small local cache, and if it's not there we ask the distributed fetch cache for it. Each key is owned by an agent in the same AZ as the caller. The key is hashed using a consistent hashing algorithm (to minimise key migration when agents are added or removed) to determine the agent which "owns" that key. An RPC is sent to that node (if it's not the current node). On receipt the agent first looks in it's cache and returns the sstable bytes from there if they have been got before. If not it retrieves the sstable from the object store and adds it to the cache returning it to the caller. The cache used is from the ristretto library - this is a highly concurrent LRU cache.
This PR also updates cluster/membership to store some arbitrary data for each member entry and replaces address with an id. Address is now just a field in the data, and the data can store other stuff in the future.