### PR TITLE
Update state updater and Lsm holder to use conditional put using etag

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -47,7 +47,7 @@ type Agent struct {
 	partitionLeaders         map[string]map[int]map[int]int32
 	clusterMembershipFactory ClusterMembershipFactory
 	tableGetter              sst.TableGetter
-	authCaches *auth.UserAuthCaches
+	authCaches               *auth.UserAuthCaches
 }
 
 func NewAgent(cfg Conf, objStore objstore.Client) (*Agent, error) {

--- a/agent/conf.go
+++ b/agent/conf.go
@@ -109,13 +109,8 @@ func CreateConfFromCommandConf(commandConf CommandConf) (Conf, error) {
 	cfg.ClusterMembershipConfig.EvictionInterval = evictionInterval
 	// configure controller
 	cfg.ControllerConf.SSTableBucketName = dataBucketName
-	cfg.ControllerConf.ControllerMetaDataKeyPrefix = "meta-data"
+	cfg.ControllerConf.ControllerMetaDataKey = "meta-data"
 	cfg.ControllerConf.ControllerMetaDataBucketName = dataBucketName
-	// We put the controller state machine in a different bucket - as this will likely be configured with an expiry
-	// TODO move to Dynamo based state machine
-	controllerStateMachineBucketName := commandConf.ClusterName + "-controller-sm"
-	cfg.ControllerConf.ControllerStateUpdaterBucketName = controllerStateMachineBucketName
-	cfg.ControllerConf.ControllerStateUpdaterKeyPrefix = "meta-state"
 	cfg.ControllerConf.AzInfo = commandConf.Location
 	cfg.ControllerConf.LsmConf.SSTableBucketName = dataBucketName
 	// configure compaction workers

--- a/cluster/clustered_data.go
+++ b/cluster/clustered_data.go
@@ -45,9 +45,9 @@ type ClusteredData struct {
 	dataKeyPrefix  string
 	stateMachine   *StateUpdater
 	objStoreClient objstore.Client
-	epoch      uint64
-	opts       ClusteredDataConf
-	readyState clusteredDataState
+	epoch          uint64
+	opts           ClusteredDataConf
+	readyState     clusteredDataState
 	stopping       atomic.Bool
 	logPrefix      string
 }
@@ -66,8 +66,8 @@ func NewClusteredData(stateMachineBucketName string, stateMachineKeyPrefix strin
 		objStoreClient: objStoreClient,
 		dataBucketName: dataBucketName,
 		dataKeyPrefix:  dataKeyPrefix,
-		stateMachine: NewStateUpdator(stateMachineBucketName, stateMachineKeyPrefix, objStoreClient,
-			StateUpdatorOpts{}),
+		stateMachine: NewStateUpdater(stateMachineBucketName, stateMachineKeyPrefix, objStoreClient,
+			StateUpdaterOpts{}),
 		opts:       opts,
 		readyState: clusteredDataStateReady,
 		logPrefix:  fmt.Sprintf("clustered data(%s / %s) -", dataBucketName, stateMachineBucketName),

--- a/cluster/membership.go
+++ b/cluster/membership.go
@@ -51,7 +51,7 @@ func NewMembership(cfg MembershipConf, data []byte, objStoreClient objstore.Clie
 	return &Membership{
 		id:                   -1,
 		data:                 data,
-		stateUpdater:         NewStateUpdator(cfg.BucketName, cfg.KeyPrefix, objStoreClient, StateUpdatorOpts{}),
+		stateUpdater:         NewStateUpdater(cfg.BucketName, cfg.KeyPrefix, objStoreClient, StateUpdaterOpts{}),
 		updateInterval:       cfg.UpdateInterval,
 		evictionDuration:     cfg.EvictionInterval,
 		stateChangedCallback: stateChangedCallback,

--- a/cluster/state_updater.go
+++ b/cluster/state_updater.go
@@ -124,7 +124,7 @@ func (s *StateUpdater) update(updateFunc func(state []byte) ([]byte, error)) ([]
 		}
 		var ok bool
 		if exists {
-			ok, err = objstore.PutIfMatchingEtagWithTimeout(s.objStoreClient, s.stateBucket, s.stateKey, newState,
+			ok, _, err = objstore.PutIfMatchingEtagWithTimeout(s.objStoreClient, s.stateBucket, s.stateKey, newState,
 				info.Etag, s.opts.ObjStoreCallTimeout)
 		} else {
 			ok, _, err = objstore.PutIfNotExistsWithTimeout(s.objStoreClient, s.stateBucket, s.stateKey, newState,

--- a/cluster/state_updater.go
+++ b/cluster/state_updater.go
@@ -18,7 +18,6 @@ type StateUpdater struct {
 	opts           StateUpdaterOpts
 	started        bool
 	stopping       atomic.Bool
-	initialised    bool
 	latestState    []byte
 	retryCount     int64
 }

--- a/cluster/state_updater.go
+++ b/cluster/state_updater.go
@@ -1,119 +1,49 @@
 package cluster
 
 import (
-	"fmt"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/spirit-labs/tektite/asl/arista"
 	"github.com/spirit-labs/tektite/common"
 	log "github.com/spirit-labs/tektite/logger"
 	"github.com/spirit-labs/tektite/objstore"
-	"math"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 )
 
-/*
-StateUpdater persists its state in object storage. Clients concurrently update the state through their own instances
-of this struct by supplying a function that takes the previous state and returns the new state. The struct provides
-serializability to updates even though clients are distributed. Updates occur as if they happened one after another.
-It can be used as the foundation for various distributed concurrency primitives, such as finite state machines, group
-membership, distributed locks, distributed sequences, and more.
-
-StateUpdater uses conditional writes via the PutIfNotExists method of the object store. This method atomically stores an
-object only if no existing object with the same key is present.
-
-Each StateUpdater instance maintains an internal sequence. When updating the state, it attempts to store a key composed
-of a prefix and a sequence number. If the key already exists, it indicates that another StateUpdater instance has
-updated the state based on the previous state. In this scenario, the latest state is loaded, and the update is retried
-until successful. The sequence number is stored as MaxInt64 - sequence, ensuring that keys are ordered from newest to
-oldest lexicographically. This ordering makes it faster to retrieve the most recent key during initialization, as it
-avoids iterating through numerous keys.
-
-Upon startup, each instance lists objects with the given prefix and uses the smallest key as the starting state,
-representing the most recent update.
-
-If an instance hasn’t updated the state for a while, and other instances have made many updates, its sequence number
-might fall significantly behind. In this case, the instance may experience multiple failed PutIfNotExists attempts
-before succeeding. To prevent instances from lagging too much, no-op updates that don’t change the state but update
-the sequence can be made periodically by settings `AutoUpdate` to `true` on the options and providing an `AutoUpdateInterval`.
-
-StateUpdater does not delete old keys. Deleting keys is challenging because members might lag behind due to network
-issues or other factors. Members retry updates based on their current sequence value up to a time limit before
-discarding that value and reinitializing upon reconnection. This approach prevents members from relying on outdated
-sequences for an extended period. It's crucial not to delete keys associated with in-use sequences, as doing so could
-result in lost state.
-
-For key management, it's recommended to store the keys in a dedicated bucket with an expiration policy set to an
-appropriate duration (e.g., 7 days), longer than the maximum retry time for the state machine.
-
-If the object store becomes unavailable, or if all StateUpdater instances are shut down for a period longer than the
-expiration time, all state will be lost.
-
-Optionally, StateUpdater can be configured to write the latest state to a dedicated key for each member as a backup.
-This is done by specifying the LatestStateBucketName in the options. The bucket should have no expiration policy. In the
-rare event that the most recent state machine key is lost, the key can be restored from this backup to the state machine bucket.
-*/
 type StateUpdater struct {
 	lock           sync.Mutex
 	stateBucket    string
-	stateKeyPrefix string
-	keyBucket      string
+	stateKey       string
 	objStoreClient objstore.Client
-	memberID       string
-	opts           StateUpdatorOpts
+	opts           StateUpdaterOpts
 	started        bool
 	stopping       atomic.Bool
-	updateTimer    *time.Timer
-	lastUpdateTime int64
-	nextSequence   int
-	state          []byte
-	reinitCount    int64
+	initialised    bool
+	latestState    []byte
 	retryCount     int64
 }
 
-const DefaultMaxTimeBeforeReinitialise = 30 * time.Millisecond
 const DefaultObjStoreCallTimeout = 5 * time.Second
 const DefaultAvailabilityRetryInterval = 1 * time.Second
-const DefaultAutoUpdateInterval = 5 * time.Second
 
-type StateUpdatorOpts struct {
-	AutoUpdate                bool
-	AutoUpdateInterval        time.Duration
-	MaxTimeBeforeReinitialise time.Duration
+type StateUpdaterOpts struct {
 	ObjStoreCallTimeout       time.Duration
 	AvailabilityRetryInterval time.Duration
-	LatestStateBucketName     string
 }
 
-func NewStateUpdator(stateBucket string, stateKeyPrefix string, objStoreClient objstore.Client,
-	opts StateUpdatorOpts) *StateUpdater {
-	if opts.MaxTimeBeforeReinitialise == 0 {
-		opts.MaxTimeBeforeReinitialise = DefaultMaxTimeBeforeReinitialise
-	}
+func NewStateUpdater(stateBucket string, stateKey string, objStoreClient objstore.Client,
+	opts StateUpdaterOpts) *StateUpdater {
 	if opts.ObjStoreCallTimeout == 0 {
 		opts.ObjStoreCallTimeout = DefaultObjStoreCallTimeout
 	}
 	if opts.AvailabilityRetryInterval == 0 {
 		opts.AvailabilityRetryInterval = DefaultAvailabilityRetryInterval
 	}
-	if opts.AutoUpdate && opts.AutoUpdateInterval == 0 {
-		opts.AutoUpdateInterval = DefaultAutoUpdateInterval
-	}
-	memberID := ""
-	if opts.LatestStateBucketName != "" {
-		memberID = uuid.New().String()
-	}
 	sm := &StateUpdater{
 		stateBucket:    stateBucket,
-		stateKeyPrefix: stateKeyPrefix,
+		stateKey:       stateKey,
 		objStoreClient: objStoreClient,
-		memberID:       memberID,
 		opts:           opts,
-		nextSequence:   -1,
-		lastUpdateTime: -1,
 	}
 	return sm
 }
@@ -123,9 +53,6 @@ func (s *StateUpdater) Start() {
 	defer s.lock.Unlock()
 	if s.started {
 		return
-	}
-	if s.opts.AutoUpdate {
-		s.scheduleUpdate()
 	}
 	s.started = true
 }
@@ -141,56 +68,13 @@ func (s *StateUpdater) Stop() {
 	if !s.started {
 		return
 	}
-	if s.opts.AutoUpdate {
-		s.updateTimer.Stop()
-	}
 	s.started = false
-}
-
-func (s *StateUpdater) NextSequence() int {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	return s.nextSequence
-}
-
-func (s *StateUpdater) scheduleUpdate() {
-	s.updateTimer = time.AfterFunc(s.opts.AutoUpdateInterval, func() {
-		s.lock.Lock()
-		defer s.lock.Unlock()
-		if !s.started {
-			return
-		}
-		if int64(arista.NanoTime())-s.lastUpdateTime >= int64(s.opts.AutoUpdateInterval) {
-			// If user hasn't updated, then we run a no-op update - this ensures our current sequence number remains
-			// up to date with latest state.
-			if _, err := s.update(func(state []byte) ([]byte, error) {
-				return state, nil
-			}); err != nil {
-				log.Errorf("failed to update: %v", err)
-			}
-		}
-		s.scheduleUpdate()
-	})
-}
-
-func (s *StateUpdater) createKey(sequence int) string {
-	// Note that later keys have a smaller key - this allows us to init more quickly as we just load the first key
-	key := fmt.Sprintf("%s-%09d", s.stateKeyPrefix, math.MaxInt64-sequence)
-	return key
-}
-
-func (s *StateUpdater) extractSequenceFromKey(key string) (int, error) {
-	i, err := strconv.Atoi(key[len(s.stateKeyPrefix)+1:])
-	if err != nil {
-		return 0, err
-	}
-	return math.MaxInt64 - i, nil
 }
 
 func (s *StateUpdater) GetState() ([]byte, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	return s.state, nil
+	return s.latestState, nil
 }
 
 // FetchLatestState fetches the latest state by performing a no-op update.
@@ -200,149 +84,57 @@ func (s *StateUpdater) FetchLatestState() ([]byte, error) {
 	})
 }
 
-// The Update function provides the operation to update the state based on the previous state, returning the new state which will be stored.
-// Through the use of the monotonically-decreasing sequence number, it ensures that the update is based on the latest state.
-// The function returns when the new state has been committed to object storage, or an error occurs.
 func (s *StateUpdater) Update(updateFunc func(state []byte) ([]byte, error)) ([]byte, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	state, err := s.update(updateFunc)
-	s.lastUpdateTime = int64(arista.NanoTime())
-	return state, err
+	for !s.stopping.Load() {
+		state, err := s.update(updateFunc)
+		if err == nil {
+			s.latestState = state
+			return state, nil
+		}
+		if !common.IsUnavailableError(err) {
+			return nil, err
+		}
+		// Retry
+		log.Warnf("state machine update failed, will retry: %v", err)
+		atomic.AddInt64(&s.retryCount, 1)
+		time.Sleep(s.opts.AvailabilityRetryInterval)
+	}
+	return nil, errors.New("updater is stopping")
 }
 
 func (s *StateUpdater) update(updateFunc func(state []byte) ([]byte, error)) ([]byte, error) {
-	var tZero []byte
-outer:
 	for {
-		if s.nextSequence == -1 {
-			// Initialise the sequence by loading the newest one from object store
-			if err := s.init(); err != nil {
-				return tZero, err
-			}
+		// Get the latest state
+		info, exists, err := objstore.GetObjectInfoWithTimeout(s.objStoreClient, s.stateBucket, s.stateKey, s.opts.ObjStoreCallTimeout)
+		if err != nil {
+			return nil, err
 		}
-		seq := s.nextSequence
-		state := s.state
-		start := arista.NanoTime()
-		for {
-			if s.stopping.Load() {
-				return tZero, errors.New("state machine is stopping")
-			}
-			// Try and update state
-			updated, newState, err := s.innerUpdate(seq, state, updateFunc)
+		var state []byte
+		if exists {
+			state, err = objstore.GetWithTimeout(s.objStoreClient, s.stateBucket, s.stateKey, s.opts.ObjStoreCallTimeout)
 			if err != nil {
-				if common.IsUnavailableError(err) {
-					// Update failed because object store is unavailable or call timed out, sleep before retrying
-					log.Warnf("state machine update failed: %v", err)
-					time.Sleep(s.opts.AvailabilityRetryInterval)
-					if time.Duration(arista.NanoTime()-start) >= s.opts.MaxTimeBeforeReinitialise {
-						// We've reached the limit of retrying with the current sequence, set it to -1 and continue
-						// outer loop so sequence gets re-initialised from the object store. This prevents us holding
-						// on to sequences that are too old.
-						s.nextSequence = -1
-						atomic.AddInt64(&s.reinitCount, 1)
-						continue outer
-					}
-					// Retry with the current sequence value
-					atomic.AddInt64(&s.retryCount, 1)
-					continue
-				}
-				return tZero, err
-			}
-			if updated {
-				// We updated ok
-				s.nextSequence = seq + 1
-				s.state = newState
-				return s.state, nil
-			}
-			// We failed to update due to our sequence being old (another member must have updated since we loaded)
-			// increment sequence and retry inner loop
-			state = newState
-			seq++
-		}
-	}
-}
-
-func (s *StateUpdater) innerUpdate(seq int, state []byte, updateFunc func(state []byte) ([]byte, error)) (bool, []byte, error) {
-	var err error
-	state, err = updateFunc(state)
-	if err != nil {
-		return false, nil, err
-	}
-	newKey := s.createKey(seq)
-	put, err := objstore.PutIfNotExistsWithTimeout(s.objStoreClient, s.stateBucket, newKey, state, s.opts.ObjStoreCallTimeout)
-	if err != nil {
-		return false, nil, err
-	}
-	if put {
-		if s.opts.LatestStateBucketName != "" {
-			// If latest state bucket name is provided we also store the latest state in a key, without versioning.
-			// This can be used as a backup to restore state if sequenced keys are lost, e.g. due to bucket expiration
-			// deleting them
-			latestStateKey := fmt.Sprintf("%s-latest-state-%s", s.stateKeyPrefix, s.memberID)
-			if err := objstore.PutWithTimeout(s.objStoreClient, s.opts.LatestStateBucketName, latestStateKey, state, s.opts.ObjStoreCallTimeout); err != nil {
-				return false, nil, err
+				return nil, err
 			}
 		}
-		return true, state, nil
-	}
-	// key exists already - load the state
-	state, err = objstore.GetWithTimeout(s.objStoreClient, s.stateBucket, newKey, s.opts.ObjStoreCallTimeout)
-	if err != nil {
-		return false, nil, err
-	}
-	if state == nil {
-		return false, nil, errors.Errorf("cannot find key %v", newKey)
-	}
-	return false, state, nil
-}
-
-func (s *StateUpdater) init() error {
-	for {
-		if s.stopping.Load() {
-			return errors.New("state machine is stopping")
+		newState, err := updateFunc(state)
+		if err != nil {
+			return nil, err
 		}
-		if err := s.initInner(); err != nil {
-			if common.IsUnavailableError(err) {
-				// Retry
-				log.Warnf("state machine init failed: %v", err)
-				time.Sleep(s.opts.AvailabilityRetryInterval)
-				continue
-			}
+		var ok bool
+		if exists {
+			ok, err = objstore.PutIfMatchingEtagWithTimeout(s.objStoreClient, s.stateBucket, s.stateKey, newState,
+				info.Etag, s.opts.ObjStoreCallTimeout)
 		} else {
-			return nil
+			ok, _, err = objstore.PutIfNotExistsWithTimeout(s.objStoreClient, s.stateBucket, s.stateKey, newState,
+				s.opts.ObjStoreCallTimeout)
 		}
-	}
-}
-
-func (s *StateUpdater) initInner() error {
-	// We store keys in reverse order, so the latest key will be the first one returned - we only need to list 1 key
-	existingInfos, err := objstore.ListObjectsWithPrefixWithTimeout(s.objStoreClient, s.stateBucket, s.stateKeyPrefix,
-		1, s.opts.ObjStoreCallTimeout)
-	if err != nil {
-		return err
-	}
-	if len(existingInfos) > 1 {
-		panic("too many keys returned")
-	}
-	if len(existingInfos) == 1 {
-		lastInfo := existingInfos[0]
-		lastSeq, err := s.extractSequenceFromKey(lastInfo.Key)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		buff, err := objstore.GetWithTimeout(s.objStoreClient, s.stateBucket, lastInfo.Key, s.opts.ObjStoreCallTimeout)
-		if err != nil {
-			return err
+		if ok {
+			return newState, nil
 		}
-		if buff == nil {
-			return errors.Errorf("cannot find key %s on init", lastInfo.Key)
-		}
-		s.nextSequence = lastSeq + 1
-		s.state = buff
-	} else {
-		s.nextSequence = 0
-		s.state = nil
 	}
-	return nil
 }

--- a/cluster/state_updater_test.go
+++ b/cluster/state_updater_test.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/spirit-labs/tektite/asl/arista"
 	"github.com/spirit-labs/tektite/common"
 	"github.com/spirit-labs/tektite/objstore"
@@ -16,35 +15,16 @@ import (
 	"time"
 )
 
-func TestStateUpdator(t *testing.T) {
+func TestStateUpdater(t *testing.T) {
 	t.Parallel()
 	objStore := dev.NewInMemStore(0)
-	numMembers := 5
+	numMembers := 1
 	objStores := make([]objstore.Client, numMembers)
 	for i := 0; i < numMembers; i++ {
 		objStores[i] = objStore
 	}
 	runTime := 3 * time.Second
-	applyLoadAndVerifyStateUpdator(t, runTime, numMembers, 10*time.Millisecond, StateUpdatorOpts{}, objStores)
-}
-
-func TestStateUpdatorAutoUpdate(t *testing.T) {
-	t.Parallel()
-	objStore := dev.NewInMemStore(0)
-	updateInterval := 100 * time.Millisecond
-	opts := StateUpdatorOpts{
-		AutoUpdate:         true,
-		AutoUpdateInterval: updateInterval,
-	}
-	member := NewStateUpdator("bucket1", "prefix1", objStore, opts)
-	member.Start()
-	defer member.Stop()
-
-	runTime := 2 * time.Second
-	time.Sleep(runTime)
-
-	expectedSequenceMin := (runTime / updateInterval) - 1
-	require.GreaterOrEqual(t, member.NextSequence(), int(expectedSequenceMin))
+	applyLoadAndVerifyStateUpdater(t, runTime, numMembers, 10*time.Millisecond, StateUpdaterOpts{}, objStores)
 }
 
 func updateWithBytesFunc(f func(s stateMachineState) (stateMachineState, error)) func(buff []byte) ([]byte, error) {
@@ -64,107 +44,7 @@ func updateWithBytesFunc(f func(s stateMachineState) (stateMachineState, error))
 	return fb
 }
 
-func TestStateUpdatorJoinMember(t *testing.T) {
-	t.Parallel()
-	objStore := dev.NewInMemStore(0)
-
-	numInitialMembers := 4
-	members := make([]*StateUpdater, numInitialMembers)
-	for i := 0; i < numInitialMembers; i++ {
-		member := NewStateUpdator("bucket1", "prefix1", objStore, StateUpdatorOpts{})
-		member.Start()
-		defer member.Stop()
-		members[i] = member
-	}
-
-	// do some updates on current members
-	numUpdates := 100
-	expectedSeq := 1
-	for i := 0; i < numUpdates; i++ {
-		for _, member := range members {
-			_, err := member.update(updateWithBytesFunc(func(s stateMachineState) (stateMachineState, error) {
-				s.Updates = append(s.Updates, fmt.Sprintf("update-%d", s.Val))
-				s.Val++
-				return s, nil
-			}))
-			require.NoError(t, err)
-			require.Equal(t, expectedSeq, member.NextSequence())
-			expectedSeq++
-		}
-	}
-
-	// Now add a new member
-	member := NewStateUpdator("bucket1", "prefix1", objStore, StateUpdatorOpts{})
-	member.Start()
-	defer member.Stop()
-
-	_, err := member.update(updateWithBytesFunc(func(s stateMachineState) (stateMachineState, error) {
-		s.Updates = append(s.Updates, fmt.Sprintf("update-%d", s.Val))
-		s.Val++
-		return s, nil
-	}))
-	require.NoError(t, err)
-	// Should catch up and get correct sequence
-	require.Equal(t, expectedSeq, member.NextSequence())
-	expectedSeq++
-}
-
-func TestStateUpdatorLatestState(t *testing.T) {
-	t.Parallel()
-	objStore := dev.NewInMemStore(0)
-
-	opts := StateUpdatorOpts{
-		LatestStateBucketName: "latest-bucket",
-	}
-
-	prefix := "prefix1"
-
-	numMembers := 4
-	members := make([]*StateUpdater, numMembers)
-	for i := 0; i < numMembers; i++ {
-		member := NewStateUpdator("bucket1", prefix, objStore, opts)
-		member.Start()
-		defer member.Stop()
-		members[i] = member
-
-		require.NotEmpty(t, member.memberID)
-	}
-
-	numUpdates := 10
-	expectedSeq := 1
-	for i := 0; i < numUpdates; i++ {
-		for _, member := range members {
-			state, err := member.update(updateWithBytesFunc(func(s stateMachineState) (stateMachineState, error) {
-				s.Updates = append(s.Updates, fmt.Sprintf("update-%d", s.Val))
-				s.Val++
-				return s, nil
-			}))
-			require.NoError(t, err)
-			require.Equal(t, expectedSeq, member.NextSequence())
-			expectedSeq++
-
-			latestStateKey := fmt.Sprintf("%s-latest-state-%s", prefix, member.memberID)
-
-			// Make sure latest state has been stored
-			latestState, err := objStore.Get(context.Background(), opts.LatestStateBucketName, latestStateKey)
-			require.NoError(t, err)
-			require.NotNil(t, latestState)
-
-			var smState stateMachineState
-			err = json.Unmarshal(latestState, &smState)
-			require.NoError(t, err)
-
-			var expectedSmState stateMachineState
-			err = json.Unmarshal(state, &expectedSmState)
-			require.NoError(t, err)
-
-			require.Equal(t, expectedSmState, smState)
-		}
-	}
-}
-
-// TestUnavailabilityRetry - verifies that the unavailability retry logic is exercised, but with low unavailability delays
-// such that a re-initialisation is not triggered
+// TestUnavailabilityRetry - verifies that the unavailability retry logic is exercised
 func TestUnavailabilityRetry(t *testing.T) {
 	t.Parallel()
 	objStore := dev.NewInMemStore(0)
@@ -182,63 +62,27 @@ func TestUnavailabilityRetry(t *testing.T) {
 			objStore.(*unavailableObjStoreProxy).stop()
 		}
 	}()
-	opts := StateUpdatorOpts{
-		AutoUpdate:                false,
+	opts := StateUpdaterOpts{
 		AvailabilityRetryInterval: 10 * time.Millisecond,
-		MaxTimeBeforeReinitialise: 30 * time.Second,
 	}
 	runTime := 3 * time.Second
-	members := applyLoadAndVerifyStateUpdator(t, runTime, numMembers, 10*time.Millisecond, opts, objStores)
+	members := applyLoadAndVerifyStateUpdater(t, runTime, numMembers, 10*time.Millisecond, opts, objStores)
 	// Make sure they are initialised
 	for _, member := range members {
-		require.Equal(t, 0, int(atomic.LoadInt64(&member.reinitCount)))
 		require.Greater(t, int(atomic.LoadInt64(&member.retryCount)), 1)
 	}
 }
 
-// TestUnavailabilityTriggerReinitialise - tests that re-initialisation logic gets triggered when state machine is unable
-// to update for a longer time
-func TestUnavailabilityTriggerReinitialise(t *testing.T) {
-	t.Parallel()
-	objStore := dev.NewInMemStore(0)
-	numMembers := 5
-	objStores := make([]objstore.Client, numMembers)
-	for i := 0; i < numMembers; i++ {
-		uav := &unavailableObjStoreProxy{
-			objStore: objStore,
-		}
-		uav.start(500*time.Millisecond, 1*time.Second)
-		objStores[i] = uav
-	}
-	defer func() {
-		for _, objStore := range objStores {
-			objStore.(*unavailableObjStoreProxy).stop()
-		}
-	}()
-	opts := StateUpdatorOpts{
-		AutoUpdate:                false,
-		AvailabilityRetryInterval: 50 * time.Millisecond,
-		MaxTimeBeforeReinitialise: 500 * time.Millisecond,
-	}
-	runTime := 3 * time.Second
-	members := applyLoadAndVerifyStateUpdator(t, runTime, numMembers, 10*time.Millisecond, opts, objStores)
-	// Make sure where initialised
-	for _, member := range members {
-		require.Greater(t, int(atomic.LoadInt64(&member.reinitCount)), 1)
-	}
-}
-
 type stateMachineState struct {
-	Val     int
-	Updates []string
+	Val int
 }
 
-func applyLoadAndVerifyStateUpdator(t *testing.T, runTime time.Duration, numMembers int, updateDelay time.Duration,
-	opts StateUpdatorOpts, objStores []objstore.Client) []*StateUpdater {
+func applyLoadAndVerifyStateUpdater(t *testing.T, runTime time.Duration, numMembers int, updateDelay time.Duration,
+	opts StateUpdaterOpts, objStores []objstore.Client) []*StateUpdater {
 
 	var members []*StateUpdater
 	for i := 0; i < numMembers; i++ {
-		member := NewStateUpdator("bucket1", "prefix1", objStores[i], opts)
+		member := NewStateUpdater("bucket1", "prefix1", objStores[i], opts)
 		members = append(members, member)
 		members[i] = member
 		member.Start()
@@ -256,7 +100,6 @@ func applyLoadAndVerifyStateUpdator(t *testing.T, runTime time.Duration, numMemb
 		go func() {
 			for arista.NanoTime() < endTime {
 				_, err := member.Update(updateWithBytesFunc(func(s stateMachineState) (stateMachineState, error) {
-					s.Updates = append(s.Updates, fmt.Sprintf("update-%d", s.Val))
 					s.Val++
 					return s, nil
 				}))
@@ -292,10 +135,6 @@ func applyLoadAndVerifyStateUpdator(t *testing.T, runTime time.Duration, numMemb
 		require.NoError(t, err)
 		require.NoError(t, err)
 		require.Equal(t, totUpdates, s.Val)
-		require.Equal(t, totUpdates, len(s.Updates))
-		for i, update := range s.Updates {
-			require.Equal(t, fmt.Sprintf("update-%d", i), update)
-		}
 	}
 	return members
 }
@@ -336,6 +175,13 @@ func (u *unavailableObjStoreProxy) delayRandom() {
 	time.Sleep(unavailDur)
 }
 
+func (u *unavailableObjStoreProxy) GetObjectInfo(ctx context.Context, bucket string, key string) (objstore.ObjectInfo, bool, error) {
+	if u.unavailable.Load() {
+		return objstore.ObjectInfo{}, false, common.NewTektiteErrorf(common.Unavailable, "store is unavailable")
+	}
+	return u.objStore.GetObjectInfo(ctx, bucket, key)
+}
+
 func (u *unavailableObjStoreProxy) Get(ctx context.Context, bucket string, key string) ([]byte, error) {
 	if u.unavailable.Load() {
 		return nil, common.NewTektiteErrorf(common.Unavailable, "store is unavailable")
@@ -348,6 +194,13 @@ func (u *unavailableObjStoreProxy) Put(ctx context.Context, bucket string, key s
 		return common.NewTektiteErrorf(common.Unavailable, "store is unavailable")
 	}
 	return u.objStore.Put(ctx, bucket, key, value)
+}
+
+func (u *unavailableObjStoreProxy) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, error) {
+	if u.unavailable.Load() {
+		return false, common.NewTektiteErrorf(common.Unavailable, "store is unavailable")
+	}
+	return u.objStore.PutIfMatchingEtag(ctx, bucket, key, value, etag)
 }
 
 func (u *unavailableObjStoreProxy) PutIfNotExists(ctx context.Context, bucket string, key string, value []byte) (bool, error) {

--- a/cluster/state_updater_test.go
+++ b/cluster/state_updater_test.go
@@ -196,16 +196,16 @@ func (u *unavailableObjStoreProxy) Put(ctx context.Context, bucket string, key s
 	return u.objStore.Put(ctx, bucket, key, value)
 }
 
-func (u *unavailableObjStoreProxy) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, error) {
+func (u *unavailableObjStoreProxy) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, string, error) {
 	if u.unavailable.Load() {
-		return false, common.NewTektiteErrorf(common.Unavailable, "store is unavailable")
+		return false, "", common.NewTektiteErrorf(common.Unavailable, "store is unavailable")
 	}
 	return u.objStore.PutIfMatchingEtag(ctx, bucket, key, value, etag)
 }
 
-func (u *unavailableObjStoreProxy) PutIfNotExists(ctx context.Context, bucket string, key string, value []byte) (bool, error) {
+func (u *unavailableObjStoreProxy) PutIfNotExists(ctx context.Context, bucket string, key string, value []byte) (bool, string, error) {
 	if u.unavailable.Load() {
-		return false, common.NewTektiteErrorf(common.Unavailable, "store is unavailable")
+		return false, "", common.NewTektiteErrorf(common.Unavailable, "store is unavailable")
 	}
 	return u.objStore.PutIfNotExists(ctx, bucket, key, value)
 }

--- a/control/conf.go
+++ b/control/conf.go
@@ -7,31 +7,27 @@ import (
 )
 
 type Conf struct {
-	ControllerStateUpdaterBucketName string
-	ControllerStateUpdaterKeyPrefix  string
-	ControllerMetaDataBucketName     string
-	ControllerMetaDataKeyPrefix      string
-	SSTableBucketName                string
-	DataFormat                       common.DataFormat
-	TableNotificationInterval        time.Duration
-	LsmConf                          lsm.Conf
-	SequencesBlockSize               int
-	AzInfo                           string
-	LsmStateWriteInterval            time.Duration
+	ControllerMetaDataBucketName string
+	ControllerMetaDataKey        string
+	SSTableBucketName            string
+	DataFormat                   common.DataFormat
+	TableNotificationInterval    time.Duration
+	LsmConf                      lsm.Conf
+	SequencesBlockSize           int
+	AzInfo                       string
+	LsmStateWriteInterval        time.Duration
 }
 
 func NewConf() Conf {
 	return Conf{
-		ControllerStateUpdaterBucketName: "controller-state-updater",
-		ControllerStateUpdaterKeyPrefix:  "controller-state-updater-key",
-		ControllerMetaDataBucketName:     "controller-meta-data",
-		ControllerMetaDataKeyPrefix:      "controller-meta-data",
-		SSTableBucketName:                "tektite-data",
-		DataFormat:                       common.DataFormatV1,
-		TableNotificationInterval:        5 * time.Second,
-		LsmConf:                          lsm.NewConf(),
-		SequencesBlockSize:               100,
-		LsmStateWriteInterval:            10 * time.Millisecond,
+		ControllerMetaDataBucketName: "controller-meta-data",
+		ControllerMetaDataKey:        "controller-meta-data",
+		SSTableBucketName:            "tektite-data",
+		DataFormat:                   common.DataFormatV1,
+		TableNotificationInterval:    5 * time.Second,
+		LsmConf:                      lsm.NewConf(),
+		SequencesBlockSize:           100,
+		LsmStateWriteInterval:        10 * time.Millisecond,
 	}
 }
 

--- a/control/controller.go
+++ b/control/controller.go
@@ -174,8 +174,7 @@ func (c *Controller) MembershipChanged(thisMemberID int32, newState cluster.Memb
 		// This controller is activating as leader
 		if c.lsmHolder == nil {
 			log.Debugf("%p controller %d activating as leader, newState %v", c, thisMemberID, newState)
-			lsmHolder := NewLsmHolder(c.cfg.ControllerStateUpdaterBucketName, c.cfg.ControllerStateUpdaterKeyPrefix,
-				c.cfg.ControllerMetaDataBucketName, c.cfg.ControllerMetaDataKeyPrefix, c.objStoreClient,
+			lsmHolder := NewLsmHolder(c.cfg.ControllerMetaDataBucketName, c.cfg.ControllerMetaDataKey, c.objStoreClient,
 				c.cfg.LsmStateWriteInterval, c.cfg.LsmConf)
 			if err := lsmHolder.Start(); err != nil {
 				return err

--- a/control/lsm_holder_test.go
+++ b/control/lsm_holder_test.go
@@ -13,17 +13,14 @@ import (
 )
 
 const (
-	stateUpdatorBucketName = "state-updator-bucket"
-	stateUpdatorKeyprefix  = "state-updator-keyprefix"
-	dataBucketName         = "data-bucket"
-	dataKeyprefix          = "data-keyprefix"
-	stateWriteInterval     = 1 * time.Millisecond
+	metaDataBucketName = "metadata-bucket"
+	metaDataKey        = "metadata-key"
+	stateWriteInterval = 1 * time.Millisecond
 )
 
 func TestApplyChanges(t *testing.T) {
 	objStore := dev.NewInMemStore(0)
-	holder := NewLsmHolder(stateUpdatorBucketName, stateUpdatorKeyprefix, dataBucketName, dataKeyprefix, objStore,
-		stateWriteInterval, lsm.Conf{})
+	holder := NewLsmHolder(metaDataBucketName, metaDataKey, objStore, stateWriteInterval, lsm.Conf{})
 	err := holder.Start()
 	require.NoError(t, err)
 
@@ -32,8 +29,7 @@ func TestApplyChanges(t *testing.T) {
 
 func TestApplyChangesRestart(t *testing.T) {
 	objStore := dev.NewInMemStore(0)
-	holder := NewLsmHolder(stateUpdatorBucketName, stateUpdatorKeyprefix, dataBucketName, dataKeyprefix, objStore,
-		stateWriteInterval, lsm.Conf{})
+	holder := NewLsmHolder(metaDataBucketName, metaDataKey, objStore, stateWriteInterval, lsm.Conf{})
 	err := holder.Start()
 	require.NoError(t, err)
 
@@ -44,8 +40,7 @@ func TestApplyChangesRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	// recreate holder
-	holder = NewLsmHolder(stateUpdatorBucketName, stateUpdatorKeyprefix, dataBucketName, dataKeyprefix, objStore,
-		stateWriteInterval, lsm.Conf{})
+	holder = NewLsmHolder(metaDataBucketName, metaDataKey, objStore, stateWriteInterval, lsm.Conf{})
 	err = holder.Start()
 	require.NoError(t, err)
 
@@ -87,8 +82,7 @@ func TestApplyChangesL0Full(t *testing.T) {
 	opts := lsm.Conf{
 		L0MaxTablesBeforeBlocking: 10,
 	}
-	holder := NewLsmHolder(stateUpdatorBucketName, stateUpdatorKeyprefix, dataBucketName, dataKeyprefix, objStore,
-		stateWriteInterval, opts)
+	holder := NewLsmHolder(metaDataBucketName, metaDataKey, objStore, stateWriteInterval, opts)
 	err := holder.Start()
 	require.NoError(t, err)
 

--- a/objstore/api.go
+++ b/objstore/api.go
@@ -10,7 +10,7 @@ type Client interface {
 	Get(ctx context.Context, bucket string, key string) ([]byte, error)
 	Put(ctx context.Context, bucket string, key string, value []byte) error
 	PutIfNotExists(ctx context.Context, bucket string, key string, value []byte) (bool, string, error)
-	PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, error)
+	PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, string, error)
 	Delete(ctx context.Context, bucket string, key string) error
 	DeleteAll(ctx context.Context, bucket string, keys []string) error
 	ListObjectsWithPrefix(ctx context.Context, bucket string, prefix string, maxKeys int) ([]ObjectInfo, error)
@@ -52,7 +52,7 @@ func PutIfNotExistsWithTimeout(client Client, bucket string, key string, value [
 	return client.PutIfNotExists(ctx, bucket, key, value)
 }
 
-func PutIfMatchingEtagWithTimeout(client Client, bucket string, key string, value []byte, etag string, timeout time.Duration) (bool, error) {
+func PutIfMatchingEtagWithTimeout(client Client, bucket string, key string, value []byte, etag string, timeout time.Duration) (bool, string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	return client.PutIfMatchingEtag(ctx, bucket, key, value, etag)

--- a/objstore/api.go
+++ b/objstore/api.go
@@ -6,9 +6,11 @@ import (
 )
 
 type Client interface {
+	GetObjectInfo(ctx context.Context, bucket string, key string) (ObjectInfo, bool, error)
 	Get(ctx context.Context, bucket string, key string) ([]byte, error)
 	Put(ctx context.Context, bucket string, key string, value []byte) error
-	PutIfNotExists(ctx context.Context, bucket string, key string, value []byte) (bool, error)
+	PutIfNotExists(ctx context.Context, bucket string, key string, value []byte) (bool, string, error)
+	PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, error)
 	Delete(ctx context.Context, bucket string, key string) error
 	DeleteAll(ctx context.Context, bucket string, keys []string) error
 	ListObjectsWithPrefix(ctx context.Context, bucket string, prefix string, maxKeys int) ([]ObjectInfo, error)
@@ -19,11 +21,18 @@ type Client interface {
 type ObjectInfo struct {
 	Key          string
 	LastModified time.Time
+	Etag         string
 }
 
 const DefaultCallTimeout = 5 * time.Second
 
 // Convenience methods that apply a timeout to the Client operations
+
+func GetObjectInfoWithTimeout(client Client, bucket string, key string, timeout time.Duration) (ObjectInfo, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return client.GetObjectInfo(ctx, bucket, key)
+}
 
 func GetWithTimeout(client Client, bucket string, key string, timeout time.Duration) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -37,10 +46,16 @@ func PutWithTimeout(client Client, bucket string, key string, value []byte, time
 	return client.Put(ctx, bucket, key, value)
 }
 
-func PutIfNotExistsWithTimeout(client Client, bucket string, key string, value []byte, timeout time.Duration) (bool, error) {
+func PutIfNotExistsWithTimeout(client Client, bucket string, key string, value []byte, timeout time.Duration) (bool, string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	return client.PutIfNotExists(ctx, bucket, key, value)
+}
+
+func PutIfMatchingEtagWithTimeout(client Client, bucket string, key string, value []byte, etag string, timeout time.Duration) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return client.PutIfMatchingEtag(ctx, bucket, key, value, etag)
 }
 
 func DeleteWithTimeout(client Client, bucket string, key string, timeout time.Duration) error {

--- a/objstore/api_test_util.go
+++ b/objstore/api_test_util.go
@@ -170,7 +170,7 @@ func testPutIfNotExists(t *testing.T, client Client) {
 	err := client.Put(ctx, DefaultBucket, "key1", []byte("val1"))
 	require.NoError(t, err)
 
-	ok, err := client.PutIfNotExists(ctx, DefaultBucket, "key1", []byte("val2"))
+	ok, _, err := client.PutIfNotExists(ctx, DefaultBucket, "key1", []byte("val2"))
 	require.NoError(t, err)
 	require.False(t, ok)
 
@@ -179,7 +179,7 @@ func testPutIfNotExists(t *testing.T, client Client) {
 	require.NotNil(t, vb)
 	require.Equal(t, "val1", string(vb))
 
-	ok, err = client.PutIfNotExists(ctx, DefaultBucket, "key2", []byte("val2"))
+	ok, _, err = client.PutIfNotExists(ctx, DefaultBucket, "key2", []byte("val2"))
 	require.NoError(t, err)
 	require.True(t, ok)
 

--- a/objstore/dev/dev_objstore.go
+++ b/objstore/dev/dev_objstore.go
@@ -147,7 +147,7 @@ func (c *Client) Put(_ context.Context, bucket string, key string, value []byte)
 	return nil
 }
 
-func (c *Client) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, error) {
+func (c *Client) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, string, error) {
 	panic("not supported")
 }
 

--- a/objstore/minio/client.go
+++ b/objstore/minio/client.go
@@ -89,22 +89,22 @@ func (m *Client) PutIfNotExists(ctx context.Context, bucket string, key string, 
 	return true, info.ETag, nil
 }
 
-func (m *Client) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, error) {
+func (m *Client) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, string, error) {
 	buff := bytes.NewBuffer(value)
 	opts := minio.PutObjectOptions{}
 	opts.SetMatchETag(etag)
-	_, err := m.client.PutObject(ctx, bucket, key, buff, int64(len(value)), opts)
+	info, err := m.client.PutObject(ctx, bucket, key, buff, int64(len(value)), opts)
 	if err != nil {
 		var errResponse minio.ErrorResponse
 		if errors.As(err, &errResponse) {
 			if errResponse.StatusCode == 412 {
 				// Pre-condition failed - this means key already exists
-				return false, nil
+				return false, "", nil
 			}
 		}
-		return false, maybeConvertError(err)
+		return false, "", maybeConvertError(err)
 	}
-	return true, nil
+	return true, info.ETag, nil
 }
 
 func (m *Client) Delete(ctx context.Context, bucket string, key string) error {

--- a/pusher/table_pusher_test.go
+++ b/pusher/table_pusher_test.go
@@ -2218,7 +2218,7 @@ func (f *failingObjectStoreClient) GetObjectInfo(ctx context.Context, bucket str
 	panic("should not be called")
 }
 
-func (f *failingObjectStoreClient) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, error) {
+func (f *failingObjectStoreClient) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, string, error) {
 	panic("should not be called")
 }
 
@@ -2230,7 +2230,7 @@ func (f *failingObjectStoreClient) Put(_ context.Context, _ string, _ string, _ 
 	return errors.New("some random error")
 }
 
-func (f *failingObjectStoreClient) PutIfNotExists(_ context.Context, _ string, _ string, _ []byte) (bool, error) {
+func (f *failingObjectStoreClient) PutIfNotExists(_ context.Context, _ string, _ string, _ []byte) (bool, string, error) {
 	panic("should not be called")
 }
 
@@ -2266,9 +2266,9 @@ func (u *unavailableObjStoreClient) GetObjectInfo(ctx context.Context, bucket st
 	return u.cl.GetObjectInfo(ctx, bucket, key)
 }
 
-func (u *unavailableObjStoreClient) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, error) {
+func (u *unavailableObjStoreClient) PutIfMatchingEtag(ctx context.Context, bucket string, key string, value []byte, etag string) (bool, string, error) {
 	if !u.available.Load() {
-		return false, common.NewTektiteErrorf(common.Unavailable, "object store is unavailable")
+		return false, "", common.NewTektiteErrorf(common.Unavailable, "object store is unavailable")
 	}
 	return u.cl.PutIfMatchingEtag(ctx, bucket, key, value, etag)
 }
@@ -2287,9 +2287,9 @@ func (u *unavailableObjStoreClient) Put(ctx context.Context, bucket string, key 
 	return u.cl.Put(ctx, bucket, key, value)
 }
 
-func (u *unavailableObjStoreClient) PutIfNotExists(ctx context.Context, bucket string, key string, value []byte) (bool, error) {
+func (u *unavailableObjStoreClient) PutIfNotExists(ctx context.Context, bucket string, key string, value []byte) (bool, string, error) {
 	if !u.available.Load() {
-		return false, common.NewTektiteErrorf(common.Unavailable, "object store is unavailable")
+		return false, "", common.NewTektiteErrorf(common.Unavailable, "object store is unavailable")
 	}
 	return u.cl.PutIfNotExists(ctx, bucket, key, value)
 }


### PR DESCRIPTION
S3 now supports atomic conditional puts by comparing etag. Previously, it only supported conditional updates when the key did not exist at all which forced us into a lot of complexity to ensure atomic updates by creating new keys with a sequence number. That method also created a lot of garbage keys.
Now, we can simply fail to update the key if etag has changed, which simplifies things a lot.