### PR TITLE
Preparatory work for idempotent producers / tx

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -100,7 +100,7 @@ func NewAgentWithFactories(cfg Conf, objStore objstore.Client, connectionFactory
 		return nil, err
 	}
 	agent.tablePusher = tablePusher
-	transportServer.RegisterHandler(transport.HandlerIDTablePusherOffsetCommit, tablePusher.HandleOffsetCommit)
+	transportServer.RegisterHandler(transport.HandlerIDTablePusherDirectWrite, tablePusher.HandleDirectWrite)
 	fetchCache, err := fetchcache.NewCache(objStore, connectionFactory, transportServer, cfg.FetchCacheConf)
 	if err != nil {
 		return nil, err

--- a/common/util.go
+++ b/common/util.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"unsafe"
 )
 
@@ -17,7 +16,7 @@ func StrPtr(s string) *string {
 
 func SafeDerefStringPtr(s *string) string {
 	if s == nil {
-		return fmt.Sprintf("string ptr is nil")
+		return ""
 	}
 	return *s
 }

--- a/control/client_cache.go
+++ b/control/client_cache.go
@@ -86,7 +86,7 @@ type clientWrapper struct {
 	client Client
 }
 
-func (c *clientWrapper) PrePush(infos []offsets.GetOffsetTopicInfo, epochInfos []GroupEpochInfo) ([]offsets.OffsetTopicInfo, int64, []bool, error) {
+func (c *clientWrapper) PrePush(infos []offsets.GetOffsetTopicInfo, epochInfos []EpochInfo) ([]offsets.OffsetTopicInfo, int64, []bool, error) {
 	offs, seq, epochsOK, err := c.client.PrePush(infos, epochInfos)
 	if err != nil {
 		c.closeConnection()
@@ -159,8 +159,8 @@ func (c *clientWrapper) DeleteTopic(topicName string) error {
 	return err
 }
 
-func (c *clientWrapper) GetGroupCoordinatorInfo(groupID string) (int32, string, int, error) {
-	memberID, address, groupEpoch, err := c.client.GetGroupCoordinatorInfo(groupID)
+func (c *clientWrapper) GetCoordinatorInfo(groupID string) (int32, string, int, error) {
+	memberID, address, groupEpoch, err := c.client.GetCoordinatorInfo(groupID)
 	if err != nil {
 		c.closeConnection()
 	}

--- a/control/controller.go
+++ b/control/controller.go
@@ -32,7 +32,7 @@ type Controller struct {
 	topicMetaManager           *topicmeta.Manager
 	currentMembership          cluster.MembershipState
 	tableListeners             *tableListeners
-	groupCoordinatorController *GroupCoordinatorController
+	groupCoordinatorController *CoordinatorController
 	memberID                   int32
 }
 
@@ -95,7 +95,7 @@ func (c *Controller) Stop() error {
 	return nil
 }
 
-func (c *Controller) GetGroupCoordinatorController() *GroupCoordinatorController {
+func (c *Controller) GetGroupCoordinatorController() *CoordinatorController {
 	return c.groupCoordinatorController
 }
 
@@ -311,9 +311,9 @@ func (c *Controller) handlePrePush(_ *transport.ConnectionContext, request []byt
 	}
 
 	var epochsOK []bool
-	if len(req.GroupEpochInfos) > 0 {
+	if len(req.EpochInfos) > 0 {
 		// First we check whether the group epochs are valid
-		epochsOK = c.groupCoordinatorController.CheckGroupEpochs(req.GroupEpochInfos)
+		epochsOK = c.groupCoordinatorController.CheckGroupEpochs(req.EpochInfos)
 	}
 
 	// And then we get the offsets

--- a/control/controller_test.go
+++ b/control/controller_test.go
@@ -276,17 +276,17 @@ func TestControllerGroupEpochs(t *testing.T) {
 		groupIDs = append(groupIDs, uuid.New().String())
 	}
 
-	var epochInfos []GroupEpochInfo
+	var epochInfos []EpochInfo
 	for _, groupID := range groupIDs {
-		memberID, address, groupEpoch, err := cl.GetGroupCoordinatorInfo(groupID)
+		memberID, address, groupEpoch, err := cl.GetCoordinatorInfo(groupID)
 		require.NoError(t, err)
 		require.Equal(t, controllers[0].memberID, memberID)
 		require.Equal(t, "kafka-address-0:1234", address)
 		require.Equal(t, 1, groupEpoch)
 
-		epochInfos = append(epochInfos, GroupEpochInfo{
-			GroupID:    groupID,
-			GroupEpoch: 1,
+		epochInfos = append(epochInfos, EpochInfo{
+			Key:   groupID,
+			Epoch: 1,
 		})
 	}
 
@@ -303,7 +303,7 @@ func TestControllerGroupEpochs(t *testing.T) {
 	// Now try with incorrect epoch infos
 	for i := 0; i < len(epochInfos); i++ {
 		if i%2 == 0 {
-			epochInfos[i].GroupEpoch++
+			epochInfos[i].Epoch++
 		}
 	}
 

--- a/control/groups_test.go
+++ b/control/groups_test.go
@@ -92,12 +92,12 @@ func TestGroupCoordinatorCheckEpochs(t *testing.T) {
 	}
 
 	// First create some correct epochs
-	var epochInfos []GroupEpochInfo
+	var epochInfos []EpochInfo
 	for i := 0; i < numGroups; i++ {
 		groupID := fmt.Sprintf("group-%d", i)
-		epochInfos = append(epochInfos, GroupEpochInfo{
-			GroupID:    groupID,
-			GroupEpoch: i + 1,
+		epochInfos = append(epochInfos, EpochInfo{
+			Key:   groupID,
+			Epoch: i + 1,
 		})
 	}
 
@@ -111,9 +111,9 @@ func TestGroupCoordinatorCheckEpochs(t *testing.T) {
 	epochInfos = nil
 	for i := 0; i < numGroups; i++ {
 		groupID := fmt.Sprintf("group-%d", i)
-		epochInfos = append(epochInfos, GroupEpochInfo{
-			GroupID:    groupID,
-			GroupEpoch: i + 2,
+		epochInfos = append(epochInfos, EpochInfo{
+			Key:   groupID,
+			Epoch: i + 2,
 		})
 	}
 
@@ -133,9 +133,9 @@ func TestGroupCoordinatorCheckEpochs(t *testing.T) {
 		} else {
 			epoch = i + 2
 		}
-		epochInfos = append(epochInfos, GroupEpochInfo{
-			GroupID:    groupID,
-			GroupEpoch: epoch,
+		epochInfos = append(epochInfos, EpochInfo{
+			Key:   groupID,
+			Epoch: epoch,
 		})
 	}
 
@@ -156,7 +156,7 @@ func getAddressFromMember(member cluster.MembershipEntry) string {
 	return memberData.KafkaListenerAddress
 }
 
-func applyClusterState(numMembers int, cg *GroupCoordinatorController) *cluster.MembershipState {
+func applyClusterState(numMembers int, cg *CoordinatorController) *cluster.MembershipState {
 	state := cluster.MembershipState{
 		LeaderVersion:  1,
 		ClusterVersion: 1,

--- a/control/rpcs.go
+++ b/control/rpcs.go
@@ -125,13 +125,13 @@ func (g *RegisterTableListenerResponse) Deserialize(buff []byte, offset int) int
 
 type PrePushRequest struct {
 	LeaderVersion   int
-	Infos           []offsets.GetOffsetTopicInfo
-	GroupEpochInfos []GroupEpochInfo
+	Infos      []offsets.GetOffsetTopicInfo
+	EpochInfos []EpochInfo
 }
 
-type GroupEpochInfo struct {
-	GroupID    string
-	GroupEpoch int
+type EpochInfo struct {
+	Key   string
+	Epoch int
 }
 
 func (g *PrePushRequest) Serialize(buff []byte) []byte {
@@ -145,11 +145,11 @@ func (g *PrePushRequest) Serialize(buff []byte) []byte {
 			buff = binary.BigEndian.AppendUint32(buff, uint32(partitionInfo.NumOffsets))
 		}
 	}
-	buff = binary.BigEndian.AppendUint32(buff, uint32(len(g.GroupEpochInfos)))
-	for _, gInfo := range g.GroupEpochInfos {
-		buff = binary.BigEndian.AppendUint32(buff, uint32(len(gInfo.GroupID)))
-		buff = append(buff, gInfo.GroupID...)
-		buff = binary.BigEndian.AppendUint64(buff, uint64(gInfo.GroupEpoch))
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(g.EpochInfos)))
+	for _, gInfo := range g.EpochInfos {
+		buff = binary.BigEndian.AppendUint32(buff, uint32(len(gInfo.Key)))
+		buff = append(buff, gInfo.Key...)
+		buff = binary.BigEndian.AppendUint64(buff, uint64(gInfo.Epoch))
 	}
 	return buff
 }
@@ -177,14 +177,14 @@ func (g *PrePushRequest) Deserialize(buff []byte, offset int) int {
 	}
 	lInfos = int(binary.BigEndian.Uint32(buff[offset:]))
 	offset += 4
-	g.GroupEpochInfos = make([]GroupEpochInfo, lInfos)
+	g.EpochInfos = make([]EpochInfo, lInfos)
 	for i := 0; i < lInfos; i++ {
-		groupEpochInfo := &g.GroupEpochInfos[i]
+		groupEpochInfo := &g.EpochInfos[i]
 		lid := int(binary.BigEndian.Uint32(buff[offset:]))
 		offset += 4
-		groupEpochInfo.GroupID = string(buff[offset : offset+lid])
+		groupEpochInfo.Key = string(buff[offset : offset+lid])
 		offset += lid
-		groupEpochInfo.GroupEpoch = int(binary.BigEndian.Uint64(buff[offset:]))
+		groupEpochInfo.Epoch = int(binary.BigEndian.Uint64(buff[offset:]))
 		offset += 8
 	}
 	return offset

--- a/control/rpcs_test.go
+++ b/control/rpcs_test.go
@@ -168,18 +168,18 @@ func TestSerializeDeserializeGetOffsetsRequest(t *testing.T) {
 				},
 			},
 		},
-		GroupEpochInfos: []GroupEpochInfo{
+		EpochInfos: []EpochInfo{
 			{
-				GroupID:    "consumer-group-1",
-				GroupEpoch: 123213,
+				Key:   "consumer-group-1",
+				Epoch: 123213,
 			},
 			{
-				GroupID:    "consumer-group-2",
-				GroupEpoch: 23423,
+				Key:   "consumer-group-2",
+				Epoch: 23423,
 			},
 			{
-				GroupID:    "consumer-group-3",
-				GroupEpoch: 34545,
+				Key:   "consumer-group-3",
+				Epoch: 34545,
 			},
 		},
 	}

--- a/fetcher/fetcher_test.go
+++ b/fetcher/fetcher_test.go
@@ -2286,7 +2286,7 @@ func (t *testControlClient) setLastReadableOffset(topicID int, partitionID int, 
 	partMap[partitionID] = offset
 }
 
-func (t *testControlClient) PrePush(infos []offsets.GetOffsetTopicInfo, epochInfos []control.GroupEpochInfo) ([]offsets.OffsetTopicInfo, int64, []bool, error) {
+func (t *testControlClient) PrePush(infos []offsets.GetOffsetTopicInfo, epochInfos []control.EpochInfo) ([]offsets.OffsetTopicInfo, int64, []bool, error) {
 	panic("should not be called")
 }
 
@@ -2315,7 +2315,7 @@ func (t *testControlClient) DeleteTopic(topicName string) error {
 	panic("should not be called")
 }
 
-func (t *testControlClient) GetGroupCoordinatorInfo(groupID string) (memberID int32, address string, groupEpoch int, err error) {
+func (t *testControlClient) GetCoordinatorInfo(key string) (memberID int32, address string, groupEpoch int, err error) {
 	panic("should not be called")
 }
 

--- a/pusher/table_pusher.go
+++ b/pusher/table_pusher.go
@@ -28,12 +28,12 @@ import (
 /*
 TablePusher handles produce requests and buffers batches internally. After a timeout, or if buffer gets full it starts
 the process of writing batches to permanent storage.
-It handles committing of offsets - these are also buffered and written in the same table as any produced data.
+It also allows direct writing of KVs - these are also buffered and written in the same table as any produced data.
 The write process involves:
 * Requesting offsets for each topic partition that needs to be written - these come from the controller which
-caches them in memory. In the same call (PrePush) group epochs for any offsets to be committed are also passed in and
-verified. The return of PrePush contains the offsets (if any) and whether each group epoch was OK or not.
-* If group epochs were not valid, then any committed offsets for invalid epochs do not get written in the table.
+caches them in memory. In the same call (PrePush) epochs for any kvs to be committed are also passed in and
+verified. The return of PrePush contains the offsets (if any) and whether each epoch was OK or not.
+* If epochs were not valid, then any KVs for invalid epochs do not get written in the table.
 * Building the record batches and committed offsets into an SSTable. The table contains one entry per record batch, and
 one entry for each committed partition.
 * Writing the SSTable to object storage
@@ -42,22 +42,22 @@ one entry for each committed partition.
 commit responses.
 */
 type TablePusher struct {
-	lock               sync.Mutex
-	cfg                Conf
-	topicProvider      topicInfoProvider
-	objStore           objstore.Client
-	clientFactory      controllerClientFactory
-	started            bool
-	stopping           atomic.Bool
-	controllerClient   ControlClient
-	partitionRecords   map[int]map[int][]bufferedEntry
-	offsetKVs          map[string][]common.KV
-	offsetCompletions  map[string][]func(error)
-	groupEpochInfos    map[string]int
-	numOffsetsToCommit int
-	partitionHashes    *parthash.PartitionHashes
-	writeTimer         *time.Timer
-	sizeBytes          int
+	lock                 sync.Mutex
+	cfg                  Conf
+	topicProvider        topicInfoProvider
+	objStore             objstore.Client
+	clientFactory        controllerClientFactory
+	started              bool
+	stopping             atomic.Bool
+	controllerClient     ControlClient
+	partitionRecords     map[int]map[int][]bufferedEntry
+	directKVs            map[string][]common.KV
+	directCompletions    map[string][]func(error)
+	directWriterEpochs   map[string]int
+	numDirectKVsToCommit int
+	partitionHashes      *parthash.PartitionHashes
+	writeTimer           *time.Timer
+	sizeBytes            int
 }
 
 type bufferedEntry struct {
@@ -72,7 +72,7 @@ type topicInfoProvider interface {
 type controllerClientFactory func() (ControlClient, error)
 
 type ControlClient interface {
-	PrePush(infos []offsets.GetOffsetTopicInfo, epochInfos []control.GroupEpochInfo) ([]offsets.OffsetTopicInfo, int64,
+	PrePush(infos []offsets.GetOffsetTopicInfo, epochInfos []control.EpochInfo) ([]offsets.OffsetTopicInfo, int64,
 		[]bool, error)
 	RegisterL0Table(sequence int64, regEntry lsm.RegistrationEntry) error
 	Close() error
@@ -95,15 +95,15 @@ func init() {
 func NewTablePusher(cfg Conf, topicProvider topicInfoProvider, objStore objstore.Client,
 	clientFactory controllerClientFactory, partitionHashes *parthash.PartitionHashes) (*TablePusher, error) {
 	return &TablePusher{
-		cfg:               cfg,
-		topicProvider:     topicProvider,
-		objStore:          objStore,
-		clientFactory:     clientFactory,
-		partitionHashes:   partitionHashes,
-		partitionRecords:  map[int]map[int][]bufferedEntry{},
-		groupEpochInfos:   map[string]int{},
-		offsetKVs:         map[string][]common.KV{},
-		offsetCompletions: map[string][]func(error){},
+		cfg:                cfg,
+		topicProvider:      topicProvider,
+		objStore:           objStore,
+		clientFactory:      clientFactory,
+		partitionHashes:    partitionHashes,
+		partitionRecords:   map[int]map[int][]bufferedEntry{},
+		directWriterEpochs: map[string]int{},
+		directKVs:          map[string][]common.KV{},
+		directCompletions:  map[string][]func(error){},
 	}, nil
 }
 
@@ -174,7 +174,7 @@ func (t *TablePusher) callCompletions(err error) {
 			}
 		}
 	}
-	for _, offsetCompletions := range t.offsetCompletions {
+	for _, offsetCompletions := range t.directCompletions {
 		for _, completionFunc := range offsetCompletions {
 			completionFunc(err)
 		}
@@ -273,91 +273,34 @@ func (t *TablePusher) HandleProduceRequest(req *kafkaprotocol.ProduceRequest,
 	return nil
 }
 
-func (t *TablePusher) HandleOffsetCommit(_ *transport.ConnectionContext, request []byte, responseBuff []byte, responseWriter transport.ResponseWriter) error {
+func (t *TablePusher) HandleDirectWrite(_ *transport.ConnectionContext, request []byte, responseBuff []byte, responseWriter transport.ResponseWriter) error {
 	if err := checkRPCVersion(request); err != nil {
 		return err
 	}
-	var req OffsetCommitRequest
+	var req DirectWriteRequest
 	req.Deserialize(request, 2)
-	return t.handleOffsetCommit0(req.Request, req.GroupEpoch, func(resp *kafkaprotocol.OffsetCommitResponse) {
-		responseBuff = resp.Write(req.RequestVersion, responseBuff, nil)
-		if err := responseWriter(responseBuff, nil); err != nil {
-			log.Errorf("failed to write offset commit: %v", err)
+	t.addDirectKVs(&req, func(err error) {
+		if err := responseWriter(responseBuff, err); err != nil {
+			log.Errorf("failed to write response: %v", err)
 		}
-	})
-}
-
-func (t *TablePusher) handleOffsetCommit0(req *kafkaprotocol.OffsetCommitRequest, groupEpoch int,
-	completionFunc func(resp *kafkaprotocol.OffsetCommitResponse)) error {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-	var resp kafkaprotocol.OffsetCommitResponse
-	resp.Topics = make([]kafkaprotocol.OffsetCommitResponseOffsetCommitResponseTopic, len(req.Topics))
-	for i, topicData := range req.Topics {
-		resp.Topics[i].Name = req.Topics[i].Name
-		resp.Topics[i].Partitions = make([]kafkaprotocol.OffsetCommitResponseOffsetCommitResponsePartition, len(topicData.Partitions))
-		for j, partData := range topicData.Partitions {
-			resp.Topics[i].Partitions[j].PartitionIndex = partData.PartitionIndex
-		}
-	}
-	groupID := *req.GroupId
-	lastEpoch, ok := t.groupEpochInfos[groupID]
-	if ok && groupEpoch != lastEpoch {
-		log.Warnf("rejecting offset commit from group %s as epoch is invalid", groupID)
-		fillInErrorCodesForOffsetCommitResponse(&resp, kafkaprotocol.ErrorCodeCoordinatorNotAvailable)
-		completionFunc(&resp)
-		return nil
-	}
-	if !ok {
-		t.groupEpochInfos[groupID] = groupEpoch
-	}
-	partHash, err := parthash.CreateHash([]byte(groupID))
-	if err != nil {
-		panic(err) // won't happen
-	}
-	// Convert to KV pairs
-	var kvs []common.KV
-	for i, topicData := range req.Topics {
-		foundTopic := false
-		info, err := t.topicProvider.GetTopicInfo(*topicData.Name)
-		if err != nil {
-			log.Errorf("failed to find topic %s", *topicData.Name)
-		} else {
-			foundTopic = true
-		}
-		for j, partitionData := range topicData.Partitions {
-			if !foundTopic {
-				resp.Topics[i].Partitions[j].ErrorCode = kafkaprotocol.ErrorCodeUnknownTopicOrPartition
-				continue
-			}
-			offset := partitionData.CommittedOffset
-			// key is [partition_hash, topic_id, partition_id] value is [offset]
-			key := CreateOffsetKey(partHash, info.ID, int(partitionData.PartitionIndex))
-			value := make([]byte, 8)
-			binary.BigEndian.PutUint64(value, uint64(offset))
-			kvs = append(kvs, common.KV{
-				Key:   key,
-				Value: value,
-			})
-			t.numOffsetsToCommit++
-			log.Debugf("group %s topic %d partition %d committing offset %d", *req.GroupId, info.ID,
-				partitionData.PartitionIndex, offset)
-		}
-	}
-	t.offsetKVs[groupID] = append(t.offsetKVs[groupID], kvs...)
-	t.offsetCompletions[groupID] = append(t.offsetCompletions[groupID], func(err error) {
-		if err != nil {
-			if common.IsUnavailableError(err) {
-				log.Warnf("failed to handle offset commit: %v", err)
-				fillInErrorCodesForOffsetCommitResponse(&resp, kafkaprotocol.ErrorCodeCoordinatorNotAvailable)
-			} else {
-				log.Errorf("failed to handle offset commit: %v", err)
-				fillInErrorCodesForOffsetCommitResponse(&resp, kafkaprotocol.ErrorCodeUnknownServerError)
-			}
-		}
-		completionFunc(&resp)
 	})
 	return nil
+}
+
+func (t *TablePusher) addDirectKVs(req *DirectWriteRequest, completionFunc func(err error)) {
+	lastEpoch, ok := t.directWriterEpochs[req.WriterKey]
+	if ok && req.WriterEpoch != lastEpoch {
+		msg := fmt.Sprintf("table pusher rejecting direct write from key %s as epoch is invalid", req.WriterKey)
+		log.Warn(msg)
+		completionFunc(common.NewTektiteErrorf(common.Unavailable, msg))
+		return
+	}
+	if !ok {
+		t.directWriterEpochs[req.WriterKey] = req.WriterEpoch
+	}
+	t.directKVs[req.WriterKey] = append(t.directKVs[req.WriterKey], req.KVs...)
+	t.directCompletions[req.WriterKey] = append(t.directCompletions[req.WriterKey], completionFunc)
+	t.numDirectKVsToCommit += len(req.KVs)
 }
 
 func checkRPCVersion(request []byte) error {
@@ -369,32 +312,24 @@ func checkRPCVersion(request []byte) error {
 	return nil
 }
 
-func fillInErrorCodesForOffsetCommitResponse(resp *kafkaprotocol.OffsetCommitResponse, errorCode int) {
-	for i, topicData := range resp.Topics {
-		for j := range topicData.Partitions {
-			resp.Topics[i].Partitions[j].ErrorCode = int16(errorCode)
-		}
-	}
-}
-
-func (t *TablePusher) failOffsetCommits(groupID string) {
-	log.Warnf("attempt to commit offsets for invalid group epoch for consumer group %s - will be ignored", groupID)
-	completions, ok := t.offsetCompletions[groupID]
+func (t *TablePusher) failDirectWrites(writerKey string) {
+	log.Warnf("attempt to write data for invalid group epoch for writer key %s - will be ignored", writerKey)
+	completions, ok := t.directCompletions[writerKey]
 	if !ok {
-		panic("not found offset completions")
+		panic("not found direct completions")
 	}
-	kvs, ok := t.offsetKVs[groupID]
+	kvs, ok := t.directKVs[writerKey]
 	if !ok {
-		panic("not found offset kvs")
+		panic("not found direct kvs")
 	}
 	for _, completion := range completions {
-		err := common.NewTektiteErrorf(common.Unavailable, "unable to commit offsets for group %s as epoch is invalid",
-			groupID)
+		err := common.NewTektiteErrorf(common.Unavailable, "unable to commit direct writes for key %s as epoch is invalid",
+			writerKey)
 		completion(err)
 	}
-	delete(t.offsetKVs, groupID)
-	delete(t.offsetCompletions, groupID)
-	t.numOffsetsToCommit -= len(kvs)
+	delete(t.directKVs, writerKey)
+	delete(t.directCompletions, writerKey)
+	t.numDirectKVsToCommit -= len(kvs)
 }
 
 func CreateOffsetKey(partHash []byte, topicID int, partitionID int) []byte {
@@ -470,7 +405,7 @@ func intCompare(i1, i2 int) int {
 }
 
 func (t *TablePusher) write() error {
-	if len(t.partitionRecords) == 0 && t.numOffsetsToCommit == 0 {
+	if len(t.partitionRecords) == 0 && t.numDirectKVsToCommit == 0 {
 		// Nothing to do
 		return nil
 	}
@@ -514,11 +449,11 @@ func (t *TablePusher) write() error {
 		}
 	}
 	// Prepare the epoch infos
-	groupEpochInfos := make([]control.GroupEpochInfo, 0, len(t.groupEpochInfos))
-	for groupID, epoch := range t.groupEpochInfos {
-		groupEpochInfos = append(groupEpochInfos, control.GroupEpochInfo{
-			GroupID:    groupID,
-			GroupEpoch: epoch,
+	groupEpochInfos := make([]control.EpochInfo, 0, len(t.directWriterEpochs))
+	for groupID, epoch := range t.directWriterEpochs {
+		groupEpochInfos = append(groupEpochInfos, control.EpochInfo{
+			Key:   groupID,
+			Epoch: epoch,
 		})
 	}
 	// Now make the prePush call - this gets any offsets for topic data to be written and also provides epochs for
@@ -531,21 +466,21 @@ func (t *TablePusher) write() error {
 	if len(offs) != len(getOffSetInfos) {
 		panic("invalid offsets returned")
 	}
-	if len(epochsOK) != len(t.groupEpochInfos) {
+	if len(epochsOK) != len(t.directWriterEpochs) {
 		panic("invalid epochs ok returned")
 	}
 	for i, ok := range epochsOK {
 		if !ok {
 			// If invalid epochs for any committed offsets are returned we fail the offset commits for that groupID
 			// and they are not included in the table that is pushed
-			groupID := groupEpochInfos[i].GroupID
-			t.failOffsetCommits(groupID)
+			groupID := groupEpochInfos[i].Key
+			t.failDirectWrites(groupID)
 		}
 	}
 	// Create KVs for the batches
-	kvs := make([]common.KV, 0, len(offs)+t.numOffsetsToCommit)
+	kvs := make([]common.KV, 0, len(offs)+t.numDirectKVsToCommit)
 	// Add any offsets to commit
-	for _, offsetKVs := range t.offsetKVs {
+	for _, offsetKVs := range t.directKVs {
 		kvs = append(kvs, offsetKVs...)
 	}
 	for i, topOffset := range offs {
@@ -636,37 +571,58 @@ func (t *TablePusher) write() error {
 
 func (t *TablePusher) reset() {
 	t.partitionRecords = make(map[int]map[int][]bufferedEntry)
-	if t.numOffsetsToCommit > 0 {
-		t.offsetKVs = map[string][]common.KV{}
-		t.offsetCompletions = map[string][]func(error){}
-		t.groupEpochInfos = make(map[string]int)
-		t.numOffsetsToCommit = 0
+	if t.numDirectKVsToCommit > 0 {
+		t.directKVs = map[string][]common.KV{}
+		t.directCompletions = map[string][]func(error){}
+		t.directWriterEpochs = make(map[string]int)
+		t.numDirectKVsToCommit = 0
 	}
 	t.sizeBytes = 0
 }
 
-type OffsetCommitRequest struct {
-	GroupEpoch     int
-	RequestVersion int16
-	Request        *kafkaprotocol.OffsetCommitRequest
+type DirectWriteRequest struct {
+	WriterKey   string
+	WriterEpoch int
+	KVs         []common.KV
 }
 
-func (o *OffsetCommitRequest) Serialize(buff []byte) []byte {
-	buff = binary.BigEndian.AppendUint64(buff, uint64(o.GroupEpoch))
-	buff = binary.BigEndian.AppendUint16(buff, uint16(o.RequestVersion))
-	return o.Request.Write(o.RequestVersion, buff, nil)
-}
-
-func (o *OffsetCommitRequest) Deserialize(buff []byte, offset int) int {
-	o.GroupEpoch = int(binary.BigEndian.Uint64(buff[offset:]))
-	offset += 8
-	o.RequestVersion = int16(binary.BigEndian.Uint16(buff[offset:]))
-	offset += 2
-	o.Request = &kafkaprotocol.OffsetCommitRequest{}
-	br, err := o.Request.Read(o.RequestVersion, buff[offset:])
-	if err != nil {
-		panic(err)
+func (o *DirectWriteRequest) Serialize(buff []byte) []byte {
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(o.WriterKey)))
+	buff = append(buff, o.WriterKey...)
+	buff = binary.BigEndian.AppendUint64(buff, uint64(o.WriterEpoch))
+	buff = binary.BigEndian.AppendUint32(buff, uint32(len(o.KVs)))
+	for _, kv := range o.KVs {
+		buff = binary.BigEndian.AppendUint32(buff, uint32(len(kv.Key)))
+		buff = append(buff, kv.Key...)
+		buff = binary.BigEndian.AppendUint32(buff, uint32(len(kv.Value)))
+		buff = append(buff, kv.Value...)
 	}
-	offset += br
+	return buff
+}
+
+func (o *DirectWriteRequest) Deserialize(buff []byte, offset int) int {
+	ln := int(binary.BigEndian.Uint32(buff[offset:]))
+	offset += 4
+	o.WriterKey = string(buff[offset : offset+ln])
+	offset += ln
+	o.WriterEpoch = int(binary.BigEndian.Uint64(buff[offset:]))
+	offset += 8
+	ln = int(binary.BigEndian.Uint32(buff[offset:]))
+	offset += 4
+	o.KVs = make([]common.KV, ln)
+	for i := 0; i < ln; i++ {
+		lk := int(binary.BigEndian.Uint32(buff[offset:]))
+		offset += 4
+		key := buff[offset : offset+lk]
+		offset += lk
+		lv := int(binary.BigEndian.Uint32(buff[offset:]))
+		offset += 4
+		value := buff[offset : offset+lv]
+		offset += lv
+		o.KVs[i] = common.KV{
+			Key:   key,
+			Value: value,
+		}
+	}
 	return offset
 }

--- a/transport/handler_ids.go
+++ b/transport/handler_ids.go
@@ -15,5 +15,5 @@ const (
 	HandlerIDMetaLocalCacheTopicDeleted
 	HandlerIDFetchCacheGetTableBytes
 	HandlerIDFetcherTableRegisteredNotification
-	HandlerIDTablePusherOffsetCommit
+	HandlerIDTablePusherDirectWrite
 )

--- a/tx/coordinator.go
+++ b/tx/coordinator.go
@@ -1,0 +1,92 @@
+package tx
+
+import (
+	"github.com/spirit-labs/tektite/common"
+	"github.com/spirit-labs/tektite/kafkaprotocol"
+	"math"
+	"sync"
+)
+
+type Coordinator struct {
+	lock               sync.Mutex
+	producerIDSequence int64
+	txInfos map[int64]*txInfo
+}
+
+type txInfo struct {
+	pid           int64
+	producerEpoch int16
+	tektiteEpoch  int64
+}
+
+func NewCoordinator() *Coordinator {
+	return &Coordinator{
+		txInfos: make(map[int64]*txInfo),
+	}
+}
+
+func (c *Coordinator) HandleInitProducerID(req *kafkaprotocol.InitProducerIdRequest) (*kafkaprotocol.InitProducerIdResponse, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// First look up any existing pid already mapped to the transactional id
+	transactionalID := common.SafeDerefStringPtr(req.TransactionalId)
+
+	var info *txInfo
+	if transactionalID != "" {
+		info = c.loadInfoForTransactionalID(transactionalID)
+		if info != nil {
+
+			// TODO verify existing producer epoch?
+
+			// TODO resolve any prepared but not committed/aborted transaction state
+
+			// bump the kafka epoch
+			if info.producerEpoch == math.MaxInt16 {
+				info.producerEpoch = 0
+			} else {
+				info.producerEpoch++
+			}
+		}
+	}
+
+	if info == nil {
+		// First time transactionalID was used or no transactional id - generate a pid
+		pid := c.producerIDSequence
+		c.producerIDSequence++
+		info = &txInfo{
+			pid:           pid,
+			producerEpoch: 0,
+		}
+	}
+
+	// Store the tx state
+	c.storeTxInfo(info)
+
+	resp := &kafkaprotocol.InitProducerIdResponse{
+		ProducerId:    info.pid,
+		ProducerEpoch: info.producerEpoch,
+	}
+	return resp, nil
+}
+
+
+func (c *Coordinator) loadInfoForTransactionalID(transactionalID string) *txInfo {
+
+	// TODO load from storage with query
+
+	// Next: call controller to get tektite epoch and set it on the info
+
+	return nil
+}
+
+func (c *Coordinator) storeTxInfo(txInfo *txInfo) {
+
+	// Send to table pusher with tektite epoch
+
+}
+
+func createCoordinatorKey(transactionalID string) string {
+	// prefix with 't.' to disambiguate with group coordinator keys
+	return "t." + transactionalID
+}


### PR DESCRIPTION
This PR applies some preparatory work before implementing tx / idempotent producers
* Makes the control/CoordinatorController agnostic to type of key being managed - same logic for managing epochs will be used by both group coordinator and transaction coordinator
* Table pusher now has no knowledge of offsets but allows for direct writes of agnostic KVs - this is used by group coordinator for offset commit and will be used by transaction coordinator for persisting tx state.
* A basic skeleton for the transaction coordinator (unused)